### PR TITLE
Multiple scripts

### DIFF
--- a/ryven/ironflow/CanvasObject.py
+++ b/ryven/ironflow/CanvasObject.py
@@ -7,7 +7,6 @@ from time import time
 from .NodeWidget import NodeWidget, PortWidget, BaseCanvasWidget, ButtonNodeWidget
 from .layouts import NodeLayout
 from .NodeWidgets import NodeWidgets
-from .has_session import HasSession
 
 from typing import TYPE_CHECKING, Optional, Union, List
 if TYPE_CHECKING:
@@ -27,8 +26,10 @@ __status__ = "production"
 __date__ = "May 10, 2022"
 
 
-class CanvasObject(HasSession):
+class CanvasObject:
     """
+    A canvas for representing a particular Ryven script, which is determined at instantiation by the currently active
+    gui script.
 
     Mouse behaviour:
         - Mouse click (down and release) on a node element or any child element selects that element
@@ -45,7 +46,7 @@ class CanvasObject(HasSession):
     """
     def __init__(self, gui: Optional[GUI] = None, width: int = 2000, height: int = 1000):
         self.gui = gui
-        super().__init__(self.gui.session)
+        self.flow = gui.flow
         self._width, self._height = width, height
 
         self._col_background = "black"  # "#584f4e"

--- a/ryven/ironflow/FlowCanvas.py
+++ b/ryven/ironflow/FlowCanvas.py
@@ -26,7 +26,7 @@ __status__ = "production"
 __date__ = "May 10, 2022"
 
 
