### PR TITLE
Parse defaults

### DIFF
--- a/ironflow/model/__init__.py
+++ b/ironflow/model/__init__.py
@@ -6,7 +6,6 @@ Wrappers and extensions of the underlying ryven model.
 """
 
 from ryvencore import (
-    dtypes,
     Flow,
     NodeInputBP,
     NodeOutputBP,

--- a/ironflow/model/dtypes.py
+++ b/ironflow/model/dtypes.py
@@ -1,0 +1,25 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+"""
+Wrapped dtypes to avoid mutable defaults.
+
+Implementation changes in ryvencore v0.4, so this file may be short-lived.
+"""
+
+from typing import Optional
+
+from ryvencore.dtypes import DType, Data, Integer, Float, String, Boolean, Char
+
+
+class Choice(DType):
+    def __init__(self, default=None, items: Optional[list] = None, doc: str = "", _load_state=None):
+        self.items = items if items is not None else []
+        super().__init__(default=default, doc=doc, _load_state=_load_state)
+        self.add_data('items')
+
+
+class List(DType):
+    def __init__(self, default: Optional[list] = None, doc: str = "", _load_state=None):
+        default = default if default is not None else []
+        super().__init__(default=default, doc=doc, _load_state=_load_state)

--- a/ironflow/model/node.py
+++ b/ironflow/model/node.py
@@ -54,6 +54,15 @@ class Node(NodeCore):
         self.representation_updated = False
         self.after_update.connect(self._representation_update)
 
+    def place_event(self):
+        # place_event() is executed *before* the connections are built
+        super().place_event()
+        for inp in self.inputs:
+            if inp.dtype is not None:
+                inp.update(inp.dtype.default)
+            elif 'val' in inp.add_data.keys():
+                inp.update(inp.add_data['val'])
+
     def update(self, inp=-1):
         self.before_update.emit(self, inp)
         super().update(inp=inp)

--- a/ironflow/nodes/pyiron/atomistics_nodes.py
+++ b/ironflow/nodes/pyiron/atomistics_nodes.py
@@ -80,6 +80,7 @@ class Project_Node(Node):
     color = "#aabb44"
 
     def place_event(self):
+        super().place_event()
         self.update()
 
     def update_event(self, inp=-1):
@@ -433,6 +434,7 @@ class Linspace_Node(Node):
     color = "#aabb44"
 
     def place_event(self):
+        super().place_event()
         self.update()    
 
     def update_event(self, inp=-1):
@@ -542,6 +544,7 @@ class Result_Node(Node):
         self.val = None
 
     def place_event(self):
+        super().place_event()
         self.update()
 
     def view_place_event(self):


### PR DESCRIPTION
There is a bit of a bug in ryvencore 0.3.1.1 where default values passed to the datatypes don't actually get passed to the input ports. I've been [in touch with the ryvencore owner]() and (a) v0.4 has a slightly different management of data, and (b) there should be no problem patching in defaults from the input channel declaration to the actual placed node input. But the timeline for 0.4 being on conda is not clear, so I'll just quickly patch it in our extensions module.

I don't expect it to ever come up because of how the dtypes get used, but I did also patch over an issue with the `Choice` and `List` dtypes having mutable defaults.

Closes #83.