### PR TITLE
Package freedom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 **/*checkpoint.py
 info.log
 pyiron.log
-scratch.ipynb

--- a/ryven/ironflow/Gui.py
+++ b/ryven/ironflow/Gui.py
@@ -9,6 +9,7 @@ from ryven.main.utils import import_nodes_package, load_from_file, NodesPackage
 from .CanvasObject import CanvasObject, gui_modes
 
 import ryven.NENV as NENV
+from pathlib import Path
 
 __author__ = "Joerg Neugebauer"
 __copyright__ = (
@@ -24,8 +25,8 @@ __date__ = "May 10, 2022"
 os.environ["RYVEN_MODE"] = "no-gui"
 NENV.init_node_env()
 
-PACKAGES = ["ryven/std", "ryven/nodes/built_in/"]  # , 'ryven/mynodes']
-
+ryven_location = Path(__file__).parents[1]
+PACKAGES = [os.path.join(ryven_location, *subloc) for subloc in [("std",), ("nodes", "built_in")]]  # , ("mynodes",)
 alg_modes = ["data", "exec"]
 
 

--- a/ryven/ironflow/Gui.py
+++ b/ryven/ironflow/Gui.py
@@ -34,10 +34,9 @@ debug_view = widgets.Output(layout={"border": "1px solid black"})
 
 
 class GUI:
-    def __init__(self, packages=None):  # , onto_dic=onto_dic):
+    def __init__(self):  # , onto_dic=onto_dic):
         session = rc.Session()
-        packages = packages if packages is not None else PACKAGES
-        for package in packages:
+        for package in PACKAGES:
             session.register_nodes(
                 import_nodes_package(NodesPackage(directory=package))
             )

--- a/ryven/ironflow/Gui.py
+++ b/ryven/ironflow/Gui.py
@@ -26,7 +26,7 @@ os.environ["RYVEN_MODE"] = "no-gui"
 NENV.init_node_env()
 
 ryven_location = Path(__file__).parents[1]
-PACKAGES = [os.path.join(ryven_location, *subloc) for subloc in [("std",), ("nodes", "built_in")]]  # , ("mynodes",)
+packages = [os.path.join(ryven_location, *subloc) for subloc in [("std",), ("nodes", "built_in")]]  # , ("mynodes",)
 alg_modes = ["data", "exec"]
 
 
@@ -36,7 +36,7 @@ debug_view = widgets.Output(layout={"border": "1px solid black"})
 class GUI:
     def __init__(self):  # , onto_dic=onto_dic):
         session = rc.Session()
-        for package in PACKAGES:
+        for package in packages:
             session.register_nodes(
                 import_nodes_package(NodesPackage(directory=package))
             )

--- a/tests/unit/test_CanvasObject.py
+++ b/tests/unit/test_CanvasObject.py
@@ -10,7 +10,7 @@ import os
 class TestCanvasObect(TestCase):
 
     def setUp(self):
-        self.gui = GUI(packages=["../../ryven/std", "../../ryven/nodes/built_in/"])
+        self.gui = GUI()
         self.canvas = self.gui.canvas_widget
 
     @classmethod


### PR DESCRIPTION
Reference the package files relative to the source code. Previously ironflow notebooks had to sit exactly one level above the `ryven` module or the packages wouldn't load right. Now we can use ironflow anywhere, as long as the module is in our python path.