### PR TITLE
Scrolling canvas

### DIFF
--- a/ryven/ironflow/flow_canvas.py
+++ b/ryven/ironflow/flow_canvas.py
@@ -79,6 +79,8 @@ class FlowCanvas:
 
         self.x = 0
         self.y = 0
+        self._x_move_anchor = None
+        self._y_move_anchor = None
 
         self._last_selected_object = None
 
@@ -150,6 +152,9 @@ class FlowCanvas:
 
     def handle_mouse_down(self, x: Number, y: Number):
         self._mouse_is_down = True
+        self._x_move_anchor = x
+        self._y_move_anchor = y
+
         now = time()
         time_since_last_click = now - self._last_mouse_down
         self._last_mouse_down = now
@@ -192,6 +197,12 @@ class FlowCanvas:
                 with hold_canvas(self._canvas):
                     [o.set_x_y(x, y) for o in selected_objects]
                     self.redraw()
+            else:
+                self.x += x - self._x_move_anchor
+                self.y += y - self._y_move_anchor
+                self._x_move_anchor = x
+                self._y_move_anchor = y
+                self.redraw()
 
     def redraw(self) -> None:
         with hold_canvas(self._canvas):

--- a/ryven/ironflow/gui.py
+++ b/ryven/ironflow/gui.py
@@ -96,6 +96,7 @@ class GUI(HasSession):
 
         button_layout = widgets.Layout(width="50px")
         # Icon source: https://fontawesome.com
+        # It looks like I'm stuck on v4, but this might just be a limitation of my jupyter environment -Liam
         self.btn_load = widgets.Button(tooltip="Load", icon="upload", layout=button_layout)
         self.btn_save = widgets.Button(tooltip="Save", icon="download", layout=button_layout)
         self.btn_delete_node = widgets.Button(tooltip="Delete Node", icon="trash", layout=button_layout)
@@ -103,6 +104,12 @@ class GUI(HasSession):
         # TODO: Use file-pen once this is available
         self.btn_delete_script = widgets.Button(tooltip="Delete script", icon="minus", layout=button_layout)
         # TODO: Use file-circle-minus once this is available
+        self.btn_zero_location = widgets.Button(
+            tooltip="Recenter canvas at (0,0)",
+            icon="map-marker",
+            layout=button_layout
+        )
+        # TODO: Use location-dot once this is available
 
         self.text_input_panel = widgets.HBox([])
         self.text_input_field = widgets.Text(value="INIT VALUE", description="DESCRIPTION")
@@ -140,6 +147,7 @@ class GUI(HasSession):
         # https://github.com/jupyter-widgets/ipywidgets/issues/2446
         self.btn_input_text_cancel.on_click(self.click_input_text_cancel)
         self.btn_delete_script.on_click(self.click_delete_script)
+        self.btn_zero_location.on_click(self.click_zero_location)
         self.script_tabs.observe(self.change_script_tabs)
 
         return widgets.VBox(
@@ -153,6 +161,7 @@ class GUI(HasSession):
                         self.btn_delete_node,
                         self.btn_rename_script,
                         self.btn_delete_script,
+                        self.btn_zero_location,
                     ]
                 ),
                 self.text_input_panel,
@@ -252,10 +261,14 @@ class GUI(HasSession):
         else:
             self._print(f"INVALID NAME: Failed to rename script '{self.script.title}' to '{new_name}'.")
 
-
     def click_delete_script(self, change: Dict) -> None:
         self.delete_script()
         self._update_tabs_from_model()
+
+    def click_zero_location(self, change: dict) -> None:
+        self.flow_canvas_widget.x = 0
+        self.flow_canvas_widget.y = 0
+        self.flow_canvas_widget.redraw()
 
     def _update_tabs_from_model(self):
         self.script_tabs.selected_index = None


### PR DESCRIPTION
You can now click and drag on empty space to move the canvas around. Since zooming in and out seems like it will be (impossibly?) hard, this is a simple alternative to get access to a larger workspace. There's also a button to recenter the canvas at (0,0) in case you get lost.