### PR TITLE
Load custom nodes on init

### DIFF
--- a/ironflow/custom_nodes/__init__.py
+++ b/ironflow/custom_nodes/__init__.py
@@ -22,7 +22,7 @@ Example:
     >>>     def update_event(self, inp=-1):
     >>>         self.set_output_val(0, self.input(0) + 42)
     >>>
-    >>> gui.register_user_node(MyNode)
+    >>> gui.register_node(MyNode)
 """
 
 import ironflow.custom_nodes.input_widgets

--- a/ironflow/gui/gui.py
+++ b/ironflow/gui/gui.py
@@ -32,17 +32,26 @@ class GUI(HasSession):
         register_user_node: Register with ironflow a new node from the current python process.
     """
 
-    def __init__(self, session_title: str, script_title: Optional[str] = None):
+    def __init__(
+            self,
+            session_title: str,
+            extra_nodes_packages: Optional[list] = None,
+            script_title: Optional[str] = None
+    ):
         """
         Create a new gui instance.
 
         Args:
             session_title (str): Title of the session to use. Will look for a json file of the same name and try to
                 read it. If no such file exists, simply makes a new script instead.
+            extra_nodes_packages (list | None): an optional list of nodes to register at instantiation. List items can
+                be either a list of `ironflow.model.node.Node` subclasses, a module containing such subclasses, or a .py
+                file of a module containing such subclasses. In all cases only those subclasses with the name pattern
+                `*_Node` will be registered. (Default is None, don't register any extra nodes.)
             script_title (str|None): Title for an initial script. (Default is None, which generates "script_0" if a 
                 new script is needed on initialization, i.e. when existing session data cannot be read.)
         """
-        super().__init__(session_title=session_title)
+        super().__init__(session_title=session_title, extra_nodes_packages=extra_nodes_packages)
 
         self.flow_canvases = []
         self.toolbar = Toolbar()
@@ -107,10 +116,13 @@ class GUI(HasSession):
             flow_canvas.redraw()
             self.flow_canvases.append(flow_canvas)
 
-    def register_user_node(self, node_class: Type[Node]):
+    def register_node(self, node_class: Type[Node], node_group: Optional[str] = None):
         # Inherited __doc__ still applies just fine, all we do here is update a menu item afterwards.
-        super().register_user_node(node_class=node_class)
-        self.flow_box.node_selector.update(self.nodes_dictionary)
+        super().register_node(node_class=node_class, node_group=node_group)
+        try:
+            self.flow_box.node_selector.update(self.nodes_dictionary)
+        except AttributeError:
+            pass  # It's not defined yet in the super().__init__ call, which is fine
 
     def update_tabs(self):
         self.flow_box.update_tabs(

--- a/ironflow/model/model.py
+++ b/ironflow/model/model.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import types
 from abc import ABC
 from inspect import isclass
 from pathlib import Path
@@ -23,7 +24,7 @@ from ironflow.model.node import Node
 class HasSession(ABC):
     """Mixin for an object which has a Ryven session as the underlying model"""
 
-    def __init__(self, session_title: str):
+    def __init__(self, session_title: str, extra_nodes_packages: Optional[list] = None):
         self._session = Session()
         self.session_title = session_title
         self._active_script_index = 0
@@ -40,6 +41,11 @@ class HasSession(ABC):
             special_nodes
         ]:
             self.register_nodes_from_module(module)
+
+        if extra_nodes_packages is not None:
+            for package in extra_nodes_packages:
+                # TODO: Figure out how to allow node_group to be passed in in an elegant way here for each package
+                self.register_nodes(package)
 
     @property
     def active_script_index(self) -> int:

--- a/ironflow/model/model.py
+++ b/ironflow/model/model.py
@@ -136,6 +136,32 @@ class HasSession(ABC):
         Note: The sub-collection in the `nodes_dictionary` to which the node gets added depends only on the *tail* of its
               module path, so it is possible that nodes from two different sources get grouped together. In case this
               leads to a conflict, `node_module` can be explicitly provided and this will be used instead.
