### PR TITLE
Only run release CI once per release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 
 on:
   release:
+    types: [ published ]
 
 jobs:
   pyiron:


### PR DESCRIPTION
Without specifying the release type, release CI gets invoked three times.