### PR TITLE
Refactor canvas widgets

### DIFF
--- a/ryven/ironflow/canvas_widgets.py
+++ b/ryven/ironflow/canvas_widgets.py
@@ -386,14 +386,15 @@ class DisplayableNodeWidget(NodeWidget):
         self.add_widget(self.display_button)
 
     def display_node(self):
-        if self.node.displayed and self.node.representation_updated:
-            self.parent.gui.out_plot.clear_output()
-            with self.parent.gui.out_plot:
-                for rep in self.node.representations:
-                    display(rep)
-            self.node.representation_updated = False
+        """Send the node's representation to a separate GUI window"""
+        self.parent.gui.out_plot.clear_output()
+        with self.parent.gui.out_plot:
+            for rep in self.node.representations:
+                display(rep)
+        self.node.representation_updated = False
 
     def draw(self):
         super().draw()
-        self.display_node()
+        if self.node.displayed and self.node.representation_updated:
+            self.display_node()
 

--- a/ryven/ironflow/canvas_widgets.py
+++ b/ryven/ironflow/canvas_widgets.py
@@ -214,11 +214,6 @@ class NodeWidget(CanvasWidget):
         x = self.x + (self.width * 0.3)
         y = (self.y + (self.height * 0.65),)
         self.canvas.fill_text(str(val), x, y)
