### PR TITLE
Debug selection logic to correctly handle re-selecting the same object

### DIFF
--- a/ryven/ironflow/CanvasObject.py
+++ b/ryven/ironflow/CanvasObject.py
@@ -146,19 +146,19 @@ class CanvasObject(HasSession):
         sel_object = self.get_element_at_xy(x, y)
         last_object = self._last_selected_object
 
-        # Case 1: Select something new
-        if sel_object is not None and sel_object != last_object:
-            if last_object is not None:
+        if last_object is None:
+            if sel_object is not None:
+                sel_object = self._handle_new_object_selection(sel_object)
+            elif time_since_last_click < self._double_click_speed:
+                self.add_node(x, y, self.gui.new_node_class)
+                self._built_object_to_gui_dict()
+        else:
+            if sel_object is not None:
+                if sel_object != last_object:
+                    last_object.deselect()
+                    sel_object = self._handle_new_object_selection(sel_object)
+            else:
                 last_object.deselect()
-            sel_object = self._handle_new_object_selection(sel_object)
-        # Case 2: Double-click on empty space
-        elif last_object is None and time_since_last_click < self._double_click_speed:
-            self.add_node(x, y, self.gui.new_node_class)
-            self._built_object_to_gui_dict()
-        # Case 3: Single-click on empty space
-        elif last_object is not None:
-            last_object.deselect()
-        # Case 4: you re-selected the same thing (possibly empty space)
 
         self._last_selected_object = sel_object
 


### PR DESCRIPTION
When you click on an already-selected object, nothing should happen. Resolves the (other half of) #17.

This also makes moving nodes easier, since before you had to select and start moving all in one swoop. Now you can simply click and drag on an already-selected node and it will move. This was the intended behaviour all along, but I biffed the conditional logic before.