### PR TITLE
More colour control

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,7 @@
 channels:
 - conda-forge
 dependencies:
-- python >= 3.6
+- python >= 3.7
 - pyiron
 - nglview
 - ryvencore

--- a/ryven/ironflow/CanvasObject.py
+++ b/ryven/ironflow/CanvasObject.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 from ipycanvas import Canvas, hold_canvas
-import ipywidgets as widgets
-import numpy as np
 from IPython.display import display
 
 from .NodeWidget import NodeWidget, PortWidget, BaseCanvasWidget, ButtonNodeWidget

--- a/ryven/ironflow/CanvasObject.py
+++ b/ryven/ironflow/CanvasObject.py
@@ -210,12 +210,12 @@ class CanvasObject(HasSession):
             if node.main_widget_class is not None:
                 # node.title = str(node.main_widget_class)
                 f = eval(node.main_widget_class)
-                s = f(x, y, parent=self, node=node, layout=layout)
+                s = f(x, y, parent=self, layout=layout, node=node)
             else:
-                s = NodeWidget(x, y, parent=self, node=node, layout=layout)
+                s = NodeWidget(x, y, parent=self, layout=layout, node=node)
             # print ('s: ', s)
         else:
-            s = NodeWidget(x, y, parent=self, node=node, layout=layout)
+            s = NodeWidget(x, y, parent=self, layout=layout, node=node)
 
         self.objects_to_draw.append(s)
         return s

--- a/ryven/ironflow/CanvasObject.py
+++ b/ryven/ironflow/CanvasObject.py
@@ -5,7 +5,8 @@ import ipywidgets as widgets
 import numpy as np
 from IPython.display import display
 
-from .NodeWidget import CanvasLayout, NodeWidget, PortWidget, BaseCanvasWidget, ButtonNodeWidget
+from .NodeWidget import NodeWidget, PortWidget, BaseCanvasWidget, ButtonNodeWidget
+from .layouts import NodeLayout
 from .NodeWidgets import NodeWidgets
 from .has_session import HasSession
 
@@ -203,13 +204,7 @@ class CanvasObject(HasSession):
     def load_node(self, x: Number, y: Number, node: Node) -> NodeWidget:
         #    print ('node: ', node.identifier, node.GLOBAL_ID)
 
-        layout = CanvasLayout(
-            font_size=20,
-            width=200,
-            height=100,
-            background_color="gray",
-            selected_color="green",
-        )
+        layout = NodeLayout()
 
         if hasattr(node, "main_widget_class"):
             if node.main_widget_class is not None:

--- a/ryven/ironflow/NodeWidget.py
+++ b/ryven/ironflow/NodeWidget.py
@@ -79,9 +79,7 @@ class BaseCanvasWidget:
         self._y += dy_in
 
     def draw_shape(self) -> None:
-        self.canvas.fill_style = self.layout.background_color
-        if self.selected:
-            self.canvas.fill_style = self.layout.selected_color
+        self.canvas.fill_style = self.layout.selected_color if self.selected else self.layout.background_color
         self.canvas.fill_rect(
             self.x,  # - (self.width * 0.5),
             self.y,  # - (self.height * 0.5),
@@ -109,10 +107,7 @@ class BaseCanvasWidget:
             return None
 
     def is_selected(self, x_in: Number, y_in: Number) -> bool:
-        if self._is_at_xy(x_in, y_in):
-            return True
-        else:
-            return False
+        return self._is_at_xy(x_in, y_in)
 
     def set_selected(self, state: bool) -> None:
         self.selected = state

--- a/ryven/ironflow/NodeWidget.py
+++ b/ryven/ironflow/NodeWidget.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 from IPython.display import display
-from .layouts import CanvasLayout, NodeLayout, DataPortLayout, ExecPortLayout, ButtonLayout
+from .layouts import Layout, NodeLayout, DataPortLayout, ExecPortLayout, ButtonLayout
 
 from typing import TYPE_CHECKING, Optional, Union, List, Any
 if TYPE_CHECKING:
@@ -30,7 +30,7 @@ class BaseCanvasWidget:
             x: Number,
             y: Number,
             parent: Optional[Union[CanvasObject, BaseCanvasWidget]] = None,
-            layout: Optional[CanvasLayout] = None,
+            layout: Optional[Layout] = None,
             selected: bool = False
     ):
         self._x = x  # relative to parent

