### PR TITLE
Notebook nodes

### DIFF
--- a/ryven/ironflow/CanvasObject.py
+++ b/ryven/ironflow/CanvasObject.py
@@ -220,7 +220,6 @@ class CanvasObject(HasSession):
 
     def add_node(self, x: Number, y: Number, node: Node):
         n = self.flow.create_node(node)
-        print("node: ", n.identifier, n.GLOBAL_ID)
         self.load_node(x, y, n)
 
         self.redraw()

--- a/ryven/ironflow/Gui.py
+++ b/ryven/ironflow/Gui.py
@@ -75,6 +75,25 @@ class GUI(HasSession):
 
         Args:
             node_class Type[NENV.Node]: The new node class to register.
+
+        Example:
+            >>> from ryven.ironflow import GUI, Node, NodeInputBP, NodeOutputBP, dtypes
+            >>> gui = GUI(script_title='foo')
+            >>>
+            >>> class MyNode(Node):
+            >>>     title = "MyUserNode"
+            >>>     init_inputs = [
+            >>>         NodeInputBP(dtype=dtypes.Integer(default=1), label="foo")
+            >>>     ]
+            >>>     init_outputs = [
+            >>>        NodeOutputBP(label="bar")
+            >>>    ]
+            >>>    color = 'cyan'
+            >>>
+            >>>     def update_event(self, inp=-1):
+            >>>         self.set_output_val(0, self.input(0) + 42)
+            >>>
+            >>> gui.register_user_node(MyNode)
         """
         if node_class in self.session.nodes:
             self.session.unregister_node(node_class)

--- a/ryven/ironflow/Gui.py
+++ b/ryven/ironflow/Gui.py
@@ -56,8 +56,8 @@ class GUI(HasSession):
 
         self.out_log = widgets.Output(layout={"border": "1px solid black"})
 
-    def _register_node(self, node_class: Type[NENV.Node]):
-        node_module = node_class.__module__.replace('__main__', 'user')  # n.identifier_prefix
+    def _register_node(self, node_class: Type[NENV.Node], node_module: Optional[str] = None):
+        node_module = node_module or node_class.__module__  # n.identifier_prefix
         if node_module not in self._nodes_dict.keys():
             self._nodes_dict[node_module] = {}
         self._nodes_dict[node_module][node_class.title] = node_class
@@ -76,7 +76,7 @@ class GUI(HasSession):
         if node_class in self.session.nodes:
             self.session.unregister_node(node_class)
         self.session.register_node(node_class)
-        self._register_node(node_class)
+        self._register_node(node_class, node_module='user')
 
     @property
     def script_title(self) -> str:

--- a/ryven/ironflow/Gui.py
+++ b/ryven/ironflow/Gui.py
@@ -12,7 +12,7 @@ from .has_session import HasSession
 import ryven.NENV as NENV
 from pathlib import Path
 
-from typing import Optional, Dict
+from typing import Optional, Dict, Type
 
 __author__ = "Joerg Neugebauer"
 __copyright__ = (
@@ -47,18 +47,36 @@ class GUI(HasSession):
                 import_nodes_package(NodesPackage(directory=package))
             )
 
-        nodes_dict = {}
+        self._nodes_dict = {}
         for n in self.session.nodes:
-            node_class = n.__module__  # n.identifier_prefix
-            if node_class not in nodes_dict.keys():
-                nodes_dict[node_class] = {}
-            nodes_dict[node_class][n.title] = n
-        self._nodes_dict = nodes_dict
+            self._register_node(n)
 
         self.canvas_widget = CanvasObject(gui=self)
         # self.onto_dic = onto_dic
 
         self.out_log = widgets.Output(layout={"border": "1px solid black"})
+
+    def _register_node(self, node_class: Type[NENV.Node]):
+        node_module = node_class.__module__.replace('__main__', 'notebook')  # n.identifier_prefix
+        if node_module not in self._nodes_dict.keys():
+            self._nodes_dict[node_module] = {}
+        self._nodes_dict[node_module][node_class.title] = node_class
+
+    def register_custom_node(self, node_class: Type[NENV.Node]):
+        """
+        Register a custom node class from the gui's current working scope. These nodes are available under the
+        'notebook' module.
+
+        Note: You can re-register a class to update its functionality, but only *newly placed* nodes will see this
+                update. Already-placed nodes are still instances of the old class and need to be deleted.
+
+        Args:
+            node_class Type[NENV.Node]: The new node class to register.
+        """
+        if node_class in self.session.nodes:
+            self.session.unregister_node(node_class)
+        self.session.register_node(node_class)
+        self._register_node(node_class)
 
     @property
     def script_title(self) -> str:

--- a/ryven/ironflow/Gui.py
+++ b/ryven/ironflow/Gui.py
@@ -57,12 +57,12 @@ class GUI(HasSession):
         self.out_log = widgets.Output(layout={"border": "1px solid black"})
 
     def _register_node(self, node_class: Type[NENV.Node]):
-        node_module = node_class.__module__.replace('__main__', 'notebook')  # n.identifier_prefix
+        node_module = node_class.__module__.replace('__main__', 'user')  # n.identifier_prefix
         if node_module not in self._nodes_dict.keys():
             self._nodes_dict[node_module] = {}
         self._nodes_dict[node_module][node_class.title] = node_class
 
-    def register_custom_node(self, node_class: Type[NENV.Node]):
+    def register_user_node(self, node_class: Type[NENV.Node]):
         """
         Register a custom node class from the gui's current working scope. These nodes are available under the
         'notebook' module.

--- a/ryven/ironflow/Gui.py
+++ b/ryven/ironflow/Gui.py
@@ -70,6 +70,9 @@ class GUI(HasSession):
         Note: You can re-register a class to update its functionality, but only *newly placed* nodes will see this
                 update. Already-placed nodes are still instances of the old class and need to be deleted.
 
