### PR TITLE
Port access by attribute

### DIFF
--- a/ironflow/model/node.py
+++ b/ironflow/model/node.py
@@ -5,8 +5,28 @@ from __future__ import annotations
 
 from ryvencore import Node as NodeCore
 from ryvencore.Base import Event
+from ryvencore.NodePort import NodePort
 
 from ironflow.gui.canvas_widgets import NodeWidget
+
+
+class LabelList(list):
+    """
+    When used to hold a collection of `NodePort` objects, the values of these ports then become accessible by their
+    labels, as long as those labels do not match an existing method of the builtin list class.
+
+    Warning:
+        This class makes no check that these labels are unique; if multiple items have the same label, the first one
+        is returned.
+
+    Warning:
+        this class does not prevent you from adding a `NodePort` whose label matches an existing attribute of the list
+        class.
+    """
+    def __getattr__(self, key):
+        for node_port in [item for item in self if isinstance(item, NodePort)]:
+            if node_port.label_str == key:
+                return node_port
 
 
 class Node(NodeCore):
@@ -46,6 +66,8 @@ class Node(NodeCore):
 
     def __init__(self, params):
         super().__init__(params)
+        self.inputs = LabelList()
+        self.outputs = LabelList()
 
         self.before_update = Event(self, int)
         self.after_update = Event(self, int)

--- a/ironflow/model/node.py
+++ b/ironflow/model/node.py
@@ -10,23 +10,6 @@ from ryvencore.NodePort import NodePort
 from ironflow.gui.canvas_widgets import NodeWidget
 
 
-class PortFinder:
-    def __init__(self, port_list: PortList):
-        self._port_list = port_list
-
-    def __getattr__(self, key):
-        for node_port in [item for item in self._port_list if isinstance(item, NodePort)]:
-            if node_port.label_str == key:
-                return node_port
-        raise AttributeError(f"No port found with the label {key}")
-
-
-class ValueFinder(PortFinder):
-    def __getattr__(self, key):
-        node_port = super().__getattr__(key)
-        return node_port.val
-
-
 class PortList(list):
     """
     When used to hold a collection of `NodePort` objects, the values of these ports then become accessible by their
@@ -65,6 +48,23 @@ class PortList(list):
     @property
     def labels(self):
         return [item.label_str if isinstance(item, NodePort) else None for item in self]
+
+
+class PortFinder:
+    def __init__(self, port_list: PortList):
+        self._port_list = port_list
+
+    def __getattr__(self, key):
+        for node_port in [item for item in self._port_list if isinstance(item, NodePort)]:
+            if node_port.label_str == key:
+                return node_port
+        raise AttributeError(f"No port found with the label {key}")
+
+
+class ValueFinder(PortFinder):
+    def __getattr__(self, key):
+        node_port = super().__getattr__(key)
+        return node_port.val
 
 
 class Node(NodeCore):

--- a/ironflow/model/node.py
+++ b/ironflow/model/node.py
@@ -56,7 +56,9 @@ class PortFinder:
         self._port_list = port_list
 
     def __getattr__(self, key):
-        for node_port in [item for item in self._port_list if isinstance(item, NodePort)]:
+        for node_port in [
+            item for item in self._port_list if isinstance(item, NodePort)
+        ]:
             if node_port.label_str == key:
                 return node_port
         raise AttributeError(f"No port found with the label {key}")

--- a/ironflow/model/node.py
+++ b/ironflow/model/node.py
@@ -62,6 +62,10 @@ class PortList(list):
         """
         return self._value_finder
 
+    @property
+    def labels(self):
+        return [item.label_str if isinstance(item, NodePort) else None for item in self]
+
 
 class Node(NodeCore):
     """

--- a/ironflow/model/node.py
+++ b/ironflow/model/node.py
@@ -18,13 +18,13 @@ class PortFinder:
         for node_port in [item for item in self._port_list if isinstance(item, NodePort)]:
             if node_port.label_str == key:
                 return node_port
+        raise AttributeError(f"No port found with the label {key}")
 
 
 class ValueFinder(PortFinder):
     def __getattr__(self, key):
         node_port = super().__getattr__(key)
-        if node_port is not None:
-            return node_port.val
+        return node_port.val
 
 
 class PortList(list):


### PR DESCRIPTION
Overrides the `inputs` and `outputs` attributes of a node with a new list-like class. This class allows elements that are `NodePort` instances (or their values) to be accessed as attributes according to their label strings.

This closes #108.

We do introduce a little danger here: accessing port values this way (instead of through `Node.input(index)`, or at least `Node.inputs[index].get_val()`) bypasses functionality for the exec mode, and for running with an executor in data mode (although for the latter I don't see in the ryvencore source code any difference to just directly grabbing `val`...) If/when I get test cases up for exec mode, this can be revisited. 