--- a/ryven/ironflow/NodeWidget.py
+++ b/ryven/ironflow/NodeWidget.py
@@ -97,7 +97,6 @@ class BaseCanvasWidget:
     def _is_at_xy(self, x_in: Number, y_in: Number) -> bool:
         x_coord = self.x  # - (self.width * 0.5)
         y_coord = self.y  # - (self.height * 0.5)
-
         return x_coord < x_in < (x_coord + self.width) and y_coord < y_in < (y_coord + self.height)
 
     def get_element_at_xy(self, x_in: Number, y_in: Number) -> Union[BaseCanvasWidget, None]:
@@ -142,7 +141,7 @@ class PortWidget(BaseCanvasWidget):
         if self.selected:
             self.canvas.fill_style = self.layout.selected_color
         self.canvas.fill_circle(self.x, self.y, self.radius)
-        self.canvas.font = f"{self.layout.font_size}px serif"
+        self.canvas.font = self.layout.font_string
         self.canvas.fill_style = self.layout.font_color
         self.canvas.fill_text(
             self.text_left, self.x + self.radius + 3, self.y + self.radius // 2
@@ -190,7 +189,7 @@ class NodeWidget(BaseCanvasWidget):
     def draw_title(self, title: str) -> None:
         self.canvas.fill_style = self.node.color
         self.canvas.fill_rect(self.x, self.y, self.width, self._title_box_height)
-        self.canvas.font = f"{self.layout.font_title_size}px serif"
+        self.canvas.font = self.layout.title_font_string
         self.canvas.fill_style = self.layout.font_title_color
         x = self.x + (self.width * 0.04)
         y = self.y + self._title_box_height - 8
@@ -198,7 +197,7 @@ class NodeWidget(BaseCanvasWidget):
 
     def draw_value(self, val: Any, val_is_updated: bool = True) -> None:
         self.canvas.fill_style = self.layout.font_color
-        self.canvas.font = f"{self.layout.font_title_size}px serif"
+        self.canvas.font = self.layout.title_font_string
         x = self.x + (self.width * 0.3)
         y = (self.y + (self.height * 0.65),)
         self.canvas.fill_text(str(val), x, y)

--- a/ryven/ironflow/NodeWidget.py
+++ b/ryven/ironflow/NodeWidget.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 from IPython.display import display
+from .layouts import CanvasLayout, NodeLayout, DataPortLayout, ExecPortLayout, ButtonLayout
 
 from typing import TYPE_CHECKING, Optional, Union, List, Any
 if TYPE_CHECKING:
@@ -21,26 +22,6 @@ __maintainer__ = "Joerg Neugebauer"
 __email__ = "janssen@mpie.de"
 __status__ = "production"
 __date__ = "May 10, 2022"
-
-
-class CanvasLayout:
-    def __init__(
-        self,
-        width: int = 100,
-        height: int = 60,
-        font_size: int = 12,
-        background_color: str = "blue",
-        selected_color: str = "lightblue",
-        font_color: str = "black",
-        font_title_color: str = "black",
-    ):
-        self.width = width
-        self.height = height
-        self.background_color = background_color
-        self.selected_color = selected_color
-        self.font_size = font_size
-        self.font_color = font_color
-        self.font_title_color = font_title_color
 
 
 class BaseCanvasWidget:
@@ -152,7 +133,7 @@ class PortWidget(BaseCanvasWidget):
         radius: Number = 10,
         parent: Optional[Union[CanvasObject, BaseCanvasWidget]] = None,
         port: Optional[NodePort] = None,
-        layout: Optional[CanvasLayout] = None,
+        layout: Optional[Union[DataPortLayout, ExecPortLayout]] = None,
         selected: bool = False,
         text_left: str = "",
     ):
@@ -167,8 +148,8 @@ class PortWidget(BaseCanvasWidget):
         if self.selected:
             self.canvas.fill_style = self.layout.selected_color
         self.canvas.fill_circle(self.x, self.y, self.radius)
