### PR TITLE
Delegate representation output to a new class

### DIFF
--- a/ryven/ironflow/canvas_widgets.py
+++ b/ryven/ironflow/canvas_widgets.py
@@ -544,16 +544,17 @@ class DisplayButtonWidget(ButtonWidget):
         super().__init__(x, y, parent, layout, selected, title=title)
 
     def on_pressed(self):
-        self.parent.set_display()
+        self.gui.node_presenter.node_widget = self.parent
 
     def on_unpressed(self):
-        self.parent.clear_display()
+        self.gui.node_presenter.node_widget = None
 
 
 class DisplayableNodeWidget(NodeWidget):
     """
-    Has a `Display` button that sends a representation over to the `ryven.ironflow.Gui.GUI.out_plot` window.
-    Display gets locked until the button is pressed again, or another node gets displayed.
+    Has a `SHOW` button that sends a representation over to the `ryven.ironflow.Gui.GUI.node_presenter.output`
+    window.
+    Display gets locked until the button is pressed again, the node is deleted, or another node gets displayed.
     While displayed, display updates automatically on changes to input.
     """
 
@@ -589,34 +590,9 @@ class DisplayableNodeWidget(NodeWidget):
         )
         self.add_widget(self.display_button)
 
-    def set_display(self):
-        if self.gui.displayed_node is not None:
-            self.gui.displayed_node.display_button.unpress()
-        self.node.displayed = True
-        self.node.representation_updated = True
-        self.gui.displayed_node = self
-
-    def clear_display(self):
-        self.node.displayed = False
-        if self.gui.displayed_node == self:
-            self.gui.out_plot.clear_output()
-            self.gui.displayed_node = None
-
-    def draw_display(self):
-        """Send the node's representation to a separate GUI window"""
-        self.parent.gui.out_plot.clear_output()
-        with self.parent.gui.out_plot:
-            for rep in self.node.representations:
-                display(rep)
-        self.node.representation_updated = False
-
-    def draw(self):
-        super().draw()
-        if self.node.displayed and self.node.representation_updated:
-            self.draw_display()
-
     def delete(self) -> None:
-        self.clear_display()
+        if self.gui.node_presenter.node_widget == self:
+            self.gui.node_presenter.node_widget = None
         return super().delete()
 
 

--- a/ryven/ironflow/canvas_widgets.py
+++ b/ryven/ironflow/canvas_widgets.py
@@ -531,12 +531,12 @@ class ButtonWidget(CanvasWidget, ABC):
         self.canvas.fill_text(self.title, x, y)
 
 