-        if val_is_updated:
-            if ("matplotlib" in str(type(val))) or ("NGLWidget" in str(type(val))):
-                self.parent.gui.out_plot.clear_output()
-                with self.parent.gui.out_plot:
-                    display(val)
 
     def _add_ports(
             self,

--- a/ryven/ironflow/canvas_widgets.py
+++ b/ryven/ironflow/canvas_widgets.py
@@ -62,7 +62,7 @@ class CanvasWidget(ABC):
         pass
 
     def on_double_click(self) -> Optional[CanvasWidget]:
-        pass
+        return self
 
     def _init_after_parent_assignment(self):
         pass
@@ -253,6 +253,10 @@ class NodeWidget(CanvasWidget):
                 self.gui.out_status.clear_output()
                 self.deselect()
                 return None
+
+    def on_double_click(self) -> Optional[CanvasWidget]:
+        self.delete()
+        return None
 
     def draw_title(self, title: str) -> None:
         self.canvas.fill_style = self.node.color
@@ -467,8 +471,9 @@ class DisplayableNodeWidget(NodeWidget):
 
     def clear_display(self):
         self.node.displayed = False
-        self.gui.out_plot.clear_output()
-        self.gui.displayed_node = None
+        if self.gui.displayed_node == self:
+            self.gui.out_plot.clear_output()
+            self.gui.displayed_node = None
 
     def draw_display(self):
         """Send the node's representation to a separate GUI window"""
@@ -482,4 +487,8 @@ class DisplayableNodeWidget(NodeWidget):
         super().draw()
         if self.node.displayed and self.node.representation_updated:
             self.draw_display()
+
+    def delete(self) -> None:
+        self.clear_display()
+        return super().delete()
 

--- a/ryven/ironflow/canvas_widgets.py
+++ b/ryven/ironflow/canvas_widgets.py
@@ -330,6 +330,14 @@ class NodeWidget(CanvasWidget):
         for o in self.objects_to_draw:
             o.draw()
 
+    def delete(self) -> None:
+        for c in self.flow.connections[::-1]:  # Reverse to make sure we traverse whole thing even if we delete
+            # TODO: Can we be more efficient than looping over all nodes?
+            if (c.inp.node == self.node) or (c.out.node == self.node):
+                self.flow.remove_connection(c)
+        self.flow.remove_node(self.node)
+        self.parent.objects_to_draw.remove(self)
+
 
 class ButtonNodeWidget(NodeWidget):
     def __init__(

--- a/ryven/ironflow/canvas_widgets.py
+++ b/ryven/ironflow/canvas_widgets.py
@@ -372,19 +372,19 @@ class ButtonWidget(CanvasWidget, ABC):
     def on_click(self, last_selected_object: Optional[CanvasWidget]) -> Optional[CanvasWidget]:
         if self.pressed:
             self.pressed = False
-            self.on_unpressed()
+            self.unpress()
         else:
             self.pressed = True
-            self.on_pressed()
+            self.press()
         self.deselect()
         return last_selected_object
 
     @abstractmethod
-    def on_pressed(self):
+    def press(self):
         pass
 
     @abstractmethod
-    def on_unpressed(self):
+    def unpress(self):
         pass
 
     def draw_shape(self) -> None:
@@ -420,18 +420,13 @@ class DisplayButtonWidget(ButtonWidget):
     ):
         super().__init__(x, y, parent, layout, selected, title=title)
 
-    def on_pressed(self):
-        if self.parent.parent.gui.displayed_node is not None:
-            self.parent.parent.gui.displayed_node.node.displayed = False
-            self.parent.parent.gui.displayed_node.display_button.pressed = False
-        self.parent.node.displayed = True
-        self.parent.node.representation_updated = True
-        self.parent.parent.gui.displayed_node = self.parent
+    def press(self):
+        self.pressed = True
+        self.parent.set_display()
 
-    def on_unpressed(self):
-        self.parent.node.displayed = False
-        self.parent.parent.gui.out_plot.clear_output()
-        self.parent.parent.gui.displayed_node = None
+    def unpress(self):
+        self.pressed = False
+        self.parent.clear_display()
 
 
 class DisplayableNodeWidget(NodeWidget):
@@ -455,6 +450,18 @@ class DisplayableNodeWidget(NodeWidget):
 
         self.display_button = DisplayButtonWidget(80, 50, parent=self, layout=ButtonLayout())
         self.add_widget(self.display_button)
+
+    def set_display(self):
+        if self.gui.displayed_node is not None:
+            self.gui.displayed_node.display_button.unpress()
+        self.node.displayed = True
+        self.node.representation_updated = True
+        self.gui.displayed_node = self
+
+    def clear_display(self):
+        self.node.displayed = False
+        self.gui.out_plot.clear_output()
+        self.gui.displayed_node = None
 
     def draw_display(self):
         """Send the node's representation to a separate GUI window"""

--- a/ryven/ironflow/canvas_widgets.py
+++ b/ryven/ironflow/canvas_widgets.py
@@ -8,7 +8,6 @@ import numpy as np
 from IPython.display import display
 from .layouts import Layout, NodeLayout, PortLayout, DataPortLayout, ExecPortLayout, ButtonLayout
 from ryven.ironflow.node_widgets import NodeWidgets
-import ipywidgets as widgets
 from abc import ABC, abstractmethod
 
 from typing import TYPE_CHECKING, Optional, Union, List, Any

--- a/ryven/ironflow/canvas_widgets.py
+++ b/ryven/ironflow/canvas_widgets.py
@@ -8,6 +8,7 @@ import numpy as np
 from IPython.display import display
 from .layouts import Layout, NodeLayout, PortLayout, DataPortLayout, ExecPortLayout, ButtonLayout
 import ipywidgets as widgets
+from abc import ABC
 
 from typing import TYPE_CHECKING, Optional, Union, List, Any
 if TYPE_CHECKING:
@@ -29,12 +30,16 @@ __status__ = "production"
 __date__ = "May 10, 2022"
 
 
-class BaseCanvasWidget:
+class CanvasWidget(ABC):
+    """
+    Parent class for all "widgets" that exist inside the scope of the flow canvas.
+    """
+
     def __init__(
             self,
             x: Number,
             y: Number,
-            parent: Union[FlowCanvas, BaseCanvasWidget],
+            parent: Union[FlowCanvas, CanvasWidget],
             layout: Layout,
             selected: bool = False
     ):
@@ -72,7 +77,7 @@ class BaseCanvasWidget:
     def canvas(self) -> Canvas:
         return self.parent.canvas
 
-    def add_widget(self, widget: BaseCanvasWidget) -> None:
+    def add_widget(self, widget: CanvasWidget) -> None:
         self.objects_to_draw.append(widget)
 
     def set_x_y(self, x_in: Number, y_in: Number) -> None:
@@ -102,7 +107,7 @@ class BaseCanvasWidget:
         y_coord = self.y  # - (self.height * 0.5)
         return x_coord < x_in < (x_coord + self.width) and y_coord < y_in < (y_coord + self.height)
 
-    def get_element_at_xy(self, x_in: Number, y_in: Number) -> Union[BaseCanvasWidget, None]:
+    def get_element_at_xy(self, x_in: Number, y_in: Number) -> Union[CanvasWidget, None]:
         if self._is_at_xy(x_in, y_in):
             for o in self.objects_to_draw:
                 if o.is_here(x_in, y_in):
@@ -126,12 +131,12 @@ class BaseCanvasWidget:
         return self._selected
 
 
-class PortWidget(BaseCanvasWidget):
+class PortWidget(CanvasWidget):
     def __init__(
         self,
         x: Number,
         y: Number,
-        parent: Union[FlowCanvas, BaseCanvasWidget],
+        parent: Union[FlowCanvas, CanvasWidget],
         layout: PortLayout,
         radius: Number = 10,
         port: Optional[NodePort] = None,
@@ -162,12 +167,12 @@ class PortWidget(BaseCanvasWidget):
         return x_coord < x_in < (x_coord + 2 * self.radius) and y_coord < y_in < (y_coord + 2 * self.radius)
 
 
-class NodeWidget(BaseCanvasWidget):
+class NodeWidget(CanvasWidget):
     def __init__(
             self,
             x: Number,
             y: Number,
-            parent: Union[FlowCanvas, BaseCanvasWidget],
+            parent: Union[FlowCanvas, CanvasWidget],
             layout: NodeLayout,
             node: Node,
             selected: bool = False,
@@ -281,7 +286,7 @@ class ButtonNodeWidget(NodeWidget):
             self,
             x: Number,
             y: Number,
-            parent: Union[FlowCanvas, BaseCanvasWidget],
+            parent: Union[FlowCanvas, CanvasWidget],
             layout: NodeLayout,
             node: Node,
             selected: bool = False,
@@ -290,7 +295,7 @@ class ButtonNodeWidget(NodeWidget):
         super().__init__(x, y, parent, layout, node, selected, port_radius)
 
         layout = ButtonLayout()
-        s = BaseCanvasWidget(50, 50, parent=self, layout=layout)
+        s = CanvasWidget(50, 50, parent=self, layout=layout)
         s.handle_select = self.handle_button_select
         self.add_widget(s)
 
@@ -299,7 +304,7 @@ class ButtonNodeWidget(NodeWidget):
         button.deselect()
 
 
-class ButtonWidget(BaseCanvasWidget):
+class ButtonWidget(CanvasWidget):
     def __init__(
             self,
             x: Number,
@@ -374,7 +379,7 @@ class DisplayableNodeWidget(NodeWidget):
             self,
             x: Number,
             y: Number,
-            parent: Union[FlowCanvas, BaseCanvasWidget],
+            parent: Union[FlowCanvas, CanvasWidget],
             layout: NodeLayout,
             node: Node,
             selected: bool = False,

--- a/ryven/ironflow/canvas_widgets.py
+++ b/ryven/ironflow/canvas_widgets.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import numpy as np
 from IPython.display import display
 from .layouts import Layout, NodeLayout, PortLayout, DataPortLayout, ExecPortLayout, ButtonLayout
-from ryven.ironflow.node_widgets import NodeWidgets
 from abc import ABC, abstractmethod
 
 from typing import TYPE_CHECKING, Optional, Union, List, Any
@@ -242,12 +241,8 @@ class NodeWidget(CanvasWidget):
                 last_selected_object.deselect()
             self.select()
             try:
-                node_widget = NodeWidgets(self.node, self.gui).draw()
-                with self.gui.out_status:
-                    self.gui.out_status.clear_output()
-                    display(node_widget)
-                    # PyCharm nit is invalid, display takes *args is why it claims to want a tuple
-                    return self
+                self.gui.node_interface.draw_for_node(self.node)
+                return self
             except Exception as e:
                 self.gui._print(f"Failed to handle selection of {self} with exception {e}")
                 self.gui.out_status.clear_output()
@@ -341,6 +336,8 @@ class NodeWidget(CanvasWidget):
                 self.flow.remove_connection(c)
         self.flow.remove_node(self.node)
         self.parent.objects_to_draw.remove(self)
+        if self.gui.node_interface.node == self.node:
+            self.gui.node_interface.draw_for_node(None)
 
 
 class ButtonNodeWidget(NodeWidget):

--- a/ryven/ironflow/canvas_widgets.py
+++ b/ryven/ironflow/canvas_widgets.py
@@ -374,6 +374,7 @@ class ButtonWidget(CanvasWidget, ABC):
             self.pressed = False
             self.on_unpressed()
         else:
+            self.pressed = True
             self.on_pressed()
         self.deselect()
         return last_selected_object
@@ -423,7 +424,6 @@ class DisplayButtonWidget(ButtonWidget):
         if self.parent.parent.gui.displayed_node is not None:
             self.parent.parent.gui.displayed_node.node.displayed = False
             self.parent.parent.gui.displayed_node.display_button.pressed = False
-        self.pressed = True
         self.parent.node.displayed = True
         self.parent.node.representation_updated = True
         self.parent.parent.gui.displayed_node = self.parent

--- a/ryven/ironflow/canvas_widgets.py
+++ b/ryven/ironflow/canvas_widgets.py
@@ -456,7 +456,7 @@ class DisplayableNodeWidget(NodeWidget):
         self.display_button = DisplayButtonWidget(80, 50, parent=self, layout=ButtonLayout())
         self.add_widget(self.display_button)
 
-    def display_node(self):
+    def draw_display(self):
         """Send the node's representation to a separate GUI window"""
         self.parent.gui.out_plot.clear_output()
         with self.parent.gui.out_plot:
@@ -467,5 +467,5 @@ class DisplayableNodeWidget(NodeWidget):
     def draw(self):
         super().draw()
         if self.node.displayed and self.node.representation_updated:
-            self.display_node()
+            self.draw_display()
 

--- a/ryven/ironflow/canvas_widgets.py
+++ b/ryven/ironflow/canvas_widgets.py
@@ -8,7 +8,7 @@ import numpy as np
 from IPython.display import display
 from .layouts import Layout, NodeLayout, PortLayout, DataPortLayout, ExecPortLayout, ButtonLayout
 import ipywidgets as widgets
-from abc import ABC
+from abc import ABC, abstractmethod
 
 from typing import TYPE_CHECKING, Optional, Union, List, Any
 if TYPE_CHECKING:
@@ -53,6 +53,12 @@ class CanvasWidget(ABC):
         self.objects_to_draw = []
 
         self._height = self.layout.height
+
+    def on_click(self):
+        pass
+
+    def on_double_click(self):
+        pass
 
     def _init_after_parent_assignment(self):
         pass
@@ -346,7 +352,7 @@ class DisplayButtonWidget(ButtonWidget):
     ):
         super().__init__(x, y, parent, layout, selected, title=title)
 
-    def handle_select(self, not_used):
+    def on_click(self, not_used):
         if self.pressed:
             self.pressed = False
             self.parent.node.displayed = False

--- a/ryven/ironflow/canvas_widgets.py
+++ b/ryven/ironflow/canvas_widgets.py
@@ -13,10 +13,12 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Optional, Union, List, Any
 if TYPE_CHECKING:
     from .flow_canvas import FlowCanvas
+    from ryven.ironflow.gui import GUI
     from ipycanvas import Canvas
     from ryven.NENV import Node, NodeInputBP, NodeOutputBP
     Number = Union[int, float]
     from ryvencore.NodePort import NodePort
+
 
 __author__ = "Joerg Neugebauer"
 __copyright__ = (
@@ -82,6 +84,10 @@ class CanvasWidget(ABC):
     @property
     def canvas(self) -> Canvas:
         return self.parent.canvas
+
+    @property
+    def gui(self) -> GUI:
+        return self.parent.gui
 
     def add_widget(self, widget: CanvasWidget) -> None:
         self.objects_to_draw.append(widget)

--- a/ryven/ironflow/flow_canvas.py
+++ b/ryven/ironflow/flow_canvas.py
@@ -229,13 +229,5 @@ class FlowCanvas:
     def delete_selected(self) -> None:
         for o in self.objects_to_draw:
             if o.selected:
-                self.objects_to_draw.remove(o)
-                self._remove_node_from_flow(o.node)
+                o.delete()
         self.redraw()
-
-    def _remove_node_from_flow(self, node: Node) -> None:
-        for c in self.flow.connections[::-1]:  # Reverse to make sure we traverse whole thing even if we delete
-            # TODO: Can we be more efficient than looping over all nodes?
-            if (c.inp.node == node) or (c.out.node == node):
-                self.flow.remove_connection(c)
-        self.flow.remove_node(node)

--- a/ryven/ironflow/flow_canvas.py
+++ b/ryven/ironflow/flow_canvas.py
@@ -50,7 +50,7 @@ class FlowCanvas:
             - If a port is selected, deletes all connections it is part of
     """
     def __init__(self, gui: GUI, flow: Optional[Flow] = None, width: int = 2000, height: int = 1000):
-        self.gui = gui
+        self._gui = gui
         self.flow = flow if flow is not None else gui.flow
         self._width, self._height = width, height
 
@@ -93,6 +93,10 @@ class FlowCanvas:
     @property
     def canvas(self):
         return self._canvas
+
+    @property
+    def gui(self):
+        return self._gui
 
     def draw_connection(self, port_1: int, port_2: int) -> None:
         # i_out, i_in = path

--- a/ryven/ironflow/flow_canvas.py
+++ b/ryven/ironflow/flow_canvas.py
@@ -5,12 +5,12 @@
 from __future__ import annotations
 
 from ipycanvas import Canvas, hold_canvas
-from IPython.display import display
 from time import time
 
-from .canvas_widgets import NodeWidget, PortWidget, CanvasWidget, ButtonNodeWidget, DisplayableNodeWidget, DisplayButtonWidget
+from .canvas_widgets import (
+    NodeWidget, PortWidget, CanvasWidget, ButtonNodeWidget, DisplayableNodeWidget, DisplayButtonWidget
+)
 from .layouts import NodeLayout
-from .node_widgets import NodeWidgets
 
 from typing import TYPE_CHECKING, Optional, Union, List
 if TYPE_CHECKING:

--- a/ryven/ironflow/flow_canvas.py
+++ b/ryven/ironflow/flow_canvas.py
@@ -164,7 +164,10 @@ class FlowCanvas:
                 self.add_node(x, y, self.gui.new_node_class)
                 self._built_object_to_gui_dict()
         else:
-            sel_object = sel_object.on_click(last_object)
+            if sel_object == last_object and time_since_last_click < self._double_click_speed:
+                sel_object = sel_object.on_double_click()
+            else:
+                sel_object = sel_object.on_click(last_object)
 
         self._last_selected_object = sel_object
 

--- a/ryven/ironflow/flow_canvas.py
+++ b/ryven/ironflow/flow_canvas.py
@@ -184,7 +184,7 @@ class FlowCanvas:
         elif isinstance(newly_selected_object, PortWidget):
             return self._handle_port_select(newly_selected_object)
         elif isinstance(newly_selected_object, DisplayButtonWidget):
-            newly_selected_object.handle_select(None)
+            newly_selected_object.on_click(None)
             return None
         else:
             return newly_selected_object

--- a/ryven/ironflow/flow_canvas.py
+++ b/ryven/ironflow/flow_canvas.py
@@ -8,7 +8,7 @@ from ipycanvas import Canvas, hold_canvas
 from IPython.display import display
 from time import time
 
-from .canvas_widgets import NodeWidget, PortWidget, BaseCanvasWidget, ButtonNodeWidget, DisplayableNodeWidget, DisplayButtonWidget
+from .canvas_widgets import NodeWidget, PortWidget, CanvasWidget, ButtonNodeWidget, DisplayableNodeWidget, DisplayButtonWidget
 from .layouts import NodeLayout
 from .node_widgets import NodeWidgets
 
@@ -173,7 +173,7 @@ class FlowCanvas:
     def handle_mouse_up(self, x: Number, y: Number):
         self._mouse_is_down = False
 
-    def _handle_new_object_selection(self, newly_selected_object: BaseCanvasWidget) -> Union[BaseCanvasWidget | None]:
+    def _handle_new_object_selection(self, newly_selected_object: CanvasWidget) -> Union[CanvasWidget | None]:
         newly_selected_object.select()
 
         # if hasattr(newly_selected_object, "handle_select"):
@@ -212,13 +212,13 @@ class FlowCanvas:
         else:
             return sel_object
 
-    def get_element_at_xy(self, x_in: Number, y_in: Number) -> Union[BaseCanvasWidget, None]:
+    def get_element_at_xy(self, x_in: Number, y_in: Number) -> Union[CanvasWidget, None]:
         for o in self.objects_to_draw:
             if o.is_here(x_in, y_in):
                 return o.get_element_at_xy(x_in, y_in)
         return None
 
-    def get_selected_objects(self) -> List[BaseCanvasWidget]:
+    def get_selected_objects(self) -> List[CanvasWidget]:
         return [o for o in self.objects_to_draw if o.selected if o.selected]
 
     def handle_mouse_move(self, x: Number, y: Number) -> None:

--- a/ryven/ironflow/gui.py
+++ b/ryven/ironflow/gui.py
@@ -337,6 +337,7 @@ class GUI:
                 self._update_tabs_from_model()
             else:
                 self.active_script_index = self.script_tabs.selected_index
+            self.flow_canvas_widget.redraw()
 
     def _populate_text_input_panel(self, description, initial_value):
         self.text_input_panel.children = [

--- a/ryven/ironflow/gui.py
+++ b/ryven/ironflow/gui.py
@@ -8,7 +8,7 @@ import os
 import ipywidgets as widgets
 from IPython.display import display
 from ryven.main.utils import import_nodes_package, NodesPackage
-from ryven.ironflow.node_widgets import NodeWidgets
+from ryven.ironflow.node_widgets import NodeInterface
 
 from .flow_canvas import FlowCanvas
 from ryvencore import Session, Script, Flow
@@ -69,7 +69,7 @@ class GUI:
 
         self.create_script(script_title)
         self.displayed_node = None
-        self.node_interface = NodeWidgets(self)
+        self.node_interface = NodeInterface(self)
 
     @property
     def active_script_index(self) -> int:

--- a/ryven/ironflow/gui.py
+++ b/ryven/ironflow/gui.py
@@ -8,6 +8,7 @@ import os
 import ipywidgets as widgets
 from IPython.display import display
 from ryven.main.utils import import_nodes_package, NodesPackage
+from ryven.ironflow.node_widgets import NodeWidgets
 
 from .flow_canvas import FlowCanvas
 from ryvencore import Session, Script, Flow
@@ -68,6 +69,7 @@ class GUI:
 
         self.create_script(script_title)
         self.displayed_node = None
+        self.node_interface = NodeWidgets(self)
 
     @property
     def active_script_index(self) -> int:

--- a/ryven/ironflow/node_widgets.py
+++ b/ryven/ironflow/node_widgets.py
@@ -32,7 +32,7 @@ def deserialize(data):
     return pickle.loads(base64.b64decode(data))
 
 
-class NodeWidgets:
+class NodeInterface:
     def __init__(self, central_gui: GUI):
         self.node = None
         self._central_gui = central_gui

--- a/ryven/ironflow/node_widgets.py
+++ b/ryven/ironflow/node_widgets.py
@@ -127,10 +127,10 @@ class NodeWidgets:
         self.input_change(3, change)
 
     def input_change_4(self, change: Dict) -> None:
-        self.input_change(3, change)
+        self.input_change(4, change)
 
     def input_change_5(self, change: Dict) -> None:
-        self.input_change(3, change)
+        self.input_change(5, change)
 
     def draw(self) -> widgets.HBox:
         self.inp_box = widgets.GridBox(

--- a/tests/unit/test_flow_canvas.py
+++ b/tests/unit/test_flow_canvas.py
@@ -25,11 +25,12 @@ class TestCanvasObect(TestCase):
         val_node = self.gui._nodes_dict['nodes']['val']
         results_node = self.gui._nodes_dict['nodes']['result']
 
-        n1 = flow.create_node(node_class=val_node)
-        n2 = flow.create_node(node_class=results_node)
-        c12 = flow.connect_nodes(n1.outputs[0], n2.inputs[0])
+        self.canvas.add_node(0, 0, val_node)
+        self.canvas.add_node(0, 0, results_node)
+        c12 = flow.connect_nodes(self.canvas.objects_to_draw[0].outputs[0], self.canvas.objects_to_draw[1].inputs[0])
         self.assertEqual(2, len(flow.nodes))
         self.assertEqual(1, len(flow.connections))
-        self.canvas._remove_node_from_flow(n1)
+        self.canvas.objects_to_draw[0].select()
+        self.canvas.delete_selected()
         self.assertEqual(1, len(flow.nodes), msg="Expected exactly one node to get deleted.")
         self.assertEqual(0, len(flow.connections), msg="Expected the connection to get automatically deleted")


### PR DESCRIPTION
~Todo:~
- ~Play around with `on_double_click` to get it working too (for now probably just on nodes as a shortcut for hitting the `display` button, but I want the infrastructure there and working).~
- ~Handle the display of the node interface (inputs etc) better. Mostly I want to see it get cleared when the owning node is deleted.~

~No new functionality, just~ behind-the-scenes stuff on the pseudo-widgets that live in the canvas. Control flow is handled better by calling `on_click` methods of each of the relevant widgets themselves, and the widget OOP structure is (IMO) a bit clearer and more extensible.

New functionality: double clicking on a node deletes it, analogous to how double clicking on empty space places a new node.