-        self.canvas.font = "21px serif"
-        self.canvas.fill_style = "black"
+        self.canvas.font = f"{self.layout.font_size}px serif"
+        self.canvas.fill_style = self.layout.font_color
         self.canvas.fill_text(
             self.text_left, self.x + self.radius + 3, self.y + self.radius // 2
         )
@@ -187,7 +168,7 @@ class NodeWidget(BaseCanvasWidget):
             y: Number,
             node: Node,
             parent: Optional[Union[CanvasObject, BaseCanvasWidget]] = None,
-            layout: Optional[CanvasLayout] = None,
+            layout: Optional[NodeLayout] = None,
             selected: bool = False,
             port_radius: Number = 10,
     ):
@@ -203,18 +184,8 @@ class NodeWidget(BaseCanvasWidget):
 
         self.port_radius = port_radius
         self.port_layouts = {
-            'data': CanvasLayout(
-                width=20,
-                height=10,
-                background_color="lightgreen",
-                selected_color="darkgreen",
-            ),
-            'exec': CanvasLayout(
-                width=20,
-                height=10,
-                background_color="lightblue",
-                selected_color="darkblue",
-            )
+            'data': DataPortLayout(),
+            'exec': ExecPortLayout()
         }
 
         if len(self.node.inputs) > 3:
@@ -223,9 +194,9 @@ class NodeWidget(BaseCanvasWidget):
         self.add_outputs()
 
     def draw_title(self, title: str) -> None:
-        self.canvas.fill_style = self.node.color if hasattr(self.node, 'color') else "darkgray"
+        self.canvas.fill_style = self.node.color
         self.canvas.fill_rect(self.x, self.y, self.width, self._title_box_height)
-        self.canvas.font = f"{self.layout.font_size}px serif"
+        self.canvas.font = f"{self.layout.font_title_size}px serif"
         self.canvas.fill_style = self.layout.font_title_color
         x = self.x + (self.width * 0.04)
         y = self.y + self._title_box_height - 8
@@ -233,7 +204,7 @@ class NodeWidget(BaseCanvasWidget):
 
     def draw_value(self, val: Any, val_is_updated: bool = True) -> None:
         self.canvas.fill_style = self.layout.font_color
-        self.canvas.font = f"{self.layout.font_size}px serif"
+        self.canvas.font = f"{self.layout.font_title_size}px serif"
         x = self.x + (self.width * 0.3)
         y = (self.y + (self.height * 0.65),)
         self.canvas.fill_text(str(val), x, y)
@@ -311,13 +282,13 @@ class ButtonNodeWidget(NodeWidget):
             y: Number,
             node: Node,
             parent: Optional[Union[CanvasObject, BaseCanvasWidget]] = None,
-            layout: Optional[CanvasLayout] = None,
+            layout: Optional[ButtonLayout] = None,
             selected: bool = False,
             port_radius: Number = 10,
     ):
         super().__init__(x, y, node, parent, layout, selected, port_radius)
 
-        layout = CanvasLayout(width=100, height=30, background_color="darkgray")
+        layout = ButtonLayout()
         s = BaseCanvasWidget(50, 50, parent=self, layout=layout)
         s.handle_select = self.handle_button_select
         self.add_widget(s)

--- a/ryven/ironflow/NodeWidget.py
+++ b/ryven/ironflow/NodeWidget.py
@@ -215,7 +215,7 @@ class NodeWidget(BaseCanvasWidget):
         self.add_outputs()
 
     def draw_title(self, title: str) -> None:
-        self.canvas.fill_style = "darkgray"
+        self.canvas.fill_style = self.node.color if hasattr(self.node, 'color') else "darkgray"
         self.canvas.fill_rect(self.x, self.y, self.width, self._title_box_height)
         self.canvas.font = f"{self.layout.font_size}px serif"
         self.canvas.fill_style = self.layout.font_title_color

--- a/ryven/ironflow/NodeWidget.py
+++ b/ryven/ironflow/NodeWidget.py
@@ -177,7 +177,7 @@ class NodeWidget(BaseCanvasWidget):
         }
 
         if len(self.node.inputs) > 3:
-            self._height = 200
+            self._height = 200  # TODO: Make height programatically dependent on content
         self.add_inputs()
         self.add_outputs()
 