+        Note: You can save the graph as normal, but new gui instances will need to register the same custom nodes before
+            loading the saved graph is possible.
+
         Args:
             node_class Type[NENV.Node]: The new node class to register.
         """

--- a/ryven/ironflow/__init__.py
+++ b/ryven/ironflow/__init__.py
@@ -1,1 +1,4 @@
 __all__ = ['Gui', 'CanvasObject', 'NodeWidget', 'NodeWidgets']
+
+from .Gui import GUI
+from ryven.NENV import Node, NodeInputBP, NodeOutputBP, dtypes

--- a/tests/unit/test_Gui.py
+++ b/tests/unit/test_Gui.py
@@ -3,7 +3,7 @@
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
 from unittest import TestCase
-from ryven.ironflow.Gui import GUI
+from ryven.ironflow import GUI, Node, NodeInputBP, NodeOutputBP, dtypes
 import os
 
 
@@ -52,3 +52,48 @@ class TestGUI(TestCase):
         )
 
         os.remove(f"{title}.json")
+
+    def test_user_node_registration(self):
+        """TODO: This only tests the backend graph, need to test front end as well"""
+        gui = GUI(script_title='foo')
+
+        class MyNode(Node):
+            title = "MyUserNode"
+            init_inputs = [
+                NodeInputBP(dtype=dtypes.Integer(default=1), label="foo")
+            ]
+            init_outputs = [
+                NodeOutputBP(label="bar")
+            ]
+            color = 'cyan'
+
+            def update_event(self, inp=-1):
+                self.set_output_val(0, self.input(0) + 42)
+
+        gui.register_user_node(MyNode)
+        self.assertIn(MyNode, gui.session.nodes)
+
+        gui.canvas_widget.add_node(0, 0, gui._nodes_dict["user"][MyNode.title])
+        gui.flow.nodes[0].inputs[0].update(1)
+        self.assertEqual(gui.flow.nodes[0].outputs[0].val, 43)
+
+        class MyNode(Node):  # Update class
+            title = "MyUserNode"
+            init_inputs = [
+                NodeInputBP(dtype=dtypes.Integer(default=1), label="foo")
+            ]
+            init_outputs = [
+                NodeOutputBP(label="bar")
+            ]
+            color = 'cyan'
+
+            def update_event(self, inp=-1):
+                self.set_output_val(0, self.input(0) - 42)
+
+        gui.register_user_node(MyNode)
+        gui.flow.nodes[0].inputs[0].update(2)
+        self.assertEqual(gui.flow.nodes[0].outputs[0].val, 44, msg="Expected to be using instance of old class")
+
+        gui.canvas_widget.add_node(1, 1, gui._nodes_dict["user"][MyNode.title])
+        gui.flow.nodes[1].inputs[0].update(2)
+        self.assertEqual(gui.flow.nodes[1].outputs[0].val, -40, msg="New node instances should reflect updated class.")

--- a/tests/unit/test_Gui.py
+++ b/tests/unit/test_Gui.py
@@ -36,11 +36,10 @@ class TestGUI(TestCase):
         # Maybe this will change in the future, but it's baked in the assumptions for now so let's make sure to test it
 
         new_flow = new_gui._session.scripts[0].flow
-        print(new_flow)
         self.assertEqual(0, len(new_flow.nodes), msg="Fresh GUI shouldn't have any nodes yet.")
         self.assertEqual(0, len(new_flow.connections), msg="Fresh GUI shouldn't have any connections yet.")
 
-        new_gui.draw()  # Temporary hack to ensure new_gui.out_canvas exists
+        new_gui.draw()  # TODO: Temporary hack to ensure new_gui.out_canvas exists, allow renderless loading
         new_gui.on_file_load(None)
         new_flow = new_gui._session.scripts[0].flow  # Session script gets reloaded, so grab this again
         print(new_gui._session.scripts, new_gui._session.scripts[0].flow)
@@ -97,3 +96,21 @@ class TestGUI(TestCase):
         gui.canvas_widget.add_node(1, 1, gui._nodes_dict["user"][MyNode.title])
         gui.flow.nodes[1].inputs[0].update(2)
         self.assertEqual(gui.flow.nodes[1].outputs[0].val, -40, msg="New node instances should reflect updated class.")
+
+        gui.on_file_save(None)
+        new_gui = GUI(script_title=gui.script_title)
+        new_gui.draw()  # TODO: Change the gui to allow renderless loading
+        with self.assertRaises(Exception):
+            new_gui.on_file_load(None)
+
+        new_gui.register_user_node(MyNode)
+        new_gui.on_file_load(None)
+        new_gui.flow.nodes[0].inputs[0].update(3)
+        new_gui.flow.nodes[1].inputs[0].update(3)
+        self.assertEqual(
+            new_gui.flow.nodes[0].outputs[0].val,
+            new_gui.flow.nodes[1].outputs[0].val,
+            msg="The updated class was registered, so expect the same behaviour from both nodes now."
+        )
+
+        os.remove(f"{gui.script_title}.json")


### PR DESCRIPTION
Allow users to develop nodes right in the notebook and immediately use them.

- Necessary bits (`Node, NodeInputBP, NodeOutputBP, dtypes`) are available for import directly from `ryven.ironflow`
- Convenient helper function allows easy registration (`GUI.register_user_node`), including an example
- Re-registering updates the functionality
  - All newly added nodes have the new behaviour, existing nodes in the graph are already instances of the old class and so they need to be manually deleted. There is no need to restart the entire gui though.
- Saving the graph works fine, loading works fine as long as the custom nodes have been registered with the new gui instance beforehand
-Back-end tests in place