### PR TITLE
Richer representation

### DIFF
--- a/ryven/ironflow/canvas_widgets/buttons.py
+++ b/ryven/ironflow/canvas_widgets/buttons.py
@@ -56,6 +56,13 @@ class ButtonWidget(CanvasWidget, ABC):
     def press(self):
         self.pressed = True
         self.on_pressed()
+        # Ok, now here is a weird hack:
+        self.gui.node_controller.draw()
+        # This way, if a button causes some change in node-state, it gets reflected in the node_controller,
+        # e.g. if we `run` or `remove` some job, but a nodestream node is taking that job as input.
+        # Performance and usability hits are minimal, but from a maintenance perspective it is super bad, confusing,
+        # and hard to maintain, so it would be much nicer in the future to find a way to hook the node_controller right
+        #  onto input updates on the nodes
 
     def unpress(self):
         self.pressed = False

--- a/ryven/ironflow/node_interface/control.py
+++ b/ryven/ironflow/node_interface/control.py
@@ -106,8 +106,9 @@ class NodeController(NodeInterfaceBase):
 
     def input_change_i(self, i_c) -> Callable:
         def input_change(change: dict) -> None:
+            # TODO: Test this in exec mode
             self.node.inputs[i_c].val = change["new"]
-            self.node.update_event()
+            self.node.update(i_c)
             self.gui.flow_canvas.redraw()
         return input_change
 

--- a/ryven/ironflow/node_interface/representation.py
+++ b/ryven/ironflow/node_interface/representation.py
@@ -31,8 +31,8 @@ class NodePresenter(NodeInterfaceBase):
     def __init__(self, gui: GUI, layout: Optional[dict] = None):
         super().__init__(gui=gui, layout=layout)
         self._node_widget = None
-        self._widgets = None
-        self._toggles = None
+        self._widgets = []
+        self._toggles = []
 
     @property
     def node_widget(self) -> RepresentableNodeWidget | None:
@@ -51,8 +51,8 @@ class NodePresenter(NodeInterfaceBase):
             self._toggles = self._build_toggles(new_node_widget.node.representations)
         else:
             self._node_widget = None
-            self._widgets = None
-            self._toggles = None
+            self._widgets = []
+            self._toggles = []
 
     @staticmethod
     def _build_widgets(representations: dict) -> list[widgets.Output]:
@@ -96,3 +96,8 @@ class NodePresenter(NodeInterfaceBase):
         if self.node_widget is not None and self.node_widget.node.representation_updated:
             self._draw()
             self.node_widget.node.representation_updated = False
+
+    def clear_output(self):
+        for w in self._widgets:
+            w.clear_output()
+        super().clear_output()

--- a/ryven/ironflow/node_interface/representation.py
+++ b/ryven/ironflow/node_interface/representation.py
@@ -6,8 +6,9 @@ from __future__ import annotations
 
 from ryven.ironflow.node_interface.base import NodeInterfaceBase
 from IPython.display import display
+import ipywidgets as widgets
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Callable
 if TYPE_CHECKING:
     from ryven.ironflow.gui import GUI
     from ryven.ironflow.canvas_widgets.nodes import RepresentableNodeWidget
@@ -30,6 +31,8 @@ class NodePresenter(NodeInterfaceBase):
     def __init__(self, gui: GUI, layout: Optional[dict] = None):
         super().__init__(gui=gui, layout=layout)
         self._node_widget = None
+        self._widgets = None
+        self._toggles = None
 
     @property
     def node_widget(self) -> RepresentableNodeWidget | None:
@@ -40,14 +43,56 @@ class NodePresenter(NodeInterfaceBase):
         if self._node_widget is not None:
             self.clear_output()
             self._node_widget.represent_button.pressed = False
+
         if new_node_widget is not None:
             new_node_widget.node.representation_updated = True
