### PR TITLE
Move displays

### DIFF
--- a/ryven/ironflow/canvas_widgets.py
+++ b/ryven/ironflow/canvas_widgets.py
@@ -426,6 +426,11 @@ class NodeWidget(CanvasWidget):
         if self.gui.node_interface.node == self.node:
             self.gui.node_interface.draw_for_node(None)
 
+    def deselect(self) -> None:
+        super().deselect()
+        if self.gui.node_interface.node == self.node:
+            self.gui.node_interface.draw_for_node(None)
+
     @property
     def port_widgets(self) -> list[PortWidget]:
         return [o for o in self.objects_to_draw if isinstance(o, PortWidget)]

--- a/ryven/ironflow/gui.py
+++ b/ryven/ironflow/gui.py
@@ -201,10 +201,10 @@ class GUI(HasSession):
                 ),
                 self.text_input_panel,
                 widgets.HBox(
-                    [widgets.VBox([self.node_selector]), self.script_tabs, self.out_plot]
+                    [widgets.VBox([self.node_selector]), self.script_tabs]
                 ),
                 self.out_log,
-                self.out_status,
+                widgets.HBox([self.out_status, self.out_plot]),
                 debug_view
             ]
         )

--- a/ryven/ironflow/gui.py
+++ b/ryven/ironflow/gui.py
@@ -168,8 +168,8 @@ class GUI(HasSession):
         self._update_tabs_from_model()
 
         self.out_log = widgets.Output(layout={"border": "1px solid black"})
-        self.out_plot = widgets.Output(layout={"width": "50%", "border": "1px solid black", "align_content": "flex-end"})
-        self.out_status = widgets.Output(layout={"border": "1px solid black"})
+        self.out_plot = widgets.Output(layout={"width": "50%", "border": "1px solid black"})
+        self.out_status = widgets.Output(layout={"width": "50%", "border": "1px solid black"})
 
         # Wire callbacks
         self.alg_mode_dropdown.observe(self.change_alg_mode_dropdown, names="value")

--- a/ryven/ironflow/gui.py
+++ b/ryven/ironflow/gui.py
@@ -92,18 +92,19 @@ class GUI(HasSession):
 
     @debug_view.capture(clear_output=True)
     def draw(self) -> widgets.VBox:
-        self.out_plot = widgets.Output(layout={"width": "50%", "border": "1px solid black"})
-        self.out_log = widgets.Output(layout={"border": "1px solid black"})
-
-        self.script_tabs = widgets.Tab([])
-        self._update_tabs_from_model()
-
         module_options = sorted(self._nodes_dict.keys())
         self.modules_dropdown = widgets.Dropdown(
             options=module_options,
             value=list(module_options)[0],
             disabled=False,
             layout=widgets.Layout(width="130px"),
+        )
+
+        self.alg_mode_dropdown = widgets.Dropdown(
+            options=alg_modes,
+            value=alg_modes[0],
+            disabled=False,
+            layout=widgets.Layout(width="80px"),
         )
 
         button_layout = widgets.Layout(width="50px")
@@ -156,13 +157,6 @@ class GUI(HasSession):
         self.btn_input_text_cancel = widgets.Button(tooltip="Cancel renaming", icon="ban", layout=button_layout)
         # TODO: Use xmark once this is available
 
-        self.alg_mode_dropdown = widgets.Dropdown(
-            options=alg_modes,
-            value=alg_modes[0],
-            disabled=False,
-            layout=widgets.Layout(width="80px"),
-        )
-
         nodes_options = sorted(self._nodes_dict[self.modules_dropdown.value].keys())
         self.node_selector = widgets.RadioButtons(
             options=nodes_options,
@@ -170,8 +164,14 @@ class GUI(HasSession):
             disabled=False,
         )
 
+        self.script_tabs = widgets.Tab([])
+        self._update_tabs_from_model()
+
+        self.out_log = widgets.Output(layout={"border": "1px solid black"})
+        self.out_plot = widgets.Output(layout={"width": "50%", "border": "1px solid black", "align_content": "flex-end"})
         self.out_status = widgets.Output(layout={"border": "1px solid black"})
 
