### PR TITLE
Session management

### DIFF
--- a/ironflow/ironflow/gui.py
+++ b/ironflow/ironflow/gui.py
@@ -40,7 +40,8 @@ class GUI(HasSession):
         Args:
             session_title (str): Title of the session to use. Will look for a json file of the same name and try to
                 read it. If no such file exists, simply makes a new script instead.
-            script_title (str|None): Title for an initial script. (Default is None, which generates "script_0".)
+            script_title (str|None): Title for an initial script. (Default is None, which generates "script_0" if a 
+                new script is needed on initialization, i.e. when existing session data cannot be read.)
         """
         super().__init__(session_title=session_title)
 

--- a/ironflow/ironflow/gui.py
+++ b/ironflow/ironflow/gui.py
@@ -38,7 +38,8 @@ class GUI(HasSession):
         Create a new gui instance.
 
         Args:
-            session_title (str): Title of the session to use. Only impacts QoL stuff for saving/loading sessions.
+            session_title (str): Title of the session to use. Will look for a json file of the same name and try to
+                read it. If no such file exists, simply makes a new script instead.
             session (ryvencore.Session|None): Ryven session to connect to. (Default is None, which starts a new
                 session.)
             script_title (str|None): Title for an initial script. (Default is None, which generates "script_0".)
@@ -53,7 +54,12 @@ class GUI(HasSession):
         self.input = UserInput()
         self.flow_box = FlowBox(self._nodes_dict)
 
-        self.create_script(script_title)
+        try:
+            self.load(f"{self.session_title}.json")
+            print(f"Loaded session data for {self.session_title}")
+        except FileNotFoundError:
+            print(f"No session data found for {self.session_title}, making a new script.")
+            self.create_script(script_title)
         self.update_tabs()
 
     def create_script(

--- a/ironflow/ironflow/gui.py
+++ b/ironflow/ironflow/gui.py
@@ -17,7 +17,6 @@ from ironflow.ironflow.canvas_widgets import FlowCanvas
 from ironflow.ironflow.model import HasSession
 
 if TYPE_CHECKING:
-    from ryvencore import Session
     from ironflow.NENV import Node
     from ironflow.ironflow.canvas_widgets.nodes import NodeWidget
 

--- a/ironflow/ironflow/gui.py
+++ b/ironflow/ironflow/gui.py
@@ -33,18 +33,16 @@ class GUI(HasSession):
         register_user_node: Register with ironflow a new node from the current python process.
     """
 
-    def __init__(self, session_title: str, session: Optional[Session] = None, script_title: Optional[str] = None):
+    def __init__(self, session_title: str, script_title: Optional[str] = None):
         """
         Create a new gui instance.
 
         Args:
             session_title (str): Title of the session to use. Will look for a json file of the same name and try to
                 read it. If no such file exists, simply makes a new script instead.
-            session (ryvencore.Session|None): Ryven session to connect to. (Default is None, which starts a new
-                session.)
             script_title (str|None): Title for an initial script. (Default is None, which generates "script_0".)
         """
-        super().__init__(session_title=session_title, session=session)
+        super().__init__(session_title=session_title)
 
         self.flow_canvases = []
         self.toolbar = Toolbar()

--- a/ironflow/ironflow/model.py
+++ b/ironflow/ironflow/model.py
@@ -33,8 +33,8 @@ packages = [os.path.join(ryven_location, "nodes", *subloc) for subloc in [
 class HasSession(ABC):
     """Mixin for an object which has a Ryven session as the underlying model"""
 
-    def __init__(self, session_title: str, session: Optional[Session] = None):
-        self._session = session if session is not None else Session()
+    def __init__(self, session_title: str):
+        self._session = Session()
         self.session_title = session_title
         self._active_script_index = 0
 


### PR DESCRIPTION
QoL change: uses the GUI's `session_title` to try and automatically load saved session data. If it fails, only then create a blank script.

Also got rid of `ryvencore.Session` argument for the gui -- I don't currently see a need for two GUI instances to ever share a session.