-        self._node_widget = new_node_widget
+            self._node_widget = new_node_widget
+            self._widgets = self._build_widgets(new_node_widget.node.representations)
+            self._toggles = self._build_toggles(new_node_widget.node.representations)
+        else:
+            self._node_widget = None
+            self._widgets = None
+            self._toggles = None
+
+    @staticmethod
+    def _build_widgets(representations: dict) -> list[widgets.Output]:
+        return [widgets.Output(layout={"border": "solid 1px gray"}) for _ in representations]
+
+    def _build_toggles(self, representations: dict) -> list[widgets.Checkbox]:
+        toggles = []
+        for i, label in enumerate(representations.keys()):
+            toggle = widgets.Checkbox(description=label, value=i == 0)
+            toggle.observe(self._on_toggle)
+            toggles.append(toggle)
+        return toggles
+
+    def _on_toggle(self, change: dict) -> None:
+        if change['name'] == 'value':
+            self._draw()
+
+    def _draw(self):
+        self.clear_output()
+
+        representations = []
+        for (toggle, widget, representation) in zip(
+                self._toggles,
+                self._widgets,
+                self.node_widget.node.representations.values()
+        ):
+            if toggle.value:
+                with widget:
+                    display(representation)
+                representations.append(widget)
+
+        with self.output:
+            display(
+                widgets.VBox([
+                    widgets.HBox(self._toggles),
+                    *representations
+                ])
+            )
 
     def draw(self):
         if self.node_widget is not None and self.node_widget.node.representation_updated:
-            self.clear_output()
-            with self.output:
-                for rep in self.node_widget.node.representations:
-                    display(rep)
+            self._draw()
             self.node_widget.node.representation_updated = False

--- a/ryven/nodes/pyiron/atomistics_nodes.py
+++ b/ryven/nodes/pyiron/atomistics_nodes.py
@@ -49,10 +49,8 @@ class NodeWithRepresentation(NodeBase, ABC):
 
     def __init__(self, params):
         super().__init__(params)
-        self._representation = None
         self.representation_updated = False
         self._call_after_update.append(self._representation_update)
-        self.displayed = False
 
     def _representation_update(self, inp):
         self.representation_updated = True

--- a/ryven/nodes/pyiron/atomistics_nodes.py
+++ b/ryven/nodes/pyiron/atomistics_nodes.py
@@ -49,7 +49,7 @@ class NodeWithDisplay(NodeBase, ABC):
     @property
     def representations(self) -> dict:
         return {
-            o.label_str if o.label_str != "" else i: o.val for i, o in enumerate(self.outputs)
+            o.label_str if o.label_str != "" else f"output{i}": o.val for i, o in enumerate(self.outputs)
         }
 
     def output(self, i):

--- a/ryven/nodes/pyiron/atomistics_nodes.py
+++ b/ryven/nodes/pyiron/atomistics_nodes.py
@@ -34,7 +34,7 @@ class NodeBase(Node):
     # here we could add some stuff for all nodes below...
 
 
-class NodeWithDisplay(NodeBase, ABC):
+class NodeWithRepresentation(NodeBase, ABC):
     main_widget_class = RepresentableNodeWidget
 
     def __init__(self, params):
@@ -56,7 +56,7 @@ class NodeWithDisplay(NodeBase, ABC):
         return self.outputs[i].val
 
 
-class Project_Node(NodeWithDisplay):
+class Project_Node(NodeWithRepresentation):
     """Create a pyiron project node"""
 
     # this __doc__ string will be displayed as tooltip in the editor
@@ -83,7 +83,7 @@ class Project_Node(NodeWithDisplay):
         return {"name": str(self.input(0))}
 
 
-class OutputsOnlyAtoms(NodeWithDisplay, ABC):
+class OutputsOnlyAtoms(NodeWithRepresentation, ABC):
     init_outputs = [
         NodeOutputBP(),
     ]
@@ -161,7 +161,7 @@ class ApplyStrain_Node(OutputsOnlyAtoms):
         self.set_output_val(0, self.input(0).apply_strain(float(self.input(1)), return_box=True))
 
 