+
+        Note: You can re-register a class to update its functionality, but only *newly placed* nodes will see this
+                update. Already-placed nodes are still instances of the old class and need to be deleted.
+
+        Note: You can save the graph as normal, but new gui instances will need to register the same custom nodes before
+            loading the saved graph is possible.
+
+        Example:
+            >>> from ironflow import GUI
+            >>> from ironflow.custom_nodes import Node, NodeInputBP, NodeOutputBP, dtypes, input_widgets
+            >>> gui = GUI(script_title='foo')
+            >>>
+            >>> class MyNode(Node):
+            >>>     title = "MyUserNode"
+            >>>     init_inputs = [
+            >>>         NodeInputBP(dtype=dtypes.Integer(default=1), label="foo")
+            >>>     ]
+            >>>     init_outputs = [
+            >>>        NodeOutputBP(label="bar")
+            >>>    ]
+            >>>    color = 'cyan'
+            >>>
+            >>>     def update_event(self, inp=-1):
+            >>>         self.set_output_val(0, self.input(0) + 42)
+            >>>
+            >>> gui.register_node(MyNode)
         """
         if node_class in self.session.nodes:
             self.session.unregister_node(node_class)
@@ -191,41 +217,15 @@ class HasSession(ABC):
         spec.loader.exec_module(module)
         self.register_nodes_from_module(module, node_group=node_group)
 
-    def register_user_node(self, node_class: Type[Node]):
-        """
-        Register a custom node class from the gui's current working scope. These nodes are available under the
-        'user' module. You will need to (re-)draw your GUI to see the change.
-
-        Note: You can re-register a class to update its functionality, but only *newly placed* nodes will see this
-                update. Already-placed nodes are still instances of the old class and need to be deleted.
-
-        Note: You can save the graph as normal, but new gui instances will need to register the same custom nodes before
-            loading the saved graph is possible.
-
-        Args:
-            node_class Type[ironflow.ironflow.Node]: The new node class to register.
-
-        Example:
-            >>> from ironflow import GUI
-            >>> from ironflow.custom_nodes import Node, NodeInputBP, NodeOutputBP, dtypes, input_widgets
-            >>> gui = GUI(script_title='foo')
-            >>>
-            >>> class MyNode(Node):
-            >>>     title = "MyUserNode"
-            >>>     init_inputs = [
-            >>>         NodeInputBP(dtype=dtypes.Integer(default=1), label="foo")
-            >>>     ]
-            >>>     init_outputs = [
-            >>>        NodeOutputBP(label="bar")
-            >>>    ]
-            >>>    color = 'cyan'
-            >>>
-            >>>     def update_event(self, inp=-1):
-            >>>         self.set_output_val(0, self.input(0) + 42)
-            >>>
-            >>> gui.register_user_node(MyNode)
-
-        TODO:
-            Expose the more sophisticated pyironic nodes like `NodeWithRepresentation` for import.
-        """
-        self.register_node(node_class, node_group='user')
+    def register_nodes(
+            self,
+            source: str | Path | types.ModuleType | list | tuple,
+            node_group: Optional[str] = None
+    ) -> None:
+        if isinstance(source, (str, Path)):
+            self.register_nodes_from_file(source, node_group=node_group)
+        elif isinstance(source, types.ModuleType):
+            self.register_nodes_from_module(source, node_group=node_group)
+        elif isinstance(source, (list, tuple)) and all([issubclass(item, Node) for item in source]):
+            for node_class in source:
+                self.register_node(node_class, node_group=node_group)


### PR DESCRIPTION
You can now load custom packages of nodes (a module, a .py file, or a list of node subclasses) when you instantiate the GUI using the `extra_nodes_packages` argument.

This is important if you are going to also be loading a stored session that uses these nodes, and is also just a time-saver if there's packages you want to load all the time.

Addresses part of #82 