### PR TITLE
:bug: draw the new button state

### DIFF
--- a/ironflow/gui/boxes/node_interface/representation.py
+++ b/ironflow/gui/boxes/node_interface/representation.py
@@ -36,6 +36,7 @@ class NodePresenter(NodeInterfaceBase):
         if self._node_widget is not None:
             self.clear_output()
             self._node_widget.represent_button.pressed = False
+            self._node_widget.represent_button.draw()  # Re-draw it as un-pressed
 
         if new_node_widget is not None:
             new_node_widget.node.representation_updated = True


### PR DESCRIPTION
Redraw the `SHOW` button when it gets un-pressed -- if it's getting manually unpressed, or unpressed because another node in the same flow is having its button pressed, this is unnecessary. However, when another node in *another script* getting its button pressed is what causes the unpress, the original flow that owns the unpressed guy is not getting redrawn, so we need to manually trigger the button redraw.

Closes #84 