-class Lammps_Node(NodeWithDisplay):
+class Lammps_Node(NodeWithRepresentation):
     title = "Lammps"
     version = "v0.1"
     init_inputs = [
@@ -242,7 +242,7 @@ class Lammps_Node(NodeWithDisplay):
         return {"job": self.output(1)}
 
 
-class GenericOutput_Node(NodeWithDisplay):
+class GenericOutput_Node(NodeWithRepresentation):
     """Select Generic Output item"""
 
     version = "v0.1"
@@ -271,7 +271,7 @@ class GenericOutput_Node(NodeWithDisplay):
         self.set_output_val(0, val)
 
 
-class IntRand_Node(NodeWithDisplay):
+class IntRand_Node(NodeWithRepresentation):
     """Generate a random number in a given range"""
 
     # this __doc__ string will be displayed as tooltip in the editor
@@ -292,7 +292,7 @@ class IntRand_Node(NodeWithDisplay):
         self.set_output_val(0, val)
 
 
-class JobName_Node(NodeWithDisplay):
+class JobName_Node(NodeWithRepresentation):
     """Create job name for parameters"""
 
     title = "JobName"
@@ -313,7 +313,7 @@ class JobName_Node(NodeWithDisplay):
         self.set_output_val(0, val)
 
 
-class Linspace_Node(NodeWithDisplay):
+class Linspace_Node(NodeWithRepresentation):
     """Generate a linear mesh in a given range using np.linspace"""
 
     # this __doc__ string will be displayed as tooltip in the editor
@@ -339,7 +339,7 @@ class Linspace_Node(NodeWithDisplay):
         self.set_output_val(0, val)
 
 
-class Plot3d_Node(NodeWithDisplay):
+class Plot3d_Node(NodeWithRepresentation):
     title = "Plot3d"
     version = "v0.1"
     init_inputs = [
@@ -365,7 +365,7 @@ class Plot3d_Node(NodeWithDisplay):
             return {"plot3d": self.output(0)}
 
 
-class Matplot_Node(NodeWithDisplay):
+class Matplot_Node(NodeWithRepresentation):
     title = "MatPlot"
     version = "v0.1"
     init_inputs = [
@@ -387,7 +387,7 @@ class Matplot_Node(NodeWithDisplay):
         plt.ion()
 
 
-class Sin_Node(NodeWithDisplay):
+class Sin_Node(NodeWithRepresentation):
     title = "Sin"
     version = "v0.1"
     init_inputs = [

--- a/ryven/nodes/pyiron/atomistics_nodes.py
+++ b/ryven/nodes/pyiron/atomistics_nodes.py
@@ -47,8 +47,10 @@ class NodeWithDisplay(NodeBase, ABC):
         self.representation_updated = True
 
     @property
-    def representations(self) -> tuple:
-        return tuple(o.val for o in self.outputs)
+    def representations(self) -> dict:
+        return {
+            o.label_str if o.label_str != "" else i: o.val for i, o in enumerate(self.outputs)
+        }
 
     def output(self, i):
         return self.outputs[i].val
@@ -77,8 +79,8 @@ class Project_Node(NodeWithDisplay):
         self.set_output_val(0, pr)
 
     @property
-    def representations(self) -> tuple:
-        return str(self.input(0)),
+    def representations(self) -> dict:
+        return {"name": str(self.input(0))}
 
 
 class OutputsOnlyAtoms(NodeWithDisplay, ABC):
@@ -93,8 +95,11 @@ class OutputsOnlyAtoms(NodeWithDisplay, ABC):
         super().update_event(inp=inp)
 
     @property
-    def representations(self) -> tuple:
-        return self.output(0).plot3d(), self.output(0)
+    def representations(self) -> dict:
+        return {
+            "plot3d": self.output(0).plot3d(),
+            "print": self.output(0)
+        }
 
 
 class BulkStructure_Node(OutputsOnlyAtoms):
@@ -233,8 +238,8 @@ class Lammps_Node(NodeWithDisplay):
 
 
     @property
-    def representations(self) -> tuple:
-        return self.output(1),
+    def representations(self) -> dict:
+        return {"job": self.output(1)}
 
 
 class GenericOutput_Node(NodeWithDisplay):
@@ -353,11 +358,11 @@ class Plot3d_Node(NodeWithDisplay):
         self.set_output_val(1, self.input(0))
 
     @property
-    def representations(self) -> tuple:
+    def representations(self) -> dict:
         if self.input(1):
-            return self.output(0), self.output(1)
+            return {"plot3d": self.output(0), "print": self.output(1)}
         else:
-            return self.output(0),
+            return {"plot3d": self.output(0)}
 
 
 class Matplot_Node(NodeWithDisplay):

--- a/ryven/nodes/pyiron/atomistics_nodes.py
+++ b/ryven/nodes/pyiron/atomistics_nodes.py
@@ -59,7 +59,8 @@ class NodeWithRepresentation(NodeBase, ABC):
     @property
     def representations(self) -> dict:
         return {
-            o.label_str if o.label_str != "" else f"output{i}": o.val for i, o in enumerate(self.outputs)
+            o.label_str if o.label_str != "" else f"output{i}": o.val
+            for i, o in enumerate(self.outputs) if o.type_ == "data"
         }
 
 

--- a/ryven/nodes/pyiron/atomistics_nodes.py
+++ b/ryven/nodes/pyiron/atomistics_nodes.py
@@ -72,7 +72,7 @@ class Project_Node(NodeWithRepresentation):
         NodeInputBP(dtype=dtypes.Char(default="."), label="name"),
     ]
     init_outputs = [
-        NodeOutputBP(),
+        NodeOutputBP(label="project"),
     ]
     color = "#aabb44"
 
@@ -90,7 +90,7 @@ class Project_Node(NodeWithRepresentation):
 
 class OutputsOnlyAtoms(NodeWithRepresentation, ABC):
     init_outputs = [
-        NodeOutputBP(),
+        NodeOutputBP(label="structure"),
     ]
     color = "#aabb44"
 
@@ -178,7 +178,7 @@ class Lammps_Node(NodeWithRepresentation):
     ]
     init_outputs = [
         NodeOutputBP(type_="exec"),
-        NodeOutputBP(),
+        NodeOutputBP(label="job"),
     ]
     color = "#5d95de"
 
@@ -238,11 +238,6 @@ class Lammps_Node(NodeWithRepresentation):
             self._update_potential_choices()
 
 
-    @property
-    def representations(self) -> dict:
-        return {"job": self.output(1)}
-
-
 class GenericOutput_Node(NodeWithRepresentation):
     """Select Generic Output item"""
 
@@ -254,11 +249,11 @@ class GenericOutput_Node(NodeWithRepresentation):
             dtype=dtypes.Choice(
                 default="energy_tot", items=["energy_tot", "energy_pot"]
             ),
-            label="Var",
+            label="field",
         ),
     ]
     init_outputs = [
-        NodeOutputBP(),
+        NodeOutputBP(label="output"),
     ]
     color = "#c69a15"
 