-class CanvasObject:
+class FlowCanvas:
     """
     A canvas for representing a particular Ryven script, which is determined at instantiation by the currently active
     gui script.

--- a/ryven/ironflow/Gui.py
+++ b/ryven/ironflow/Gui.py
@@ -41,10 +41,10 @@ debug_view = widgets.Output(layout={"border": "1px solid black"})
 
 
 class GUI(HasSession):
-    def __init__(self, script_title: str = "test", session: Optional[rc.Session] = None):  # , onto_dic=onto_dic):
+    def __init__(self, script_title: Optional[str] = None, session: Optional[rc.Session] = None):
         super().__init__(session=rc.Session() if session is None else session)
         self._flow_canvases = []
-        self.create_script(title=self.next_auto_script_name)
+        self.create_script(title=script_title if script_title is not None else self.next_auto_script_name)
 
         for package in packages:
             self.session.register_nodes(

--- a/ryven/ironflow/Gui.py
+++ b/ryven/ironflow/Gui.py
@@ -205,8 +205,14 @@ class GUI(HasSession):
         self.btn_delete_node = widgets.Button(tooltip="Delete Node", icon="trash", layout=button_layout)
         self.btn_rename_script = widgets.Button(tooltip="Rename script", icon="file", layout=button_layout)
         # TODO: Use file-pen once this is available
-        self.btn_delete_script = widgets.Button(tooltip="Delete script", icon="square-minus", layout=button_layout)
+        self.btn_delete_script = widgets.Button(tooltip="Delete script", icon="minus", layout=button_layout)
         # TODO: Use file-circle-minus once this is available
+
+        self.script_name_box = widgets.Text(value=self.script.title, description="New script name:")
+        self.btn_confirm_script_name = widgets.Button(tooltip="Confirm new name", icon="check", layout=button_layout)
+        self.btn_cancel_script_name = widgets.Button(tooltip="Cancel renaming", icon="ban", layout=button_layout)
+        # TODO: Use xmark once this is available
+        self.script_rename_panel = widgets.HBox([])
 
         self.alg_mode_dropdown = widgets.Dropdown(
             options=alg_modes,
@@ -232,6 +238,10 @@ class GUI(HasSession):
         self.btn_load.on_click(self.on_file_load)
         self.btn_save.on_click(self.on_file_save)
         self.btn_delete_node.on_click(self.on_delete_node)
+        self.btn_rename_script.on_click(self.on_rename_script)
+        self.btn_confirm_script_name.on_click(self.on_confirm_script_name)
+        self.btn_cancel_script_name.on_click(self.on_cancel_script_name)
+
 
         # if self.canvas_widget._node_widget is None:
         #     self.canvas_widget._node_widget = widgets.Box()
@@ -249,6 +259,7 @@ class GUI(HasSession):
                         self.btn_delete_script,
                     ]
                 ),
+                self.script_rename_panel,
                 widgets.HBox(
                     [widgets.VBox([self.node_selector]), self.script_tabs, self.out_plot]
                 ),
@@ -281,6 +292,7 @@ class GUI(HasSession):
         self.canvas_widget.script.flow.set_algorithm_mode(self.alg_mode_dropdown.value)
 
     def on_tab_select(self, change: Dict):
+        self._empty_script_rename_panel()
         selected_index = self.script_tabs.get_state(key='selected_index')['selected_index']
         if selected_index == self.n_scripts:
             self.new_script_tab_selected()
@@ -295,6 +307,29 @@ class GUI(HasSession):
             display(self._flow_canvases[-1].canvas)
         self.script_tabs.selected_index = last_script_index
         self._add_new_script_tab()
+
+    def on_rename_script(self, change: Dict) -> None:
+        self.script_name_box.value = self.script.title
+        self.script_rename_panel.children = [
+            self.script_name_box,
+            self.btn_confirm_script_name,
+            self.btn_cancel_script_name
+        ]
+
+    def on_confirm_script_name(self, change: Dict) -> None:
+        new_name = self.script_name_box.value
+        self.script.title = new_name
+        self.script_tabs.set_title(
+            self.script_tabs.get_state(key='selected_index')['selected_index'],
+            new_name
+        )
+        self._empty_script_rename_panel()
+
+    def on_cancel_script_name(self, change: Dict) -> None:
+        self._empty_script_rename_panel()
+
+    def _empty_script_rename_panel(self) -> None:
+        self.script_rename_panel.children = []
 
     @property
     def new_node_class(self):

--- a/ryven/ironflow/Gui.py
+++ b/ryven/ironflow/Gui.py
@@ -223,6 +223,7 @@ class GUI(HasSession):
 
         self.alg_mode_dropdown.observe(self.on_alg_mode_change, names="value")
         self.modules_dropdown.observe(self.on_value_change, names="value")
+        self.script_tabs.observe(self.on_tab_select)
         self.btn_load.on_click(self.on_file_load)
         self.btn_save.on_click(self.on_file_save)
         self.btn_delete_node.on_click(self.on_delete_node)
@@ -270,12 +271,17 @@ class GUI(HasSession):
     def on_alg_mode_change(self, change: Dict) -> None:
         self.canvas_widget.script.flow.set_algorithm_mode(self.alg_mode_dropdown.value)
 
+    def on_tab_select(self, change: Dict):
+        self.activate_script(self.script_tabs.get_state(key='selected_index')['selected_index'])
+
     def on_new_script(self, change: Dict) -> None:
         self.create_script(f"script_{len(self.session.scripts)}")
         self.script_tabs.children += (widgets.Output(layout={"border": "1px solid black"}),)
-        self.script_tabs.set_title(len(self.script_tabs.children) - 1, self.session.scripts[-1].title)
+        last_index = len(self.script_tabs.children) - 1
+        self.script_tabs.set_title(last_index, self.session.scripts[-1].title)
         with self.script_tabs.children[-1]:
             display(self._flow_canvases[-1].canvas)
+        self.script_tabs.selected_index = last_index
 
     @property
     def new_node_class(self):

--- a/ryven/ironflow/Gui.py
+++ b/ryven/ironflow/Gui.py
@@ -197,15 +197,11 @@ class GUI(HasSession):
             layout=widgets.Layout(width="130px"),
         )
 
-        self.btn_load = widgets.Button(
-            tooltip="Load", icon="upload", layout=widgets.Layout(width="50px")
-        )
-        self.btn_save = widgets.Button(
-            tooltip="Save", icon="download", layout=widgets.Layout(width="50px")
-        )
-        self.btn_delete_node = widgets.Button(
-            tooltip="Delete Node", icon="trash", layout=widgets.Layout(width="50px")
-        )
+        button_layout = widgets.Layout(width="50px")
+        self.btn_load = widgets.Button(tooltip="Load", icon="upload", layout=button_layout)
+        self.btn_save = widgets.Button(tooltip="Save", icon="download", layout=button_layout)
+        self.btn_delete_node = widgets.Button(tooltip="Delete Node", icon="trash", layout=button_layout)
+        self.btn_new_script = widgets.Button(tooltip="New script", icon="file-plus", layout=button_layout)
 
         self.alg_mode_dropdown = widgets.Dropdown(
             options=alg_modes,
@@ -242,7 +238,8 @@ class GUI(HasSession):
                         self.alg_mode_dropdown,
                         self.btn_save,
                         self.btn_load,
-                        self.btn_delete_node
+                        self.btn_delete_node,
+                        self.btn_new_script
                     ]
                 ),
                 widgets.HBox(

--- a/ryven/ironflow/Gui.py
+++ b/ryven/ironflow/Gui.py
@@ -275,14 +275,13 @@ class GUI(HasSession):
         self.canvas_widget.script.flow.set_algorithm_mode(self.alg_mode_dropdown.value)
 
     def on_tab_select(self, change: Dict):
-        # self.activate_script(self.script_tabs.get_state(key='selected_index')['selected_index'])
         selected_index = self.script_tabs.get_state(key='selected_index')['selected_index']
         if selected_index == self.n_scripts:
-            self.on_new_script({})
+            self.new_script_tab_selected()
         else:
             self.activate_script(selected_index)
 
-    def on_new_script(self, change: Dict) -> None:
+    def new_script_tab_selected(self) -> None:
         self.create_script(f"script_{len(self.session.scripts)}")
         last_script_index = self.n_scripts - 1
         self.script_tabs.set_title(last_script_index, self.session.scripts[-1].title)

--- a/ryven/ironflow/Gui.py
+++ b/ryven/ironflow/Gui.py
@@ -54,10 +54,14 @@ class GUI(HasSession):
         for n in self.session.nodes:
             self._register_node(n)
 
-        self.canvas_widget = FlowCanvas(gui=self)
+        self._flow_canvases = [FlowCanvas(gui=self)]
         # self.onto_dic = onto_dic
 
         self.out_log = widgets.Output(layout={"border": "1px solid black"})
+
+    @property
+    def canvas_widget(self):
+        return self._flow_canvases[0]
 
     def _register_node(self, node_class: Type[NENV.Node], node_module: Optional[str] = None):
         node_module = node_module or node_class.__module__  # n.identifier_prefix
@@ -129,7 +133,7 @@ class GUI(HasSession):
         self.session.delete_script(self.script)
         self.session.load(data)
 
-        self.canvas_widget = FlowCanvas(gui=self)
+        self._flow_canvases = [FlowCanvas(gui=self)]
         self.canvas_widget.canvas_restart()
         all_data = data["scripts"][i_script]["flow"]["nodes"]
         for i, node in enumerate(self.flow.nodes):

--- a/ryven/ironflow/Gui.py
+++ b/ryven/ironflow/Gui.py
@@ -178,9 +178,15 @@ class GUI(HasSession):
             layout={"width": "50%", "border": "1px solid black"}
         )
 
+
         self.out_canvas = widgets.Output(layout={"border": "1px solid black"})
-        with self.out_canvas:
-            display(self.canvas_widget.canvas)
+        self.script_tabs = widgets.Tab(
+            [widgets.Output(layout={"border": "1px solid black"}) for _ in range(len(self.session.scripts))]
+        )
+        for i in range(len(self.session.scripts)):
+            self.script_tabs.set_title(i, self.session.scripts[i].title)
+            with self.script_tabs.children[i]:
+                display(self._flow_canvases[i].canvas)
 
         module_options = sorted(self._nodes_dict.keys())
         self.modules_dropdown = widgets.Dropdown(
@@ -240,7 +246,7 @@ class GUI(HasSession):
                     ]
                 ),
                 widgets.HBox(
-                    [widgets.VBox([self.node_selector]), self.out_canvas, self.out_plot]
+                    [widgets.VBox([self.node_selector]), self.script_tabs, self.out_plot]
                 ),
                 self.out_log,
                 self.out_status,

--- a/ryven/ironflow/Gui.py
+++ b/ryven/ironflow/Gui.py
@@ -201,7 +201,7 @@ class GUI(HasSession):
         self.btn_load = widgets.Button(tooltip="Load", icon="upload", layout=button_layout)
         self.btn_save = widgets.Button(tooltip="Save", icon="download", layout=button_layout)
         self.btn_delete_node = widgets.Button(tooltip="Delete Node", icon="trash", layout=button_layout)
-        self.btn_new_script = widgets.Button(tooltip="New script", icon="file-plus", layout=button_layout)
+        self.btn_new_script = widgets.Button(tooltip="New script", icon="file", layout=button_layout)
 
         self.alg_mode_dropdown = widgets.Dropdown(
             options=alg_modes,
@@ -226,6 +226,7 @@ class GUI(HasSession):
         self.btn_load.on_click(self.on_file_load)
         self.btn_save.on_click(self.on_file_save)
         self.btn_delete_node.on_click(self.on_delete_node)
+        self.btn_new_script.on_click(self.on_new_script)
 
         # if self.canvas_widget._node_widget is None:
         #     self.canvas_widget._node_widget = widgets.Box()
@@ -268,6 +269,9 @@ class GUI(HasSession):
 
     def on_alg_mode_change(self, change: Dict) -> None:
         self.canvas_widget.script.flow.set_algorithm_mode(self.alg_mode_dropdown.value)
+
+    def on_new_script(self, change: Dict) -> None:
+        self.create_script(f"{len(self.session.scripts)}")
 
     @property
     def new_node_class(self):

--- a/ryven/ironflow/Gui.py
+++ b/ryven/ironflow/Gui.py
@@ -43,8 +43,7 @@ debug_view = widgets.Output(layout={"border": "1px solid black"})
 class GUI(HasSession):
     def __init__(self, script_title: str = "test", session: Optional[rc.Session] = None):  # , onto_dic=onto_dic):
         super().__init__(session=rc.Session() if session is None else session)
-        self._script_title = script_title
-        self.session.create_script(title=self.script_title)
+        self.session.create_script(title=script_title)
 
         for package in packages:
             self.session.register_nodes(
@@ -103,10 +102,6 @@ class GUI(HasSession):
             self.session.unregister_node(node_class)
         self.session.register_node(node_class)
         self._register_node(node_class, node_module='user')
-
-    @property
-    def script_title(self) -> str:
-        return self._script_title
 
     def save(self, file_path: str) -> None:
         data = self.serialize()
@@ -237,10 +232,10 @@ class GUI(HasSession):
     # Type hinting for unused `change` argument in callbacks taken from ipywidgets docs:
     # https://ipywidgets.readthedocs.io/en/latest/examples/Widget%20Events.html#Traitlet-events
     def on_file_save(self, change: Dict) -> None:
-        self.save(f"{self.script_title}.json")
+        self.save(f"{self.script.title}.json")
 
     def on_file_load(self, change: Dict) -> None:
-        self.load(f"{self.script_title}.json")
+        self.load(f"{self.script.title}.json")
 
     def on_delete_node(self, change: Dict) -> None:
         self.canvas_widget.delete_selected()

--- a/ryven/ironflow/Gui.py
+++ b/ryven/ironflow/Gui.py
@@ -317,12 +317,18 @@ class GUI(HasSession):
         ]
 
     def on_confirm_script_name(self, change: Dict) -> None:
+        old_name = self.script.title
         new_name = self.script_name_box.value
-        self.script.title = new_name
-        self.script_tabs.set_title(
-            self.script_tabs.get_state(key='selected_index')['selected_index'],
-            new_name
-        )
+        rename_success = self.session.rename_script(self.script, new_name)
+        if rename_success:
+            self.script_tabs.set_title(
+                self.script_tabs.get_state(key='selected_index')['selected_index'],
+                new_name
+            )
+        else:
+            self.session.rename_script(old_name)
+            with self.out_log:
+                print(f"INVALID NAME: Failed to rename {old_name} to {new_name}.")
         self._empty_script_rename_panel()
 
     def on_cancel_script_name(self, change: Dict) -> None:

--- a/ryven/ironflow/Gui.py
+++ b/ryven/ironflow/Gui.py
@@ -6,7 +6,7 @@ import ryvencore as rc
 from IPython.display import display
 from ryven.main.utils import import_nodes_package, NodesPackage
 
-from .CanvasObject import CanvasObject
+from .FlowCanvas import FlowCanvas
 from .has_session import HasSession
 
 import ryven.NENV as NENV
@@ -55,7 +55,7 @@ class GUI(HasSession):
         for n in self.session.nodes:
             self._register_node(n)
 
-        self.canvas_widget = CanvasObject(gui=self)
+        self.canvas_widget = FlowCanvas(gui=self)
         # self.onto_dic = onto_dic
 
         self.out_log = widgets.Output(layout={"border": "1px solid black"})
@@ -134,7 +134,7 @@ class GUI(HasSession):
         self.session.delete_script(self.script)
         self.session.load(data)
 
-        self.canvas_widget = CanvasObject(gui=self)
+        self.canvas_widget = FlowCanvas(gui=self)
         self.canvas_widget.canvas_restart()
         all_data = data["scripts"][i_script]["flow"]["nodes"]
         for i, node in enumerate(self.flow.nodes):

--- a/ryven/ironflow/Gui.py
+++ b/ryven/ironflow/Gui.py
@@ -271,7 +271,11 @@ class GUI(HasSession):
         self.canvas_widget.script.flow.set_algorithm_mode(self.alg_mode_dropdown.value)
 
     def on_new_script(self, change: Dict) -> None:
-        self.create_script(f"{len(self.session.scripts)}")
+        self.create_script(f"script_{len(self.session.scripts)}")
+        self.script_tabs.children += (widgets.Output(layout={"border": "1px solid black"}),)
+        self.script_tabs.set_title(len(self.script_tabs.children) - 1, self.session.scripts[-1].title)
+        with self.script_tabs.children[-1]:
+            display(self._flow_canvases[-1].canvas)
 
     @property
     def new_node_class(self):

--- a/ryven/ironflow/Gui.py
+++ b/ryven/ironflow/Gui.py
@@ -203,7 +203,10 @@ class GUI(HasSession):
         self.btn_load = widgets.Button(tooltip="Load", icon="upload", layout=button_layout)
         self.btn_save = widgets.Button(tooltip="Save", icon="download", layout=button_layout)
         self.btn_delete_node = widgets.Button(tooltip="Delete Node", icon="trash", layout=button_layout)
-        self.btn_new_script = widgets.Button(tooltip="New script", icon="file", layout=button_layout)
+        self.btn_rename_script = widgets.Button(tooltip="Rename script", icon="file", layout=button_layout)
+        # TODO: Use file-pen once this is available
+        self.btn_delete_script = widgets.Button(tooltip="Delete script", icon="square-minus", layout=button_layout)
+        # TODO: Use file-circle-minus once this is available
 
         self.alg_mode_dropdown = widgets.Dropdown(
             options=alg_modes,
@@ -242,6 +245,8 @@ class GUI(HasSession):
                         self.btn_save,
                         self.btn_load,
                         self.btn_delete_node,
+                        self.btn_rename_script,
+                        self.btn_delete_script,
                     ]
                 ),
                 widgets.HBox(

--- a/ryven/ironflow/Gui.py
+++ b/ryven/ironflow/Gui.py
@@ -187,6 +187,7 @@ class GUI(HasSession):
             self.script_tabs.set_title(i, self.session.scripts[i].title)
             with self.script_tabs.children[i]:
                 display(self._flow_canvases[i].canvas)
+        self._add_new_script_tab()
 
         module_options = sorted(self._nodes_dict.keys())
         self.modules_dropdown = widgets.Dropdown(
@@ -227,7 +228,6 @@ class GUI(HasSession):
         self.btn_load.on_click(self.on_file_load)
         self.btn_save.on_click(self.on_file_save)
         self.btn_delete_node.on_click(self.on_delete_node)
-        self.btn_new_script.on_click(self.on_new_script)
 
         # if self.canvas_widget._node_widget is None:
         #     self.canvas_widget._node_widget = widgets.Box()
@@ -241,7 +241,6 @@ class GUI(HasSession):
                         self.btn_save,
                         self.btn_load,
                         self.btn_delete_node,
-                        self.btn_new_script
                     ]
                 ),
                 widgets.HBox(
@@ -253,6 +252,10 @@ class GUI(HasSession):
                 # self.canvas_widget._node_widget
             ]
         )
+
+    def _add_new_script_tab(self):
+        self.script_tabs.children += (widgets.Output(layout={"border": "1px solid black"}),)
+        self.script_tabs.set_title(len(self.session.scripts), "+")
 
     # Type hinting for unused `change` argument in callbacks taken from ipywidgets docs:
     # https://ipywidgets.readthedocs.io/en/latest/examples/Widget%20Events.html#Traitlet-events
@@ -272,16 +275,21 @@ class GUI(HasSession):
         self.canvas_widget.script.flow.set_algorithm_mode(self.alg_mode_dropdown.value)
 
     def on_tab_select(self, change: Dict):
-        self.activate_script(self.script_tabs.get_state(key='selected_index')['selected_index'])
+        # self.activate_script(self.script_tabs.get_state(key='selected_index')['selected_index'])
+        selected_index = self.script_tabs.get_state(key='selected_index')['selected_index']
+        if selected_index == self.n_scripts:
+            self.on_new_script({})
+        else:
+            self.activate_script(selected_index)
 
     def on_new_script(self, change: Dict) -> None:
         self.create_script(f"script_{len(self.session.scripts)}")
-        self.script_tabs.children += (widgets.Output(layout={"border": "1px solid black"}),)
-        last_index = len(self.script_tabs.children) - 1
-        self.script_tabs.set_title(last_index, self.session.scripts[-1].title)
+        last_script_index = self.n_scripts - 1
+        self.script_tabs.set_title(last_script_index, self.session.scripts[-1].title)
         with self.script_tabs.children[-1]:
             display(self._flow_canvases[-1].canvas)
-        self.script_tabs.selected_index = last_index
+        self.script_tabs.selected_index = last_script_index
+        self._add_new_script_tab()
 
     @property
     def new_node_class(self):

--- a/ryven/ironflow/Gui.py
+++ b/ryven/ironflow/Gui.py
@@ -199,6 +199,7 @@ class GUI(HasSession):
         )
 
         button_layout = widgets.Layout(width="50px")
+        # Icon source: https://fontawesome.com
         self.btn_load = widgets.Button(tooltip="Load", icon="upload", layout=button_layout)
         self.btn_save = widgets.Button(tooltip="Save", icon="download", layout=button_layout)
         self.btn_delete_node = widgets.Button(tooltip="Delete Node", icon="trash", layout=button_layout)

--- a/ryven/ironflow/Gui.py
+++ b/ryven/ironflow/Gui.py
@@ -44,7 +44,7 @@ class GUI(HasSession):
     def __init__(self, script_title: str = "test", session: Optional[rc.Session] = None):  # , onto_dic=onto_dic):
         super().__init__(session=rc.Session() if session is None else session)
         self._flow_canvases = []
-        self.create_script(title=script_title)
+        self.create_script(title="script_0")
 
         for package in packages:
             self.session.register_nodes(

--- a/ryven/ironflow/NodeWidget.py
+++ b/ryven/ironflow/NodeWidget.py
@@ -6,7 +6,7 @@ from .layouts import Layout, NodeLayout, PortLayout, DataPortLayout, ExecPortLay
 
 from typing import TYPE_CHECKING, Optional, Union, List, Any
 if TYPE_CHECKING:
-    from .CanvasObject import CanvasObject
+    from .FlowCanvas import FlowCanvas
     from ipycanvas import Canvas
     from ryven.NENV import Node, NodeInputBP, NodeOutputBP
     Number = Union[int, float]
@@ -29,7 +29,7 @@ class BaseCanvasWidget:
             self,
             x: Number,
             y: Number,
-            parent: Union[CanvasObject, BaseCanvasWidget],
+            parent: Union[FlowCanvas, BaseCanvasWidget],
             layout: Layout,
             selected: bool = False
     ):
@@ -126,7 +126,7 @@ class PortWidget(BaseCanvasWidget):
         self,
         x: Number,
         y: Number,
-        parent: Union[CanvasObject, BaseCanvasWidget],
+        parent: Union[FlowCanvas, BaseCanvasWidget],
         layout: PortLayout,
         radius: Number = 10,
         port: Optional[NodePort] = None,
@@ -162,7 +162,7 @@ class NodeWidget(BaseCanvasWidget):
             self,
             x: Number,
             y: Number,
-            parent: Union[CanvasObject, BaseCanvasWidget],
+            parent: Union[FlowCanvas, BaseCanvasWidget],
             layout: NodeLayout,
             node: Node,
             selected: bool = False,
@@ -276,7 +276,7 @@ class ButtonNodeWidget(NodeWidget):
             self,
             x: Number,
             y: Number,
-            parent: Union[CanvasObject, BaseCanvasWidget],
+            parent: Union[FlowCanvas, BaseCanvasWidget],
             layout: ButtonLayout,
             node: Node,
             selected: bool = False,

--- a/ryven/ironflow/__init__.py
+++ b/ryven/ironflow/__init__.py
@@ -1,4 +1,4 @@
-__all__ = ['Gui', 'CanvasObject', 'NodeWidget', 'NodeWidgets']
+__all__ = ['Gui', 'FlowCanvas.py', 'NodeWidget', 'NodeWidgets']
 
 from .Gui import GUI
 from ryven.NENV import Node, NodeInputBP, NodeOutputBP, dtypes

--- a/ryven/ironflow/has_session.py
+++ b/ryven/ironflow/has_session.py
@@ -19,15 +19,18 @@ __date__ = "May 26, 2022"
 
 from abc import ABC
 from ryvencore import Session, Script, Flow
+import warnings
+from typing import Dict
 
 
 class HasSession(ABC):
     """
