### PR TITLE
Where is nbsphinx

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,9 +6,9 @@
 version: 2
 
 build:
-   os: 'ubuntu-20.04'
-   tools:
-     python: '3.10'
+  os: 'ubuntu-20.04'
+  tools:
+    python: '3.10'
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: 'ubuntu-20.04'
   tools:
-    python: '3.10'
+    python: 'mambaforge-4.10'
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
Looking at the [readthedocs build log](https://readthedocs.org/projects/ironflow/builds/18408958/) I can explicitly see that the first package added on the env update is `ipycanvas` and not `nbsphinx`, which is first in `.ci_support/environment-docs.yml`. It also doesn't appear farther down alphabetically. 

I suspect what is happening is that even though I specified a `conda` flag in the config file, it's still just using the requirements from `setup.py` because I earlier specified the build as `3.10` instead of indicating to use conda somehow. Interestingly, neither the [config docs](https://docs.readthedocs.io/en/stable/config-file/v2.html) nor [conda support docs](https://docs.readthedocs.io/en/stable/guides/conda.html) show how to specify conda explicitly. However, the latter suggests using mamba to speed things up, and this is what the other pyiron repos do anyhow, so I'm optimistic this will do the trick.

With a better understanding of why mambaforge is there, I should go update other elements of the CI to use this as well.