--- a/ryven/ironflow/NodeWidget.py
+++ b/ryven/ironflow/NodeWidget.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 from IPython.display import display
-from .layouts import Layout, NodeLayout, DataPortLayout, ExecPortLayout, ButtonLayout
+from .layouts import Layout, NodeLayout, PortLayout, DataPortLayout, ExecPortLayout, ButtonLayout
 
 from typing import TYPE_CHECKING, Optional, Union, List, Any
 if TYPE_CHECKING:
@@ -29,15 +29,14 @@ class BaseCanvasWidget:
             self,
             x: Number,
             y: Number,
-            parent: Optional[Union[CanvasObject, BaseCanvasWidget]] = None,
-            layout: Optional[Layout] = None,
+            parent: Union[CanvasObject, BaseCanvasWidget],
+            layout: Layout,
             selected: bool = False
     ):
         self._x = x  # relative to parent
         self._y = y
 
         self.layout = layout
-
         self.parent = parent
         self.selected = selected
 
@@ -69,11 +68,6 @@ class BaseCanvasWidget:
         return self.parent.canvas
 
     def add_widget(self, widget: BaseCanvasWidget) -> None:
-        if widget.parent is None:
-            widget.parent = self
-        if widget.layout is None:
-            widget.layout = self.parent.layout
-
         self.objects_to_draw.append(widget)
 
     def set_x_y(self, x_in: Number, y_in: Number) -> None:
@@ -130,10 +124,10 @@ class PortWidget(BaseCanvasWidget):
         self,
         x: Number,
         y: Number,
+        parent: Union[CanvasObject, BaseCanvasWidget],
+        layout: PortLayout,
         radius: Number = 10,
-        parent: Optional[Union[CanvasObject, BaseCanvasWidget]] = None,
         port: Optional[NodePort] = None,
-        layout: Optional[Union[DataPortLayout, ExecPortLayout]] = None,
         selected: bool = False,
         text_left: str = "",
     ):
@@ -166,9 +160,9 @@ class NodeWidget(BaseCanvasWidget):
             self,
             x: Number,
             y: Number,
+            parent: Union[CanvasObject, BaseCanvasWidget],
+            layout: NodeLayout,
             node: Node,
-            parent: Optional[Union[CanvasObject, BaseCanvasWidget]] = None,
-            layout: Optional[NodeLayout] = None,
             selected: bool = False,
             port_radius: Number = 10,
     ):
@@ -244,11 +238,11 @@ class NodeWidget(BaseCanvasWidget):
                     PortWidget(
                         x,
                         y_port * d_y + y_min,
-                        radius=radius,
                         parent=self,
-                        port=data[i_port],
-                        text_left=data[i_port].label_str,
                         layout=self.port_layouts[data[i_port].type_],
+                        port=data[i_port],
+                        radius=radius,
+                        text_left=data[i_port].label_str,
                     )
                 )
 
@@ -280,13 +274,13 @@ class ButtonNodeWidget(NodeWidget):
             self,
             x: Number,
             y: Number,
+            parent: Union[CanvasObject, BaseCanvasWidget],
+            layout: ButtonLayout,
             node: Node,
-            parent: Optional[Union[CanvasObject, BaseCanvasWidget]] = None,
-            layout: Optional[ButtonLayout] = None,
             selected: bool = False,
             port_radius: Number = 10,
     ):
-        super().__init__(x, y, node, parent, layout, selected, port_radius)
+        super().__init__(x, y, parent, layout, node, selected, port_radius)
 
         layout = ButtonLayout()
         s = BaseCanvasWidget(50, 50, parent=self, layout=layout)

--- a/ryven/ironflow/NodeWidget.py
+++ b/ryven/ironflow/NodeWidget.py
@@ -202,12 +202,20 @@ class NodeWidget(BaseCanvasWidget):
         self.outputs = node.outputs
 
         self.port_radius = port_radius
-        self.layout_ports = CanvasLayout(
-            width=20,
-            height=10,
-            background_color="lightgreen",
-            selected_color="darkgreen",
-        )
+        self.port_layouts = {
+            'data': CanvasLayout(
+                width=20,
+                height=10,
+                background_color="lightgreen",
+                selected_color="darkgreen",
+            ),
+            'exec': CanvasLayout(
+                width=20,
+                height=10,
+                background_color="lightblue",
+                selected_color="darkblue",
+            )
+        }
 
         if len(self.node.inputs) > 3:
             self._height = 200
