### PR TITLE
Blink on update

### DIFF
--- a/ironflow/ironflow/canvas_widgets/base.py
+++ b/ironflow/ironflow/canvas_widgets/base.py
@@ -100,8 +100,12 @@ class CanvasWidget(ABC):
         self._x += dx_in
         self._y += dy_in
 
+    @property
+    def color(self) -> str:
+        return self.layout.selected_color if self.selected else self.layout.background_color
+
     def draw_shape(self) -> None:
-        self.canvas.fill_style = self.layout.selected_color if self.selected else self.layout.background_color
+        self.canvas.fill_style = self.color
         self.canvas.fill_rect(
             self.x,
             self.y,

--- a/ironflow/ironflow/canvas_widgets/layouts.py
+++ b/ironflow/ironflow/canvas_widgets/layouts.py
@@ -32,6 +32,7 @@ class NodeLayout(Layout):
     height: int = 100
     font_size: int = 22
     title_box_height: int = 30
+    updating_color: str = "red"
 
 
 @dataclass

--- a/ironflow/ironflow/canvas_widgets/nodes.py
+++ b/ironflow/ironflow/canvas_widgets/nodes.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional
 
 import numpy as np
+from ipycanvas import hold_canvas
 
 from ironflow.ironflow.canvas_widgets.base import CanvasWidget
 from ironflow.ironflow.canvas_widgets.buttons import (
@@ -120,14 +121,15 @@ class NodeWidget(CanvasWidget):
 
     @staticmethod
     def _draw_before_updating(node: Node, inp: int) -> None:
-        node.widget.gui.print(f"Updating {node}")
         node.widget._updating = True
-        node.widget.draw()
+        with hold_canvas(node.widget.canvas):
+            node.widget.draw()
 
     @staticmethod
     def _draw_after_updating(node: Node, inp: int) -> None:
         node.widget._updating = False
-        node.widget.draw()
+        with hold_canvas(node.widget.canvas):
+            node.widget.draw()
 
     @property
     def color(self) -> str:

--- a/ironflow/ironflow/canvas_widgets/nodes.py
+++ b/ironflow/ironflow/canvas_widgets/nodes.py
@@ -49,6 +49,12 @@ class NodeWidget(CanvasWidget):
         self.inputs = node.inputs
         self.outputs = node.outputs
 
+        # Register callback to change color on updates
+        self.node.widget = self
+        self._updating = False
+        self.node.before_update.connect(self._draw_before_updating)
+        self.node.after_update.connect(self._draw_after_updating)
+
         self.port_radius = port_radius
         self.port_layouts = {
             'data': DataPortLayout(),
@@ -111,6 +117,26 @@ class NodeWidget(CanvasWidget):
     def on_double_click(self) -> None:
         self.delete()
         return None
+
+    @staticmethod
+    def _draw_before_updating(node: Node, inp: int) -> None:
+        node.widget.gui.print(f"Updating {node}")
+        node.widget._updating = True
+        node.widget.draw()
+
+    @staticmethod
+    def _draw_after_updating(node: Node, inp: int) -> None:
+        node.widget._updating = False
+        node.widget.draw()
+
+    @property
+    def color(self) -> str:
+        if self._updating:
+            return self.layout.updating_color
+        elif self.selected:
+            return self.layout.selected_color
+        else:
+            return self.layout.background_color
 
     def draw_title(self) -> None:
         self.canvas.fill_style = self.node.color

--- a/ironflow/nodes/pyiron/atomistics_nodes.py
+++ b/ironflow/nodes/pyiron/atomistics_nodes.py
@@ -73,9 +73,9 @@ class NodeBase(Node):
         self.after_update = Event(self, int)
 
     def update(self, inp=-1):
-        self.before_update.emit(inp)
+        self.before_update.emit(self, inp)
         super().update(inp=inp)
-        self.after_update.emit(inp)
+        self.after_update.emit(self, inp)
 
     def output(self, i):
         return self.outputs[i].val
@@ -93,6 +93,7 @@ class NodeWithRepresentation(NodeBase, ABC):
         self.representation_updated = False
         self.after_update.connect(self._representation_update)
 
+    @staticmethod
     def _representation_update(self, inp):
         self.representation_updated = True
 

--- a/ironflow/nodes/pyiron/atomistics_nodes.py
+++ b/ironflow/nodes/pyiron/atomistics_nodes.py
@@ -16,6 +16,7 @@ import numpy as np
 from pyiron_atomistics import Project
 from pyiron_atomistics.atomistics.job.atomistic import AtomisticGenericJob
 from pyiron_atomistics.lammps import list_potentials
+from ryvencore.Base import Event
 
 from ironflow.NENV import Node, NodeInputBP, NodeOutputBP, dtypes
 from ironflow.ironflow.canvas_widgets.nodes import RepresentableNodeWidget, ButtonNodeWidget
@@ -68,15 +69,11 @@ class NodeBase(Node):
 
     def __init__(self, params):
         super().__init__(params)
-        self._call_after_update = []
+        self.after_update = Event(self, int)
 
     def update(self, inp=-1):
         super().update(inp=inp)
-        self._after_update(inp)
-
-    def _after_update(self, inp: int):
-        for fnc in self._call_after_update:
-            fnc(inp)
+        self.after_update.emit(inp)
 
     def output(self, i):
         return self.outputs[i].val
@@ -92,7 +89,7 @@ class NodeWithRepresentation(NodeBase, ABC):
     def __init__(self, params):
         super().__init__(params)
         self.representation_updated = False
-        self._call_after_update.append(self._representation_update)
+        self.after_update.connect(self._representation_update)
 
     def _representation_update(self, inp):
         self.representation_updated = True

--- a/ironflow/nodes/pyiron/atomistics_nodes.py
+++ b/ironflow/nodes/pyiron/atomistics_nodes.py
@@ -69,9 +69,11 @@ class NodeBase(Node):
 
     def __init__(self, params):
         super().__init__(params)
+        self.before_update = Event(self, int)
         self.after_update = Event(self, int)
 
     def update(self, inp=-1):
+        self.before_update.emit(inp)
         super().update(inp=inp)
         self.after_update.emit(inp)
 


### PR DESCRIPTION
pyiron nodes now flash red while updating. 

I also exploit ryvencore's existing callback power with an `Event` on the node instead of my own `_call_after_update` list.

TODO:
- Because `NodeWidget` is now expecting nodes to have these events, but the event is placed on `ironflow.nodes.pyiron.atomistic_nodes.NodeBase`, *non*-pyiron nodes are broken. Go in and make a common `NodeBase` parent for *all* nodes.

Closes #76.