### PR TITLE
Debug mybinder behaviour

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,10 +2,10 @@ channels:
 - conda-forge
 dependencies:
 - python >= 3.7
-- jupyterlab=3
 - ipycanvas
 - ipython
 - ipywidgets
+- lammps
 - matplotlib
 - nglview
 - numpy

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,6 @@ dependencies:
 - python >= 3.7
 - ipycanvas
 - ipython
-- ipywidgets
 - lammps
 - matplotlib
 - nglview

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,8 @@ channels:
 - conda-forge
 dependencies:
 - python >= 3.7
-- ipycanvas == 0.12.0
+- jupyterlab=3
+- ipycanvas
 - ipython
 - ipywidgets
 - matplotlib

--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ dependencies:
 - python >= 3.7
 - ipycanvas
 - ipython
+- ipywidgets == 7.*
 - lammps
 - matplotlib
 - nglview


### PR DESCRIPTION
Re #74.

I am still getting a javascript error, but `ipycanvas.Canvas()` works fine over on [their repo], and I [made a MWE]() where it also works fine. The two big differences I can see now are:
- ipycanvas automatically installs ipywidgets 7.7.0, but my build has 8.0.2
- The two working mybinder environments have jupyterlab-manager v3, but my build has jupyterlab-manager v5

ipywidgets is also still back at v7 on my local machine (where everything is working fine) so let's try pinning that next. Neverymind, 8.0.2 works locally fine.