-    A convenience parent for classes that interact with a single-script Ryven session.
+    Methods and attributes to make it more convenient to interact with the underlying model, i.e. a Ryven session.
     """
 
     def __init__(self, session: Session):
         self._session = session
+        self._active_script_index = 0
 
     @property
     def session(self) -> Session:
@@ -35,8 +38,24 @@ class HasSession(ABC):
 
     @property
     def script(self) -> Script:
-        return self.session.scripts[0]
+        return self.session.scripts[self._active_script_index]
 
     @property
     def flow(self) -> Flow:
         return self.script.flow
+
+    def activate_script(self, i: int) -> None:
+        if i > len(self.session.scripts):
+            warnings.warn(
+                f"Attempted to activate script {i}, but there are only {len(self.session.scripts)} available."
+            )
+        else:
+            self._active_script_index = i
+
+    def create_script(
+            self,
+            title: str = None,
+            create_default_logs: bool = True,
+            data: Dict = None):
+        self.session.create_script(title=title, create_default_logs=create_default_logs, data=data)
+        self.activate_script(-1)

--- a/ryven/ironflow/has_session.py
+++ b/ryven/ironflow/has_session.py
@@ -59,3 +59,7 @@ class HasSession(ABC):
             data: Dict = None):
         self.session.create_script(title=title, create_default_logs=create_default_logs, data=data)
         self.activate_script(-1)
+
+    @property
+    def n_scripts(self):
+        return len(self.session.scripts)

--- a/tests/unit/test_CanvasObject.py
+++ b/tests/unit/test_CanvasObject.py
@@ -10,7 +10,7 @@ import os
 class TestCanvasObect(TestCase):
 
     def setUp(self):
-        self.gui = GUI()
+        self.gui = GUI('gui')
         self.canvas = self.gui.canvas_widget
 
     @classmethod

--- a/tests/unit/test_CanvasObject.py
+++ b/tests/unit/test_CanvasObject.py
@@ -21,7 +21,7 @@ class TestCanvasObect(TestCase):
             pass
 
     def test_remove_node_from_flow(self):
-        flow = self.canvas.script.flow
+        flow = self.canvas.flow
         val_node = self.gui._nodes_dict['nodes']['val']
         results_node = self.gui._nodes_dict['nodes']['result']
 

--- a/tests/unit/test_Gui.py
+++ b/tests/unit/test_Gui.py
@@ -98,7 +98,7 @@ class TestGUI(TestCase):
         self.assertEqual(gui.flow.nodes[1].outputs[0].val, -40, msg="New node instances should reflect updated class.")
 
         gui.on_file_save(None)
-        new_gui = GUI(script_title=gui.script_title)
+        new_gui = GUI(script_title=gui.script.title)
         new_gui.draw()  # TODO: Change the gui to allow renderless loading
         with self.assertRaises(Exception):
             new_gui.on_file_load(None)
@@ -113,7 +113,7 @@ class TestGUI(TestCase):
             msg="The updated class was registered, so expect the same behaviour from both nodes now."
         )
 
-        os.remove(f"{gui.script_title}.json")
+        os.remove(f"{gui.script.title}.json")
 
     def test_repeated_instantiation(self):
         gui = GUI(script_title='foo')

--- a/tests/unit/test_Gui.py
+++ b/tests/unit/test_Gui.py
@@ -16,13 +16,13 @@ class TestGUI(TestCase):
             pass
 
     def test_multiple_scripts(self):
-        gui = GUI(script_title='foo')
+        gui = GUI('foo')
         gui.canvas_widget.add_node(0, 0, gui._nodes_dict['nodes']['val'])
         gui.create_script(title='bar')
         gui.canvas_widget.add_node(1, 1, gui._nodes_dict['nodes']['result'])
         fname = 'my_session.json'
         gui.save(fname)
-        new_gui = GUI(script_title='something_random')
+        new_gui = GUI('something_random')
         new_gui.draw()  # TODO: This is still just a hack to get new_gui.out_canvas to exist...
         new_gui.load(fname)
 
@@ -41,9 +41,11 @@ class TestGUI(TestCase):
                 msg=f"Expected saved and loaded nodes to match, but got {saved_node} and {loaded_node}"
             )
 
+        os.remove(fname)
+
     def test_saving_and_loading(self):
         title = 'foo'
-        gui = GUI(script_title=title)
+        gui = GUI(title)
         canvas = gui.canvas_widget
         flow = gui._session.scripts[0].flow
 
@@ -57,7 +59,7 @@ class TestGUI(TestCase):
 
         gui.on_file_save(None)
 
-        new_gui = GUI(script_title=title)
+        new_gui = GUI(title)
         self.assertNotEqual(new_gui._session, gui._session, msg="New instance expected to get its own session")
         # Maybe this will change in the future, but it's baked in the assumptions for now so let's make sure to test it
 
@@ -80,7 +82,7 @@ class TestGUI(TestCase):
 
     def test_user_node_registration(self):
         """TODO: This only tests the backend graph, need to test front end as well"""
-        gui = GUI(script_title='foo')
+        gui = GUI('foo')
 
         class MyNode(Node):
             title = "MyUserNode"
@@ -124,7 +126,7 @@ class TestGUI(TestCase):
         self.assertEqual(gui.flow.nodes[1].outputs[0].val, -40, msg="New node instances should reflect updated class.")
 
         gui.on_file_save(None)
-        new_gui = GUI(script_title=gui.script.title)
+        new_gui = GUI(gui.session_title)
         new_gui.draw()  # TODO: Change the gui to allow renderless loading
         with self.assertRaises(Exception):
             new_gui.on_file_load(None)
@@ -139,12 +141,12 @@ class TestGUI(TestCase):
             msg="The updated class was registered, so expect the same behaviour from both nodes now."
         )
 
-        os.remove(f"{gui.script.title}.json")
+        os.remove(f"{gui.session_title}.json")
 
     def test_repeated_instantiation(self):
-        gui = GUI(script_title='foo')
+        gui = GUI('foo')
         id0 = str(gui.session.nodes[0].identifier)
-        gui = GUI(script_title='foo')
+        gui = GUI(gui.session_title)
         self.assertEqual(
             gui.session.nodes[0].identifier,
             id0,

--- a/tests/unit/test_Gui.py
+++ b/tests/unit/test_Gui.py
@@ -15,6 +15,32 @@ class TestGUI(TestCase):
         except FileNotFoundError:
             pass
 
+    def test_multiple_scripts(self):
+        gui = GUI(script_title='foo')
+        gui.canvas_widget.add_node(0, 0, gui._nodes_dict['nodes']['val'])
+        gui.create_script(title='bar')
+        gui.canvas_widget.add_node(1, 1, gui._nodes_dict['nodes']['result'])
+        fname = 'my_session.json'
+        gui.save(fname)
+        new_gui = GUI(script_title='something_random')
+        new_gui.draw()  # TODO: This is still just a hack to get new_gui.out_canvas to exist...
+        new_gui.load(fname)
+
+        self.assertEqual(
+            0,
+            new_gui._active_script_index,
+            msg=f"Expected loaded sessions to start on the zeroth script, but got script {new_gui._active_script_index}"
+        )
+
+        for i in range(len(gui.session.scripts)):
+            saved_node = gui.session.scripts[i].flow.nodes[0].title
+            loaded_node = new_gui.session.scripts[i].flow.nodes[0].title
+            self.assertEqual(
+                saved_node,
+                loaded_node,
+                msg=f"Expected saved and loaded nodes to match, but got {saved_node} and {loaded_node}"
+            )
+
     def test_saving_and_loading(self):
         title = 'foo'
         gui = GUI(script_title=title)


### PR DESCRIPTION
Use tabs to have a single GUI session control multiple scripts.

Working in principle, but I'm having trouble getting the tabs to observe the new tab button, so right now the GUI always needs to be fully re-`drawn()`n.

TODO:
- ~Observe new script click and update tabs~
- ~Change GUI signature so it takes a session name and automatically creates the 0th script~
- ~Build infrastructure for re-naming individual scripts~
- ~Saving and loading of entire session (Ryven itself saves entire sessions at a time, so copy that behaviour)~