### PR TITLE
Fix setup stage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     author_email='liamhuber@greyhavensolutions.com',
     license='BSD',
 
-    classifiers=['Development Status :: 5 - Production/Stable',
+    classifiers=['Development Status :: 3 - Alpha',
                  'Topic :: Scientific/Engineering :: Physics',
                  'License :: OSI Approved :: BSD License',
                  'Intended Audience :: Science/Research',

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,9 @@ setup(
                  'License :: OSI Approved :: BSD License',
                  'Intended Audience :: Science/Research',
                  'Operating System :: OS Independent',
-                 'Programming Language :: Python :: 3.7',
                  'Programming Language :: Python :: 3.8',
-                 'Programming Language :: Python :: 3.9'],
+                 'Programming Language :: Python :: 3.9',
+                 'Programming Language :: Python :: 3.10'],
 
     keywords='pyiron',
     packages=find_packages(exclude=["*tests*", "*docs*", "*binder*", "*conda*", "*notebooks*", "*.ci_support*"]),


### PR DESCRIPTION
Project was reading as "stable" on pypi, when "alpha" is more appropriate.

Plus I had some hiccups in the tagging/releasing for 0.0.1, and want an 0.0.2 tag with a nice clean name convention matching the rest of the project (i.e. no "v")...