### PR TITLE
Collapsable input

### DIFF
--- a/ryven/ironflow/canvas_widgets.py
+++ b/ryven/ironflow/canvas_widgets.py
@@ -471,7 +471,7 @@ class ButtonWidget(CanvasWidget, ABC):
         self.canvas.font = self.layout.font_string
         self.canvas.fill_style = self.layout.font_color
         x = self.x + (self.width * 0.1)
-        y = self.y + (self.height * 0.1) + self.layout.font_size
+        y = self.y + (self.height * 0.05) + self.layout.font_size
         self.canvas.fill_text(self.title, x, y)
 
     def draw(self) -> None:
@@ -487,7 +487,7 @@ class DisplayButtonWidget(ButtonWidget):
             parent: DisplayableNodeWidget,
             layout: ButtonLayout,
             selected: bool = False,
-            title="Display",
+            title="PLOT",
     ):
         super().__init__(x, y, parent, layout, selected, title=title)
 
@@ -519,7 +519,14 @@ class DisplayableNodeWidget(NodeWidget):
     ):
         super().__init__(x, y, parent, layout, node, selected, port_radius)
 
-        self.display_button = DisplayButtonWidget(80, 50, parent=self, layout=ButtonLayout())
+        button_layout = ButtonLayout()
+        button_edge_offset = 5
+        self.display_button = DisplayButtonWidget(
+            x=self.width - button_layout.width - button_edge_offset,
+            y=button_edge_offset,
+            parent=self,
+            layout=button_layout
+        )
         self.add_widget(self.display_button)
 
     def set_display(self):

--- a/ryven/ironflow/canvas_widgets.py
+++ b/ryven/ironflow/canvas_widgets.py
@@ -606,7 +606,7 @@ class DisplayableNodeWidget(NodeWidget):
         return super().delete()
 
 
-class ExpandCollapseButtonWidget(ButtonWidget, HideableWidget):
+class ExpandCollapseButtonWidget(ButtonWidget, HideableWidget, ABC):
     def __init__(
             self,
             x: Number,
@@ -637,11 +637,24 @@ class ExpandCollapseButtonWidget(ButtonWidget, HideableWidget):
     def unpress(self):
         self.show()
 
+    def draw_shape(self) -> None:
+        self.canvas.fill_style = self.layout.pressed_color if self.pressed else self.layout.background_color
+        self.canvas.fill_polygon(self._points)
+
+    @property
+    @abstractmethod
+    def _points(self) -> list[tuple[Number, Number]]:
+        pass
+
 
 class ExpandButtonWidget(ExpandCollapseButtonWidget):
-    def draw_shape(self) -> None:
-        # TODO: Use a triangle instead of a square
-        super().draw_shape()
+    @property
+    def _points(self) -> list[tuple[Number, Number]]:
+        return [
+            (self.x, self.y),
+            (self.x + self.width, self.y),
+            (self.x + 0.5 * self.width, self.y + self.height)
+        ]
 
     def press(self):
         super().press()
@@ -649,9 +662,13 @@ class ExpandButtonWidget(ExpandCollapseButtonWidget):
 
 
 class CollapseButtonWidget(ExpandCollapseButtonWidget):
-    def draw_shape(self) -> None:
-        # TODO: Use a triangle instead of a square
-        super().draw_shape()
+    @property
+    def _points(self) -> list[tuple[Number, Number]]:
+        return [
+            (self.x, self.y + self.height),
+            (self.x + 0.5 * self.width, self.y),
+            (self.x + self.width, self.y + self.height)
+        ]
 
     def press(self):
         super().press()

--- a/ryven/ironflow/canvas_widgets.py
+++ b/ryven/ironflow/canvas_widgets.py
@@ -214,7 +214,7 @@ class NodeWidget(CanvasWidget):
     ):
         super().__init__(x, y, parent, layout, selected)
 
-        self._title_box_height = 30  # 0.3  # ratio with respect to height
+
 
         self.node = node
         self.title = node.title
@@ -228,8 +228,9 @@ class NodeWidget(CanvasWidget):
             'exec': ExecPortLayout()
         }
 
-        if len(self.node.inputs) > 3:
-            self._height = 200  # TODO: Make height programatically dependent on content
+        self._title_box_height = 30  # 0.3  # ratio with respect to height
+        self._io_height = 1.33 * 2 * self.port_radius * max(len(self.node.inputs), len(self.node.outputs))
+        self._height = self._io_height + self._title_box_height
         self.add_inputs()
         self.add_outputs()
 

--- a/ryven/ironflow/layouts.py
+++ b/ryven/ironflow/layouts.py
@@ -37,19 +37,13 @@ class Layout(ABC):
 class NodeLayout(Layout):
     width: int = 200
     height: int = 100
-    font_title_size: int = 22
-    font_title_color: str = "black"
-    title_font: str = "serif"
-
-    @property
-    def title_font_string(self):
-        return f"{self.font_title_size}px {self.title_font}"
+    font_size: int = 22
 
 
 @dataclass
 class PortLayout(Layout, ABC):
     width: int = 20
-    height: int = 10
+    height: int = 20
 
 
 @dataclass

--- a/ryven/ironflow/layouts.py
+++ b/ryven/ironflow/layouts.py
@@ -66,7 +66,8 @@ class ExecPortLayout(PortLayout):
 
 @dataclass
 class ButtonLayout(Layout):
-    width: int = 70
-    height: int = 30
+    font_size: int = 16
+    width: int = 50
+    height: int = 20
     background_color: str = "darkgray"
     pressed_color: str = "dimgray"


### PR DESCRIPTION
Todo:
- ~dynamically size nodes based on IO~
- ~hide/show IO ports and center them on the 0th IO port when hidden so connections still look good~
- ~Add new triangular show/hide buttons~
- ~Add new node button that shows/hides ports~
- ~Draw nodes depending on whether they are collapsed or expanded~

New behaviour:
- Nodes can be collapsed or expanded to hide/show IO
- Nodes with a `val` no longer display this in their node widget body (it obviously doesn't play well with being collapsable, and the OOP hierarchy was a pain. If it is desperately wanted it can be brought back, but this data is visible in the node interface and/or display panels anyhow)

The json uploaded over at #33 is still a good test set here.