@@ -282,7 +277,7 @@ class IntRand_Node(NodeWithRepresentation):
         NodeInputBP(dtype=dtypes.Integer(default=1, bounds=(1, 100)), label="length"),
     ]
     init_outputs = [
-        NodeOutputBP(),
+        NodeOutputBP(label="randint"),
     ]
     color = "#aabb44"
 
@@ -300,7 +295,7 @@ class JobName_Node(NodeWithRepresentation):
         NodeInputBP(dtype=dtypes.Float(default=0), label="float"),
     ]
     init_outputs = [
-        NodeOutputBP(),
+        NodeOutputBP(label="job name"),
     ]
     color = "#aabb44"
 
@@ -323,7 +318,7 @@ class Linspace_Node(NodeWithRepresentation):
         NodeInputBP(dtype=dtypes.Integer(default=10, bounds=(1, 100)), label="steps"),
     ]
     init_outputs = [
-        NodeOutputBP(),
+        NodeOutputBP(label="linspace"),
     ]
     color = "#aabb44"
 
@@ -342,18 +337,14 @@ class Plot3d_Node(NodeWithRepresentation):
         NodeInputBP(dtype=dtypes.Data(size="m"), label="structure"),
     ]
     init_outputs = [
-        NodeOutputBP(type_="data"),
-        NodeOutputBP(type_="data"),
+        NodeOutputBP(type_="data", label="plot3d"),
+        NodeOutputBP(type_="data", label="structure"),
     ]
     color = "#5d95de"
 
     def update_event(self, inp=-1):
         self.set_output_val(0, self.input(0).plot3d())
         self.set_output_val(1, self.input(0))