+        # Wire callbacks
         self.alg_mode_dropdown.observe(self.change_alg_mode_dropdown, names="value")
         self.modules_dropdown.observe(self.change_modules_dropdown, names="value")
         self.btn_help_node.on_click(self.click_node_help)

--- a/ryven/ironflow/node_interface.py
+++ b/ryven/ironflow/node_interface.py
@@ -166,3 +166,5 @@ class NodeInterface:
                 self.gui_object()
                 self.input_widgets()
                 display(self.draw())  # PyCharm nit is invalid, display takes *args is why it claims to want a tuple
+            else:
+                display(None)

--- a/ryven/ironflow/node_interface.py
+++ b/ryven/ironflow/node_interface.py
@@ -118,13 +118,11 @@ class NodeInterface:
             self._central_gui.flow_canvas.redraw()
         return input_change
 
-    def draw(self) -> widgets.HBox:
+    def draw(self) -> widgets.VBox:
         self.inp_box = widgets.GridBox(
             list(np.array(self._input).flatten()),
             layout=widgets.Layout(
-                width="210px",
-                grid_template_columns="90px 110px",
-                # grid_gap='1px 1px',
+                grid_template_columns="110px 50%",
                 border="solid 1px blue",
                 margin="10px",
             ),
@@ -159,7 +157,7 @@ class NodeInterface:
             padding="0px",
         )
 
-        return widgets.HBox([self.inp_box, self.gui, info_box])
+        return widgets.VBox([title, self.inp_box, info_box])  # self.gui
 
     def draw_for_node(self, node: Node | None):
         self.node = node

--- a/ryven/ironflow/node_interface.py
+++ b/ryven/ironflow/node_interface.py
@@ -63,20 +63,14 @@ class NodeInterface:
         if not hasattr(self.node, "inputs"):
             return
         for i_c, inp in enumerate(self.node.inputs[:]):
-            if inp.dtype is None:
-                # if inp.type_ == 'exec':
-                inp_widget = widgets.Label(value=inp.type_)
-                description = inp.type_
-                # inp_widget =
-            else:
+            if inp.dtype is not None:
                 dtype = str(inp.dtype).split(".")[-1]
                 dtype_state = deserialize(inp.data()["dtype state"])
                 if inp.val is None:
                     inp.val = dtype_state["val"]
-                # print (dtype)
                 if dtype == "Integer":
                     inp_widget = widgets.IntText(
-                        value=inp.val,  # dtype_state['val'],
+                        value=inp.val,
                         disabled=False,
                         description="",
                         continuous_update=False,
@@ -84,7 +78,7 @@ class NodeInterface:
                     )
                 elif dtype == "Boolean":
                     inp_widget = widgets.Checkbox(
-                        value=inp.val,  # dtype_state['val'],
+                        value=inp.val,
                         indent=True,
                         description="",
                         layout=widgets.Layout(width="110px", border="solid 1px"),
@@ -103,8 +97,13 @@ class NodeInterface:
                         value=str(inp.val),
                         continuous_update=False,
                     )
-
                 description = inp.label_str
+            elif inp.label_str != "":
+                inp_widget = widgets.Label(value=inp.type_)
+                description = inp.label_str
+            else:
+                inp_widget = widgets.Label(value=inp.type_)
+                description = inp.type_
             self._input.append([widgets.Label(description), inp_widget])
 
             inp_widget.observe(self.input_change_i(i_c), names="value")


### PR DESCRIPTION
I felt like the canvas was a little crowded and the representation plots were uselessly small, so here I moved the representation plot down to sit next to the node interface (where you enter values manually and stuff). I also did some tuning so these are persistent and take up 50% of the width each.

The only thing I'm still not happy with is that when there's lots of input ports, the input interface truncates itself and you have to scroll to see them all. I've been playing around and reading up on the CSS flags, but didn't manage to get it working. It's pretty minor so for now I'm just going to go ahead with the PR and will adjust that later.