### PR TITLE
Separate the GUI again into back- and front-end

### DIFF
--- a/ryven/ironflow/gui.py
+++ b/ryven/ironflow/gui.py
@@ -2,21 +2,7 @@
 # Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 
-import json
-import os
-
-import ipywidgets as widgets
-from IPython.display import display
-from ryven.main.utils import import_nodes_package, NodesPackage
-from ryven.ironflow.node_interface import NodeInterface
-
-from .flow_canvas import FlowCanvas
-from ryvencore import Session, Script, Flow
-
-import ryven.NENV as NENV
-from pathlib import Path
-
-from typing import Optional, Dict, Type
+from __future__ import annotations
 
 __author__ = "Joerg Neugebauer, Liam Huber"
 __copyright__ = (
@@ -29,36 +15,26 @@ __email__ = "liamhuber@greyhavensolutions.com"
 __status__ = "production"
 __date__ = "May 10, 2022"
 
-os.environ["RYVEN_MODE"] = "no-gui"
-NENV.init_node_env()
+import ipywidgets as widgets
+from IPython.display import display
+from ryven.ironflow.models import HasSession
+from ryven.ironflow.node_interface import NodeInterface
+from ryven.ironflow.flow_canvas import FlowCanvas
 
-ryven_location = Path(__file__).parents[1]
-packages = [os.path.join(ryven_location, "nodes", *subloc) for subloc in [
-    ("built_in",),
-    ("std",),
-    ("pyiron",),
-]]  # , ("mynodes",)
+from typing import Optional, Dict
+from ryvencore import Session
+
 alg_modes = ["data", "exec"]
-
-
 debug_view = widgets.Output(layout={"border": "1px solid black"})
 
 
-class GUI:
-    def __init__(self, session_title: str, script_title: Optional[str] = None, session: Optional[Session] = None):
-        self._session = session if session is not None else Session()
-        self.session_title = session_title
+class GUI(HasSession):
+    def __init__(self, session_title: str, session: Optional[Session] = None, script_title: Optional[str] = None):
+        super().__init__(session_title=session_title, session=session)
+
         self._flow_canvases = []
-        self._active_script_index = 0
-
-        for package in packages:
-            self.session.register_nodes(
-                import_nodes_package(NodesPackage(directory=package))
-            )
-
-        self._nodes_dict = {}
-        for n in self.session.nodes:
-            self._register_node(n)
+        self.displayed_node = None
+        self.node_interface = NodeInterface(self)
 
         self._context = None
         self._context_actions = {
@@ -68,44 +44,19 @@ class GUI:
         }
 
         self.create_script(script_title)
-        self.displayed_node = None
-        self.node_interface = NodeInterface(self)
 
-    @property
-    def active_script_index(self) -> int:
-        return self._active_script_index
+    def create_script(
+            self,
+            title: Optional[str] = None,
+            create_default_logs: bool = True,
+            data: Optional[Dict] = None
+    ) -> None:
+        super().create_script(title=title, create_default_logs=create_default_logs, data=data)
+        self._flow_canvases.append(FlowCanvas(gui=self))
 
-    @active_script_index.setter
-    def active_script_index(self, i: int) -> None:
-        if i >= len(self.session.scripts):
-            raise KeyError(
-                f"Attempted to activate script {i}, but there are only {len(self.session.scripts)} available."
-            )
-        self._active_script_index = i % self.n_scripts
-
-    @property
-    def session(self) -> Session:
-        return self._session
-
-    @property
-    def script(self) -> Script:
-        return self.session.scripts[self.active_script_index]
-
-    @property
-    def flow(self) -> Flow:
-        return self.script.flow
-
-    @property
-    def n_scripts(self):
-        return len(self.session.scripts)
-
-    @property
-    def next_auto_script_name(self):
-        i = 0
-        titles = [s.title for s in self.session.scripts]
-        while f"script_{i}" in titles:
-            i += 1
-        return f"script_{i}"
+    def delete_script(self) -> None:
+        self._flow_canvases.pop(self.active_script_index)
+        super().delete_script()
 
     @property
     def flow_canvas_widget(self):
@@ -115,62 +66,9 @@ class GUI:
     def new_node_class(self):
         return self._nodes_dict[self.modules_dropdown.value][self.node_selector.value]
 
-    def create_script(
-            self,
-            title: Optional[str] = None,
-            create_default_logs: bool = True,
-            data: Optional[Dict] = None
-    ) -> None:
-        self.session.create_script(
-            title=title if title is not None else self.next_auto_script_name,
-            create_default_logs=create_default_logs,
-            data=data
-        )
-        self.active_script_index = -1
-        self._flow_canvases.append(FlowCanvas(gui=self))
-
-    def delete_script(self) -> None:
-        last_active = self.active_script_index
-        self._flow_canvases.pop(self.active_script_index)
-        self.session.delete_script(self.script)
-        if self.n_scripts == 0:
-            self.create_script()
-        else:
-            self.active_script_index = last_active - 1
-
-    def rename_script(self, new_name: str) -> bool:
-        return self.session.rename_script(self.script, new_name)
-
-    def save(self, file_path: str) -> None:
-        data = self.serialize()
-
-        with open(file_path, "w") as f:
-            f.write(json.dumps(data, indent=4))
-
-    def serialize(self) -> Dict:
-        currently_active = self.active_script_index
-        data = self.session.serialize()
-        for i_script, script in enumerate(self.session.scripts):
-            all_data = data["scripts"][i_script]["flow"]["nodes"]
-            self.active_script_index = i_script
-            for i, node_widget in enumerate(self.flow_canvas_widget.objects_to_draw):
-                all_data[i]["pos x"] = node_widget.x
-                all_data[i]["pos y"] = node_widget.y
-        self.active_script_index = currently_active
-        return data
-
-    def load(self, file_path: str) -> None:
-        with open(file_path, "r") as f:
-            data = json.loads(f.read())
-
-        self.load_from_data(data)
-
     def load_from_data(self, data: Dict) -> None:
-        for script in self.session.scripts[::-1]:
-            self.session.delete_script(script)
+        super().load_from_data(data)
         self._flow_canvases = []
-
-        self.session.load(data)
         for i_script, script in enumerate(self.session.scripts):
             flow_canvas = FlowCanvas(gui=self, flow=script.flow)
             all_data = data["scripts"][i_script]["flow"]["nodes"]
@@ -179,56 +77,6 @@ class GUI:
             flow_canvas._built_object_to_gui_dict()
             flow_canvas.redraw()
             self._flow_canvases.append(flow_canvas)
-
-        self.active_script_index = 0
-
-    def _register_node(self, node_class: Type[NENV.Node], node_module: Optional[str] = None):
-        node_module = node_module or node_class.__module__  # n.identifier_prefix
-        if node_module not in self._nodes_dict.keys():
-            self._nodes_dict[node_module] = {}
-        self._nodes_dict[node_module][node_class.title] = node_class
-
-    def register_user_node(self, node_class: Type[NENV.Node]):
-        """
-        Register a custom node class from the gui's current working scope. These nodes are available under the
-        'user' module. You will need to (re-)draw your GUI to see the change.
-
-        Note: You can re-register a class to update its functionality, but only *newly placed* nodes will see this
-                update. Already-placed nodes are still instances of the old class and need to be deleted.
-
-        Note: You can save the graph as normal, but new gui instances will need to register the same custom nodes before
-            loading the saved graph is possible.
-
-        Args:
-            node_class Type[NENV.Node]: The new node class to register.
-
-        Example:
-            >>> from ryven.ironflow import GUI, Node, NodeInputBP, NodeOutputBP, dtypes
-            >>> gui = GUI(script_title='foo')
-            >>>
-            >>> class MyNode(Node):
-            >>>     title = "MyUserNode"
-            >>>     init_inputs = [
-            >>>         NodeInputBP(dtype=dtypes.Integer(default=1), label="foo")
-            >>>     ]
-            >>>     init_outputs = [
-            >>>        NodeOutputBP(label="bar")
-            >>>    ]
-            >>>    color = 'cyan'
-            >>>
-            >>>     def update_event(self, inp=-1):
-            >>>         self.set_output_val(0, self.input(0) + 42)
-            >>>
-            >>> gui.register_user_node(MyNode)
-        """
-        if node_class in self.session.nodes:
-            self.session.unregister_node(node_class)
-        self.session.register_node(node_class)
-        self._register_node(node_class, node_module='user')
-
-    ### ^ Back end ########
-    ### More or less... ###
-    ### v Front end #######
 
     @debug_view.capture(clear_output=True)
     def draw(self) -> widgets.VBox:

--- a/ryven/ironflow/models.py
+++ b/ryven/ironflow/models.py
@@ -1,0 +1,189 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+from __future__ import annotations
+
+__author__ = "Joerg Neugebauer, Liam Huber"
+__copyright__ = (
+    "Copyright 2020, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Computational Materials Design (CM) Department"
+)
+__version__ = "0.1"
+__maintainer__ = "Liam Huber"
+__email__ = "liamhuber@greyhavensolutions.com"
+__status__ = "production"
+__date__ = "Sep 6, 2022"
+
+from pathlib import Path
+import os
+import json
+from abc import ABC
+from ryvencore import Session, Script, Flow
+from ryven.main.utils import import_nodes_package, NodesPackage
+
+from typing import Optional, Dict, Type
+
+import ryven.NENV as NENV
+
+os.environ["RYVEN_MODE"] = "no-gui"
+NENV.init_node_env()
+
+ryven_location = Path(__file__).parents[1]
+packages = [os.path.join(ryven_location, "nodes", *subloc) for subloc in [
+    ("built_in",),
+    ("std",),
+    ("pyiron",),
+]]  # , ("mynodes",)
+
+
+class HasSession(ABC):
+    """Mixin for an object which has a Ryven session as the underlying model"""
+
+    def __init__(self, session_title: str, session: Optional[Session] = None):
+        self._session = session if session is not None else Session()
+        self.session_title = session_title
+        self._active_script_index = 0
+
+        for package in packages:
+            self.session.register_nodes(
+                import_nodes_package(NodesPackage(directory=package))
+            )
+
+        self._nodes_dict = {}
+        for n in self.session.nodes:
+            self._register_node(n)
+
+    @property
+    def active_script_index(self) -> int:
+        return self._active_script_index
+
+    @active_script_index.setter
+    def active_script_index(self, i: int) -> None:
+        if i >= len(self.session.scripts):
+            raise KeyError(
+                f"Attempted to activate script {i}, but there are only {len(self.session.scripts)} available."
+            )
+        self._active_script_index = i % self.n_scripts
+
+    @property
+    def session(self) -> Session:
+        return self._session
+
+    @property
+    def script(self) -> Script:
+        return self.session.scripts[self.active_script_index]
+
+    @property
+    def flow(self) -> Flow:
+        return self.script.flow
+
+    @property
+    def n_scripts(self):
+        return len(self.session.scripts)
+
+    @property
+    def next_auto_script_name(self):
+        i = 0
+        titles = [s.title for s in self.session.scripts]
+        while f"script_{i}" in titles:
+            i += 1
+        return f"script_{i}"
+
+    def create_script(
+            self,
+            title: Optional[str] = None,
+            create_default_logs: bool = True,
+            data: Optional[Dict] = None
+    ) -> None:
+        self.session.create_script(
+            title=title if title is not None else self.next_auto_script_name,
+            create_default_logs=create_default_logs,
+            data=data
+        )
+        self.active_script_index = -1
+
+    def delete_script(self) -> None:
+        last_active = self.active_script_index
+        self.session.delete_script(self.script)
+        if self.n_scripts == 0:
+            self.create_script()
+        else:
+            self.active_script_index = last_active - 1
+
+    def rename_script(self, new_name: str) -> bool:
+        return self.session.rename_script(self.script, new_name)
+
+    def save(self, file_path: str) -> None:
+        data = self.serialize()
+
+        with open(file_path, "w") as f:
+            f.write(json.dumps(data, indent=4))
+
+    def serialize(self) -> Dict:
+        currently_active = self.active_script_index
+        data = self.session.serialize()
+        for i_script, script in enumerate(self.session.scripts):
+            all_data = data["scripts"][i_script]["flow"]["nodes"]
+            self.active_script_index = i_script
+            for i, node_widget in enumerate(self.flow_canvas_widget.objects_to_draw):
+                all_data[i]["pos x"] = node_widget.x
+                all_data[i]["pos y"] = node_widget.y
+        self.active_script_index = currently_active
+        return data
+
+    def load(self, file_path: str) -> None:
+        with open(file_path, "r") as f:
+            data = json.loads(f.read())
+
+        self.load_from_data(data)
+
+    def load_from_data(self, data: Dict) -> None:
+        for script in self.session.scripts[::-1]:
+            self.session.delete_script(script)
+        self.session.load(data)
+        self.active_script_index = 0
+
+    def _register_node(self, node_class: Type[NENV.Node], node_module: Optional[str] = None):
+        node_module = node_module or node_class.__module__  # n.identifier_prefix
+        if node_module not in self._nodes_dict.keys():
+            self._nodes_dict[node_module] = {}
+        self._nodes_dict[node_module][node_class.title] = node_class
+
+    def register_user_node(self, node_class: Type[NENV.Node]):
+        """
+        Register a custom node class from the gui's current working scope. These nodes are available under the
+        'user' module. You will need to (re-)draw your GUI to see the change.
+
+        Note: You can re-register a class to update its functionality, but only *newly placed* nodes will see this
+                update. Already-placed nodes are still instances of the old class and need to be deleted.
+
+        Note: You can save the graph as normal, but new gui instances will need to register the same custom nodes before
+            loading the saved graph is possible.
+
+        Args:
+            node_class Type[NENV.Node]: The new node class to register.
+
+        Example:
+            >>> from ryven.ironflow import GUI, Node, NodeInputBP, NodeOutputBP, dtypes
+            >>> gui = GUI(script_title='foo')
+            >>>
+            >>> class MyNode(Node):
+            >>>     title = "MyUserNode"
+            >>>     init_inputs = [
+            >>>         NodeInputBP(dtype=dtypes.Integer(default=1), label="foo")
+            >>>     ]
+            >>>     init_outputs = [
+            >>>        NodeOutputBP(label="bar")
+            >>>    ]
+            >>>    color = 'cyan'
+            >>>
+            >>>     def update_event(self, inp=-1):
+            >>>         self.set_output_val(0, self.input(0) + 42)
+            >>>
+            >>> gui.register_user_node(MyNode)
+        """
+        if node_class in self.session.nodes:
+            self.session.unregister_node(node_class)
+        self.session.register_node(node_class)
+        self._register_node(node_class, node_module='user')


### PR DESCRIPTION
I anyhow had a comment line inside the GUI methods, below which was the front-end stuff and above which was the back-end stuff, so this just formalizes the arrangement. Should make testing easier as now the model is totally separated out. Makes the files a bit easier to read as they're not so long and more focused.