### PR TITLE
Script name freedom

### DIFF
--- a/ryven/ironflow/Gui.py
+++ b/ryven/ironflow/Gui.py
@@ -34,7 +34,8 @@ debug_view = widgets.Output(layout={"border": "1px solid black"})
 
 
 class GUI:
-    def __init__(self):  # , onto_dic=onto_dic):
+    def __init__(self, script_title="test"):  # , onto_dic=onto_dic):
+        self._script_title = script_title
         session = rc.Session()
         for package in packages:
             session.register_nodes(
@@ -42,7 +43,7 @@ class GUI:
             )
 
         self._session = session
-        script = session.create_script(title="test")
+        script = session.create_script(title=self.script_title)
 
         nodes_dict = {}
         for n in self._session.nodes:
@@ -56,6 +57,10 @@ class GUI:
         # self.onto_dic = onto_dic
 
         self.out_log = widgets.Output(layout={"border": "1px solid black"})
+
+    @property
+    def script_title(self) -> str:
+        return self._script_title
 
     def save(self, file_path):
         data = self.serialize()
@@ -195,10 +200,10 @@ class GUI:
         )
 
     def on_file_save(self, change):
-        self.save("test.json")
+        self.save(f"{self.script_title}.json")
 
     def on_file_load(self, change):
-        self.load("test.json")
+        self.load(f"{self.script_title}.json")
 
     def on_delete_node(self, change):
         self.canvas_widget.delete_selected()

--- a/ryven/ironflow/Gui.py
+++ b/ryven/ironflow/Gui.py
@@ -139,10 +139,10 @@ class GUI:
         )
 
         self.btn_load = widgets.Button(
-            tooltip="Load", icon="download", layout=widgets.Layout(width="50px")
+            tooltip="Load", icon="upload", layout=widgets.Layout(width="50px")
         )
         self.btn_save = widgets.Button(
-            tooltip="Save", icon="upload", layout=widgets.Layout(width="50px")
+            tooltip="Save", icon="download", layout=widgets.Layout(width="50px")
         )
         self.btn_delete_node = widgets.Button(
             tooltip="Delete Node", icon="trash", layout=widgets.Layout(width="50px")

--- a/tests/unit/test_CanvasObject.py
+++ b/tests/unit/test_CanvasObject.py
@@ -23,7 +23,7 @@ class TestCanvasObect(TestCase):
     def test_remove_node_from_flow(self):
         flow = self.canvas.script.flow
         val_node = self.gui._nodes_dict['nodes']['val']
-        results_node = self.gui._nodes_dict['nodes']['val']
+        results_node = self.gui._nodes_dict['nodes']['result']
 
         n1 = flow.create_node(node_class=val_node)
         n2 = flow.create_node(node_class=results_node)

--- a/tests/unit/test_Gui.py
+++ b/tests/unit/test_Gui.py
@@ -1,0 +1,52 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+from unittest import TestCase
+from ryven.ironflow.Gui import GUI
+import os
+
+
+class TestGUI(TestCase):
+
+    def tearDown(self) -> None:
+        os.remove("pyiron.log")
+
+    def test_saving_and_loading(self):
+        title = 'foo'
+        gui = GUI(script_title=title)
+        canvas = gui.canvas_widget
+        flow = gui._session.scripts[0].flow
+        print(flow)
+
+        canvas.add_node(0, 0, gui._nodes_dict['nodes']['val'])  # Need to create with canvas instead of flow
+        canvas.add_node(1, 0, gui._nodes_dict['nodes']['result'])  # because serialization includes xy location
+        n1, n2 = flow.nodes
+        flow.connect_nodes(n1.outputs[0], n2.inputs[0])
+
+        with self.assertRaises(FileNotFoundError):
+            gui.on_file_load(None)
+
+        gui.on_file_save(None)
+
+        new_gui = GUI(script_title=title)
+        self.assertNotEqual(new_gui._session, gui._session, msg="New instance expected to get its own session")
+        # Maybe this will change in the future, but it's baked in the assumptions for now so let's make sure to test it
+
+        new_flow = new_gui._session.scripts[0].flow
+        print(new_flow)
+        self.assertEqual(0, len(new_flow.nodes), msg="Fresh GUI shouldn't have any nodes yet.")
+        self.assertEqual(0, len(new_flow.connections), msg="Fresh GUI shouldn't have any connections yet.")
+
+        new_gui.draw()  # Temporary hack to ensure new_gui.out_canvas exists
+        new_gui.on_file_load(None)
+        new_flow = new_gui._session.scripts[0].flow  # Session script gets reloaded, so grab this again
+        print(new_gui._session.scripts, new_gui._session.scripts[0].flow)
+        self.assertEqual(len(flow.nodes), len(new_flow.nodes), msg="Loaded GUI should recover nodes.")
+        self.assertEqual(
+            len(flow.connections),
+            len(new_flow.connections),
+            msg="Loaded GUI should recover connections."
+        )
+
+        os.remove(f"{title}.json")


### PR DESCRIPTION
Make the underlying script name a variable, so you can save/load multiple different graphs. Added a test of serialization.