-
-    @property
-    def representations(self) -> dict:
-        return {"plot3d": self.output(0), "print": self.output(1)}
 
 
 class Matplot_Node(NodeWithRepresentation):
@@ -364,7 +355,7 @@ class Matplot_Node(NodeWithRepresentation):
         NodeInputBP(dtype=dtypes.Data(size="m"), label="y"),
     ]
     init_outputs = [
-        NodeOutputBP(type_="data"),
+        NodeOutputBP(type_="data", label="fig"),
     ]
     color = "#5d95de"
 
@@ -385,7 +376,7 @@ class Sin_Node(NodeWithRepresentation):
         NodeInputBP(dtype=dtypes.Data(size="m")),
     ]
     init_outputs = [
-        NodeOutputBP(),
+        NodeOutputBP(label="sin"),
     ]
     color = "#5d95de"
 
@@ -429,9 +420,9 @@ class ForEach_Node(NodeBase):
         NodeInputBP(dtype=dtypes.List(), label="elements"),
     ]
     init_outputs = [
-        NodeOutputBP("loop", type_="exec"),
-        NodeOutputBP("e", type_="data"),
-        NodeOutputBP("finished", type_="exec"),
+        NodeOutputBP(label="loop", type_="exec"),
+        NodeOutputBP(label="e", type_="data"),
+        NodeOutputBP(label="finished", type_="exec"),
     ]
     color = '#b33a27'
 

--- a/ryven/nodes/pyiron/atomistics_nodes.py
+++ b/ryven/nodes/pyiron/atomistics_nodes.py
@@ -340,7 +340,6 @@ class Plot3d_Node(NodeWithRepresentation):
     version = "v0.1"
     init_inputs = [
         NodeInputBP(dtype=dtypes.Data(size="m"), label="structure"),
-        NodeInputBP(dtype=dtypes.Boolean(default=False), label="print")
     ]
     init_outputs = [
         NodeOutputBP(type_="data"),
@@ -354,10 +353,7 @@ class Plot3d_Node(NodeWithRepresentation):
 
     @property
     def representations(self) -> dict:
-        if self.input(1):
-            return {"plot3d": self.output(0), "print": self.output(1)}
-        else:
-            return {"plot3d": self.output(0)}
+        return {"plot3d": self.output(0), "print": self.output(1)}
 
 
 class Matplot_Node(NodeWithRepresentation):


### PR DESCRIPTION
Nodes with a representation now use a dictionary for their representations, which is auto-populated by the output (including labels) if not explicitly provided. Meanwhile, the `NodePresenter` shows only the 0th of these representations by default, and other representations can be turned on and off by toggle.

Under the hood there was some refactoring, and the `GenericOutput_Node` has a slightly nicer control interface.

Because a bunch of IO labels were changed on the nodes, saved sessions are missing the new labelling features. Here is an updated session: 
[test.json.zip](https://github.com/pyiron/ironflow/files/9629638/test.json.zip)

This gives all the infrastructure for closing #56, which just now needs individual nodes to have fancier representations.