@@ -269,7 +277,7 @@ class NodeWidget(BaseCanvasWidget):
                         parent=self,
                         port=data[i_port],
                         text_left=data[i_port].label_str,
-                        layout=self.layout_ports,
+                        layout=self.port_layouts[data[i_port].type_],
                     )
                 )
 

--- a/ryven/ironflow/NodeWidget.py
+++ b/ryven/ironflow/NodeWidget.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import numpy as np
 from IPython.display import display
 
-from typing import TYPE_CHECKING, Optional, Union, Dict, Any
+from typing import TYPE_CHECKING, Optional, Union, List, Any
 if TYPE_CHECKING:
     from .CanvasObject import CanvasObject
     from ipycanvas import Canvas
-    from ryven.NENV import Node
+    from ryven.NENV import Node, NodeInputBP, NodeOutputBP
     Number = Union[int, float]
     from ryvencore.NodePort import NodePort
 
@@ -238,8 +238,8 @@ class NodeWidget(BaseCanvasWidget):
     def _add_ports(
             self,
             radius: Number,
-            inputs: Optional[Dict] = None,
-            outputs: Optional[Dict] = None,
+            inputs: Optional[List[NodeInputBP]] = None,
+            outputs: Optional[List[NodeOutputBP]] = None,
             border: Number = 1.4,
             text: str = ""
     ) -> None:

--- a/ryven/ironflow/layouts.py
+++ b/ryven/ironflow/layouts.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from typing import Optional
 from abc import ABC
 from dataclasses import dataclass
 

--- a/ryven/ironflow/layouts.py
+++ b/ryven/ironflow/layouts.py
@@ -3,6 +3,7 @@ from typing import Optional
 from abc import ABC
 from dataclasses import dataclass
 
+
 @dataclass
 class Layout(ABC):
     width: int
@@ -10,15 +11,11 @@ class Layout(ABC):
     background_color: str = "gray"
     font_size: int = 18
     font_color: str = "black"
-
-
-@dataclass
-class SelectableLayout(Layout, ABC):
     selected_color: str = "green"
 
 
 @dataclass
-class NodeLayout(SelectableLayout):
+class NodeLayout(Layout):
     width: int = 200
     height: int = 100
     font_title_size: int = 22
@@ -26,7 +23,7 @@ class NodeLayout(SelectableLayout):
 
 
 @dataclass
-class PortLayout(SelectableLayout, ABC):
+class PortLayout(Layout, ABC):
     width: int = 20
     height: int = 10
 

--- a/ryven/ironflow/layouts.py
+++ b/ryven/ironflow/layouts.py
@@ -1,66 +1,50 @@
 from __future__ import annotations
 from typing import Optional