-class DisplayButtonWidget(ButtonWidget):
+class RepresentButtonWidget(ButtonWidget):
     def __init__(
             self,
             x: Number,
             y: Number,
-            parent: DisplayableNodeWidget,
+            parent: RepresentableNodeWidget,
             layout: ButtonLayout,
             selected: bool = False,
             title="SHOW",
@@ -550,7 +550,7 @@ class DisplayButtonWidget(ButtonWidget):
         self.gui.node_presenter.node_widget = None
 
 
-class DisplayableNodeWidget(NodeWidget):
+class RepresentableNodeWidget(NodeWidget):
     """
     Has a `SHOW` button that sends a representation over to the `ryven.ironflow.Gui.GUI.node_presenter.output`
     window.
@@ -582,13 +582,13 @@ class DisplayableNodeWidget(NodeWidget):
 
         button_layout = ButtonLayout()
         button_edge_offset = 5
-        self.display_button = DisplayButtonWidget(
+        self.represent_button = RepresentButtonWidget(
             x=self.width - button_layout.width - button_edge_offset,
             y=button_edge_offset,
             parent=self,
             layout=button_layout
         )
-        self.add_widget(self.display_button)
+        self.add_widget(self.represent_button)
 
     def delete(self) -> None:
         if self.gui.node_presenter.node_widget == self:

--- a/ryven/ironflow/flow_canvas.py
+++ b/ryven/ironflow/flow_canvas.py
@@ -8,7 +8,7 @@ from ipycanvas import Canvas, hold_canvas
 from time import time
 
 from ryven.ironflow.canvas_widgets import (
-    NodeWidget, PortWidget, CanvasWidget, ButtonNodeWidget, DisplayableNodeWidget, DisplayButtonWidget
+    NodeWidget, PortWidget, CanvasWidget, ButtonNodeWidget, RepresentableNodeWidget, RepresentButtonWidget
 )
 from ryven.ironflow.layouts import NodeLayout
 

--- a/ryven/ironflow/flow_canvas.py
+++ b/ryven/ironflow/flow_canvas.py
@@ -188,6 +188,7 @@ class FlowCanvas:
             [o.draw() for o in self.objects_to_draw]
             for c in self.flow.connections:
                 self.draw_connection(c.inp, c.out)
+        self.gui.node_presenter.draw()
 
     def load_node(self, x: Number, y: Number, node: Node) -> NodeWidget:
         layout = NodeLayout()

--- a/ryven/ironflow/gui.py
+++ b/ryven/ironflow/gui.py
@@ -19,6 +19,7 @@ import ipywidgets as widgets
 from IPython.display import display, HTML
 from ryven.ironflow.models import HasSession
 from ryven.ironflow.node_interface import NodeInterface
+from ryven.ironflow.representation import NodePresenter
 from ryven.ironflow.flow_canvas import FlowCanvas
 
 from typing import Optional
@@ -35,6 +36,7 @@ class GUI(HasSession):
         self._flow_canvases = []
         self.displayed_node = None
         self.node_interface = NodeInterface(self)
+        self.node_presenter = NodePresenter(self)
 
         self._context = None
         self._context_actions = {
@@ -184,8 +186,8 @@ class GUI(HasSession):
         self._update_tabs_from_model()
 
         self.out_log = widgets.Output(layout={"border": "1px solid black"})
-        self.out_plot = widgets.Output(layout={"width": "50%", "border": "1px solid black"})
         self.out_status = widgets.Output(layout={"width": "50%", "border": "1px solid black"})
+        node_box = widgets.HBox([self.out_status, self.node_presenter.output])
 
         # Wire callbacks
         self.alg_mode_dropdown.observe(self.change_alg_mode_dropdown, names="value")
@@ -222,7 +224,7 @@ class GUI(HasSession):
                     [self.node_selector_box, self.script_tabs]
                 ),
                 self.out_log,
-                widgets.HBox([self.out_status, self.out_plot]),
+                node_box,
                 debug_view
             ]
         )
@@ -265,7 +267,7 @@ class GUI(HasSession):
     def _load_context_action(self, file_name):
         self.load(f"{file_name}.json")
         self._update_tabs_from_model()
-        self.out_plot.clear_output()
+        self.node_presenter.clear_output()
         self.out_log.clear_output()
         self._print(f"Session loaded from {file_name}.json")
 

--- a/ryven/ironflow/representation.py
+++ b/ryven/ironflow/representation.py
@@ -1,0 +1,63 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+from __future__ import annotations
+
+import ipywidgets as widgets
+from IPython.display import display
+
+from typing import TYPE_CHECKING, Optional
+if TYPE_CHECKING:
+    from ironflow.ryven.ironflow.gui import GUI
+    from ironflow.ryven.ironflow.canvas_widgets import DisplayableNodeWidget
+
+__author__ = "Liam huber"
+__copyright__ = (
+    "Copyright 2022, Max-Planck-Institut für Eisenforschung GmbH - "
+    "Computational Materials Design (CM) Department"
+)
+__version__ = "0.1"
+__maintainer__ = "Liam Huber"
+__email__ = "liamhuber@greyhavensolutions.com"
+__status__ = "production"
+__date__ = "Sept 20, 2022"
+
+
+class NodePresenter:
+
+    def __init__(self, gui: GUI, layout: Optional[dict] = None):
+        self.gui = gui
+        self.layout = layout if layout is not None else {"width": "50%", "border": "1px solid black"}
+        self._node_widget = None
+        self._output = None
+
+    @property
+    def output(self) -> widgets.Output:
+        if self._output is None:
+            self._output = widgets.Output(layout=self.layout)
+        return self._output
+
+    @property
+    def node_widget(self) -> DisplayableNodeWidget | None:
+        return self._node_widget
+
+    @node_widget.setter
+    def node_widget(self, new_node_widget: DisplayableNodeWidget | None):
+        if self._node_widget is not None:
+            self.clear_output()
+            self._node_widget.display_button.pressed = False
+        if new_node_widget is not None:
+            new_node_widget.node.representation_updated = True
+        self._node_widget = new_node_widget
+
+    def clear_output(self):
+        self.output.clear_output()
+
+    def draw(self):
+        if self.node_widget is not None and self.node_widget.node.representation_updated:
+            self.clear_output()
+            with self.output:
+                for rep in self.node_widget.node.representations:
+                    display(rep)
+            self.node_widget.node.representation_updated = False

--- a/ryven/ironflow/representation.py
+++ b/ryven/ironflow/representation.py
@@ -25,6 +25,7 @@ __date__ = "Sept 20, 2022"
 
 
 class NodePresenter:
+    """Handles the display of nodes with a representation."""
 
     def __init__(self, gui: GUI, layout: Optional[dict] = None):
         self.gui = gui

--- a/ryven/ironflow/representation.py
+++ b/ryven/ironflow/representation.py
@@ -10,7 +10,7 @@ from IPython.display import display
 from typing import TYPE_CHECKING, Optional
 if TYPE_CHECKING:
     from ironflow.ryven.ironflow.gui import GUI
-    from ironflow.ryven.ironflow.canvas_widgets import DisplayableNodeWidget
+    from ironflow.ryven.ironflow.canvas_widgets import RepresentableNodeWidget
 
 __author__ = "Liam huber"
 __copyright__ = (
@@ -39,14 +39,14 @@ class NodePresenter:
         return self._output
 
     @property
-    def node_widget(self) -> DisplayableNodeWidget | None:
+    def node_widget(self) -> RepresentableNodeWidget | None:
         return self._node_widget
 
     @node_widget.setter
-    def node_widget(self, new_node_widget: DisplayableNodeWidget | None):
+    def node_widget(self, new_node_widget: RepresentableNodeWidget | None):
         if self._node_widget is not None:
             self.clear_output()
-            self._node_widget.display_button.pressed = False
+            self._node_widget.represent_button.pressed = False
         if new_node_widget is not None:
             new_node_widget.node.representation_updated = True
         self._node_widget = new_node_widget

--- a/ryven/nodes/pyiron/atomistics_nodes.py
+++ b/ryven/nodes/pyiron/atomistics_nodes.py
@@ -7,7 +7,7 @@ import numpy as np
 from pyiron_atomistics import Project
 from pyiron_atomistics.lammps import list_potentials
 from ryven.NENV import Node, NodeInputBP, NodeOutputBP, dtypes
-from ryven.ironflow.canvas_widgets import DisplayableNodeWidget, ButtonNodeWidget
+from ryven.ironflow.canvas_widgets import RepresentableNodeWidget, ButtonNodeWidget
 
 from abc import ABC, abstractmethod
 from ryven.nodes.std.special_nodes import DualNodeBase
@@ -35,7 +35,7 @@ class NodeBase(Node):
 
 
 class NodeWithDisplay(NodeBase, ABC):
-    main_widget_class = DisplayableNodeWidget
+    main_widget_class = RepresentableNodeWidget
 
     def __init__(self, params):
         super().__init__(params)


### PR DESCRIPTION
Handling of the `out_plot` is now delegated to a new class. Simplifies the node widget that handles nodes with a representation, as well as the main gui.