### PR TITLE
Set a maximum height for the node interfaces

### DIFF
--- a/ironflow/gui/boxes/node_interface/base.py
+++ b/ironflow/gui/boxes/node_interface/base.py
@@ -24,11 +24,7 @@ class NodeInterfaceBase(Box, ABC):
 
     @property
     def layout(self) -> widgets.Layout:
-        return widgets.Layout(
-            width="50%",
-            border="1px solid black",
-            max_height="360px"
-        )
+        return widgets.Layout(width="50%", border="1px solid black", max_height="360px")
 
     @abstractmethod
     def draw(self) -> None:

--- a/ironflow/gui/boxes/node_interface/base.py
+++ b/ironflow/gui/boxes/node_interface/base.py
@@ -27,6 +27,7 @@ class NodeInterfaceBase(Box, ABC):
         return widgets.Layout(
             width="50%",
             border="1px solid black",
+            max_height="360px"
         )
 
     @abstractmethod


### PR DESCRIPTION
Scrolling is automatically possible. This (a) makes it easier to scroll down to other notebook cells when the node representation is super long, and (b) begins to prepare us for a voila application, where we will want some max size for the overall app.

Closes a small aside in #102 