### PR TITLE
Exec button

### DIFF
--- a/ryven/ironflow/canvas_widgets.py
+++ b/ryven/ironflow/canvas_widgets.py
@@ -309,8 +309,12 @@ class NodeWidget(CanvasWidget):
         self._title_box_height = 30
 
         n_ports_max = max(len(self.node.inputs), len(self.node.outputs))
+        n_ports_min = len([p for p in self.node.inputs if p.type_ == "exec"])
         subwidget_size_and_buffer = 1.33 * 2 * self.port_radius
         self._io_height = subwidget_size_and_buffer * n_ports_max
+        self._exec_height = subwidget_size_and_buffer * n_ports_min
+        # TODO: Right now we're hard-coding in that all the exec ports (which come with buttons) appear first in input
+        #       This isn't necessarily so, nor checked for anywhere. Do better.
         self._expand_collapse_height = subwidget_size_and_buffer
         self._height = self._expanded_height
 
@@ -439,7 +443,7 @@ class NodeWidget(CanvasWidget):
 
     @property
     def _collapsed_height(self) -> Number:
-        return self._title_box_height + self._expand_collapse_height
+        return self._title_box_height + max(self._expand_collapse_height, self._exec_height)
 
     def expand_io(self):
         self._height = self._expanded_height

--- a/ryven/ironflow/canvas_widgets.py
+++ b/ryven/ironflow/canvas_widgets.py
@@ -453,18 +453,22 @@ class ButtonNodeWidget(NodeWidget):
             layout: NodeLayout,
             node: Node,
             selected: bool = False,
+            title: Optional[str] = None,
             port_radius: Number = 10,
     ):
-        super().__init__(x, y, parent, layout, node, selected, port_radius)
+        super().__init__(
+            x=x, y=y, parent=parent, layout=layout, node=node, selected=selected, title=title, port_radius=port_radius
+        )
 
-        layout = ButtonLayout()
-        s = CanvasWidget(50, 50, parent=self, layout=layout)
-        s.handle_select = self.handle_button_select
-        self.add_widget(s)
-
-    def handle_button_select(self, button: ButtonNodeWidget) -> None:
-        button.parent.node.exec_output(0)
-        button.deselect()
+        button_layout = ButtonLayout()
+        self.exec_button = ExecButtonWidget(
+            x=0.8 * (self.width - button_layout.width),
+            y=self._port_y_locs[0] - 0.5 * button_layout.height,
+            parent=self,
+            layout=button_layout,
+            title="Exec",
+        )
+        self.add_widget(self.exec_button)
 
 
 class ButtonWidget(CanvasWidget, ABC):
@@ -673,3 +677,12 @@ class CollapseButtonWidget(ExpandCollapseButtonWidget):
     def press(self):
         super().press()
         self.parent.collapse_io()
+
+
+class ExecButtonWidget(ButtonWidget):
+    def press(self):
+        self.parent.node.exec_output(0)
+        self.unpress()
+
+    def unpress(self):
+        self.pressed = False

--- a/ryven/nodes/pyiron/atomistics_nodes.py
+++ b/ryven/nodes/pyiron/atomistics_nodes.py
@@ -158,7 +158,7 @@ class Lammps_Node(DualNodeBase):
     title = "Lammps"
     version = "v0.1"
     init_inputs = [
-        NodeInputBP(type_="exec"),
+        NodeInputBP(type_="exec", label="run"),
         NodeInputBP(dtype=dtypes.Data(size="m"), label="project"),
         NodeInputBP(dtype=dtypes.Char(default="job"), label="name"),
         NodeInputBP(dtype=dtypes.Data(size="m"), label="structure"),

--- a/ryven/nodes/pyiron/atomistics_nodes.py
+++ b/ryven/nodes/pyiron/atomistics_nodes.py
@@ -154,7 +154,7 @@ class ApplyStrain_Node(OutputsOnlyAtoms):
         self.set_output_val(0, self.input(0).apply_strain(float(self.input(1)), return_box=True))
 
 
-class Lammps_Node(DualNodeBase):
+class Lammps_Node(NodeWithDisplay):
     title = "Lammps"
     version = "v0.1"
     init_inputs = [
@@ -170,22 +170,23 @@ class Lammps_Node(DualNodeBase):
     ]
     color = "#5d95de"
 
-    def __init__(self, params):
-        super().__init__(params, active=True)
+    def _run(self):
+        pr = self.input(1)
+        job = pr.create.job.Lammps(self.input(2))
+        job.structure = self.input(3)
+        job.potential = self.input(4)
+        self._job = job
+        job.run()
+        self.set_output_val(1, job)
+        self.exec_output(0)
 
     def update_event(self, inp=-1):
-        self._val_is_updated = True
-        if self.active and inp == 0:
-            pr = self.input(1)
-            job = pr.create.job.Lammps(self.input(2))
-            job.structure = self.input(3)
-            job.potential = self.input(4)
-            self._job = job
-            job.run()
-            self.set_output_val(1, job)
-            self.exec_output(0)
-        elif not self.active:
-            self.val = self.input(0)
+        if inp == 0:
+            self._run()
+
+    @property
+    def representations(self) -> tuple:
+        return self.output(1),
 
 
 class GenericOutput_Node(NodeWithDisplay):


### PR DESCRIPTION
Update the "click" node, and make all "exec"-type ports come with a label(able) button to force their execution sans click-node.

Demo for the lammps node is attached, since it got a wee upgrade and can now delete its job with an exec port too.

[lammps_run.json.zip](https://github.com/pyiron/ironflow/files/9532602/lammps_run.json.zip)
