### PR TITLE
Allow reinstantiating the gui

### DIFF
--- a/ryven/main/utils.py
+++ b/ryven/main/utils.py
@@ -84,7 +84,7 @@ def import_nodes_package(package: NodesPackage = None, directory: str = None) ->
     # add package name to identifiers and define custom types
 
     for n in nodes:
-        n.identifier_prefix = package.name  #  + '.' + (n.identifier if n.identifier else n.__name__)
+        n.identifier_prefix = package.name if n.identifier is None else None
         n.type_ = package.name if not n.type_ else package.name+f'[{n.type_}]'
 
     return nodes

--- a/tests/unit/test_Gui.py
+++ b/tests/unit/test_Gui.py
@@ -114,3 +114,14 @@ class TestGUI(TestCase):
         )
 
         os.remove(f"{gui.script_title}.json")
+
+    def test_repeated_instantiation(self):
+        gui = GUI(script_title='foo')
+        id0 = str(gui.session.nodes[0].identifier)
+        gui = GUI(script_title='foo')
+        self.assertEqual(
+            gui.session.nodes[0].identifier,
+            id0,
+            msg=f"Reinstantiating the gui should not change node identifiers, but got {id0} then "
+                f"{gui.session.nodes[0].identifier}"
+        )


### PR DESCRIPTION
Nodes get registered when the gui is instantiated, and deep in the Ryven source code the identifier for a node class is it's prefix plus its current identifier. In our code we set a prefix, but that meant that the node identifiers contained the prefix repeatedly for each time the gui was instantiated! This broke saving and loading as we got identifiers like `std.std.std.SomeNode`, while a new gui on a new kernel instance was looking simply for `std.SomeNode`, or vice versa, depending whether you're reinstantiating at save or load time -- but if the reinstantiation count didn't match you were sunk. It's just a tiny one-liner fix, but took forever to track down 😭 