### PR TITLE
Filter directly by class, no presence of an attribute

### DIFF
--- a/ryven/ironflow/flow_canvas.py
+++ b/ryven/ironflow/flow_canvas.py
@@ -113,7 +113,7 @@ class FlowCanvas:
         for n in self.objects_to_draw:
             self._object_to_gui_dict[n.node] = n
             for p in n.objects_to_draw:
-                if hasattr(p, "port"):
+                if isinstance(p, PortWidget):
                     self._object_to_gui_dict[p.port] = p
 
     def canvas_restart(self) -> None:


### PR DESCRIPTION
Closes #57.

The problem was that the flow canvas was getting exec buttons added to its `_object_to_gui_dict` because these buttons had a `port` attribute. Switching the attribute check to an explicit check that the tested object is a `PortWidget` resolves everything.