+from abc import ABC
+from dataclasses import dataclass
+
+@dataclass
+class Layout(ABC):
+    width: int
+    height: int
+    background_color: str = "gray"
+    font_size: int = 18
+    font_color: str = "black"
 
 
-def layout_factory(
-        width: int = 100,
-        height: int = 60,
-        font_size: int = 18,
-        background_color: str = "gray",
-        selected_color: str = "green",
-        font_color: str = "black",
-        font_title_color: str = "black",
-        font_title_size: int = 22,
-        docstring: Optional[str] = None,
-):
-    class Layout:
-        def __init__(
-                self,
-                width: int = width,
-                height: int = height,
-                font_size: int = font_size,
-                background_color: str = background_color,
-                selected_color: str = selected_color,
-                font_color: str = font_color,
-                font_title_color: str = font_title_color,
-                font_title_size: int = font_title_size
-        ):
-            self.width = width
-            self.height = height
-            self.background_color = background_color
-            self.selected_color = selected_color
-            self.font_size = font_size
-            self.font_color = font_color
-            self.font_title_color = font_title_color
-            self.font_title_size = font_title_size
-    Layout.__doc__ = docstring
-    return Layout
+@dataclass
+class SelectableLayout(Layout, ABC):
+    selected_color: str = "green"
 
 
-CanvasLayout = layout_factory()
-
-NodeLayout = layout_factory(
-    width=200,
-    height=100
-)
-
-DataPortLayout = layout_factory(
-    width=20,
-    height=10,
-    background_color="lightgreen",
-    selected_color="darkgreen",
-)
-
-ExecPortLayout = layout_factory(
-    width=20,
-    height=10,
-    background_color="lightblue",
-    selected_color="darkblue",
-)
+@dataclass
+class NodeLayout(SelectableLayout):
+    width: int = 200
+    height: int = 100
+    font_title_size: int = 22
+    font_title_color: str = "black"
 
 
-ButtonLayout = layout_factory(
-    width=100,
-    height=30,
-    background_color="darkgray",
-)
+@dataclass
+class PortLayout(SelectableLayout, ABC):
+    width: int = 20
+    height: int = 10
+
+
+@dataclass
+class DataPortLayout(PortLayout):
+    background_color: str = "lightgreen"
+    selected_color: str = "darkgreen"
+
+
+@dataclass
+class ExecPortLayout(PortLayout):
+    background_color: str = "lightblue"
+    selected_color: str = "darkblue"
+
+
+@dataclass
+class ButtonLayout(Layout):
+    width: int = 100
+    height: int = 30
+    background_color: str = "darkgray"

--- a/ryven/ironflow/layouts.py
+++ b/ryven/ironflow/layouts.py
@@ -12,6 +12,11 @@ class Layout(ABC):
     font_size: int = 18
     font_color: str = "black"
     selected_color: str = "green"
+    font: str = "serif"
+
+    @property
+    def font_string(self):
+        return f"{self.font_size}px {self.font}"
 
 
 @dataclass
@@ -20,6 +25,11 @@ class NodeLayout(Layout):
     height: int = 100
     font_title_size: int = 22
     font_title_color: str = "black"
+    title_font: str = "serif"
+
+    @property
+    def title_font_string(self):
+        return f"{self.font_title_size}px {self.title_font}"
 
 
 @dataclass

--- a/ryven/ironflow/layouts.py
+++ b/ryven/ironflow/layouts.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+from typing import Optional
+
+
+def layout_factory(
+        width: int = 100,
+        height: int = 60,
+        font_size: int = 18,
+        background_color: str = "gray",
+        selected_color: str = "green",
+        font_color: str = "black",
+        font_title_color: str = "black",
+        font_title_size: int = 22,
+        docstring: Optional[str] = None,
+):
+    class Layout:
+        def __init__(
+                self,
+                width: int = width,
+                height: int = height,
+                font_size: int = font_size,
+                background_color: str = background_color,
+                selected_color: str = selected_color,
+                font_color: str = font_color,
+                font_title_color: str = font_title_color,
+                font_title_size: int = font_title_size
+        ):
+            self.width = width
+            self.height = height
+            self.background_color = background_color
+            self.selected_color = selected_color
+            self.font_size = font_size
+            self.font_color = font_color
+            self.font_title_color = font_title_color
+            self.font_title_size = font_title_size
+    Layout.__doc__ = docstring
+    return Layout
+
+
+CanvasLayout = layout_factory()
+
+NodeLayout = layout_factory(
+    width=200,
+    height=100
+)
+
+DataPortLayout = layout_factory(
+    width=20,
+    height=10,
+    background_color="lightgreen",
+    selected_color="darkgreen",
+)
+
+ExecPortLayout = layout_factory(
+    width=20,
+    height=10,
+    background_color="lightblue",
+    selected_color="darkblue",
+)
+
+
+ButtonLayout = layout_factory(
+    width=100,
+    height=30,
+    background_color="darkgray",
+)


### PR DESCRIPTION
Work in progress.

Distinguishing data and exec ports by colour, as suggested in #8.

Under the hood I'm also trying to better encapsulate logic from presentation. Right now that means pulling out the `Layout` classes into their own module, but these in turn should also probably be fed by some sort of theme.yml file. I'm also not totally happy with the factory pattern for the layouts, as I have some ugly class stuff like the two port classes redefining shared values (instead of having a shared parent) and all the classes carrying around title data that should really only be for the node class.