### PR TITLE
Automatically replot

### DIFF
--- a/ryven/ironflow/Gui.py
+++ b/ryven/ironflow/Gui.py
@@ -323,7 +323,10 @@ class GUI:
         self.node_selector.options = sorted(self._nodes_dict[self.modules_dropdown.value].keys())
 
     def change_alg_mode_dropdown(self, change: Dict) -> None:
-        self.flow_canvas_widget.script.flow.set_algorithm_mode(self.alg_mode_dropdown.value)
+        # Current behaviour: Updates the flow mode for all scripts
+        # TODO: Change only for the active script, and update the dropdown on tab (script) switching
+        for script in self.session.scripts:
+            script.flow.set_algorithm_mode(self.alg_mode_dropdown.value)
 
     def change_script_tabs(self, change: Dict):
         if change['name'] == 'selected_index' and change['new'] is not None:

--- a/ryven/nodes/pyiron/atomistics_nodes.py
+++ b/ryven/nodes/pyiron/atomistics_nodes.py
@@ -264,7 +264,7 @@ class Plot3d_Node(DualNodeBase):
 
     def update_event(self, inp=-1):
         self._val_is_updated = True
-        if self.active and inp == 0:
+        if self.active:
             self.val = self.input(1).plot3d()
         elif not self.active:
             self.val = self.input(0)

--- a/ryven/nodes/pyiron/atomistics_nodes.py
+++ b/ryven/nodes/pyiron/atomistics_nodes.py
@@ -289,10 +289,12 @@ class Matplot_Node(DualNodeBase):
     def update_event(self, inp=-1):
         self._val_is_updated = True
         if self.active:
+            plt.ioff()
             fig = plt.figure()
             plt.clf()
             plt.plot(self.input(1), self.input(2))
             self.val = fig
+            plt.ion()
         elif not self.active:
             self.val = self.input(0)
 

--- a/ryven/nodes/pyiron/atomistics_nodes.py
+++ b/ryven/nodes/pyiron/atomistics_nodes.py
@@ -288,7 +288,7 @@ class Matplot_Node(DualNodeBase):
 
     def update_event(self, inp=-1):
         self._val_is_updated = True
-        if self.active and inp == 0:
+        if self.active:
             fig = plt.figure()
             plt.clf()
             plt.plot(self.input(1), self.input(2))
@@ -393,7 +393,7 @@ class Print_Node(DualNodeBase):
         super().__init__(params, active=True)
 
     def update_event(self, inp=-1):
-        if self.active and inp == 0:
+        if self.active:
             self.val = self.input(1)
         elif not self.active:
             self.val = self.input(0)


### PR DESCRIPTION
Print, matplotlib, and plot3d nodes now all automatically update when their input updates. (For print you still need to have some sort of interaction with the main graph canvas, but as soon as it updates itself you'll get the updated value, so literally clicking anywhere does the trick.)