### PR TITLE
Source representation

### DIFF
--- a/ironflow/gui/gui.py
+++ b/ironflow/gui/gui.py
@@ -260,7 +260,10 @@ class GUI(HasSession):
 
     def _click_node_help(self, change: dict) -> None:
         self.print(
-            display_string(f"{self.new_node_class.__name__.replace('_Node', '')}:\n{self.new_node_class.__doc__}"))
+            display_string(
+                f"{self.new_node_class.__name__.replace('_Node', '')}:\n{self.new_node_class.__doc__}"
+            )
+        )
 
     def _click_add_node(self, change: dict) -> None:
         self.flow_canvas.add_node(10, 10, self.new_node_class)

--- a/ironflow/gui/gui.py
+++ b/ironflow/gui/gui.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Optional, Type
 
 import ipywidgets as widgets
-from IPython.display import HTML
 
 from ironflow.gui.boxes import (
     Toolbar,
@@ -22,6 +21,7 @@ from ironflow.gui.boxes import (
 )
 from ironflow.gui.canvas_widgets import FlowCanvas
 from ironflow.model.model import HasSession
+from ironflow.utils import display_string
 
 if TYPE_CHECKING:
     from ironflow.model.node import Node
@@ -259,22 +259,8 @@ class GUI(HasSession):
         self.input.clear()
 
     def _click_node_help(self, change: dict) -> None:
-        def _pretty_docstring(node_class):
-            """
-            If we just pass a string, `display` doesn't resolve newlines.
-            If we pass a `print`ed string, `display` also shows the `None` value returned by `print`
-            So we use this ugly hack.
-            """
-            string = (
-                f"{node_class.__name__.replace('_Node', '')}:\n{node_class.__doc__}"
-            )
-            return HTML(
-                string.replace("\n", "<br>")
-                .replace("\t", "&emsp;")
-                .replace(" ", "&nbsp;")
-            )
-
-        self.print(_pretty_docstring(self.new_node_class))
+        self.print(
+            display_string(f"{self.new_node_class.__name__.replace('_Node', '')}:\n{self.new_node_class.__doc__}"))
 
     def _click_add_node(self, change: dict) -> None:
         self.flow_canvas.add_node(10, 10, self.new_node_class)

--- a/ironflow/model/node.py
+++ b/ironflow/model/node.py
@@ -3,6 +3,8 @@
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 from __future__ import annotations
 
+import inspect
+
 from ryvencore import Node as NodeCore
 from ryvencore.Base import Event
 
@@ -82,11 +84,13 @@ class Node(NodeCore):
 
     @property
     def _standard_representations(self):
-        return {
+        standard_reps = {
             o.label_str if o.label_str != "" else f"output{i}": o.val
             for i, o in enumerate(self.outputs)
             if o.type_ == "data"
         }
+        standard_reps["source code"] = inspect.getsource(self.__class__)
+        return standard_reps
 
     @property
     def extra_representations(self):

--- a/ironflow/model/node.py
+++ b/ironflow/model/node.py
@@ -81,12 +81,26 @@ class Node(NodeCore):
         self.representation_updated = True
 
     @property
-    def representations(self) -> dict:
+    def _standard_representations(self):
         return {
             o.label_str if o.label_str != "" else f"output{i}": o.val
             for i, o in enumerate(self.outputs)
             if o.type_ == "data"
         }
+
+    @property
+    def extra_representations(self):
+        """
+        When developing nodes, override this with any desired additional representations.
+
+        Note that standard representations exist for all output ports using the port's label (where available), so if
+        you add a key here matching one of those labels, you will override the standard output.
+        """
+        return {}
+
+    @property
+    def representations(self) -> dict:
+        return {**self.extra_representations, **self._standard_representations}
 
 
 class PlaceholderWidgetsContainer:

--- a/ironflow/model/node.py
+++ b/ironflow/model/node.py
@@ -9,6 +9,7 @@ from ryvencore import Node as NodeCore
 from ryvencore.Base import Event
 
 from ironflow.gui.canvas_widgets import NodeWidget
+from ironflow.utils import display_string
 
 
 class Node(NodeCore):
@@ -89,7 +90,7 @@ class Node(NodeCore):
             for i, o in enumerate(self.outputs)
             if o.type_ == "data"
         }
-        standard_reps["source code"] = inspect.getsource(self.__class__)
+        standard_reps["source code"] = display_string(inspect.getsource(self.__class__))
         return standard_reps
 
     @property

--- a/ironflow/nodes/pyiron/atomistics_nodes.py
+++ b/ironflow/nodes/pyiron/atomistics_nodes.py
@@ -95,7 +95,7 @@ class Project_Node(Node):
         return self.output(0)
 
     @property
-    def representations(self) -> dict:
+    def extra_representations(self) -> dict:
         return {
             "name": str(self.input(0)),
             # "job_table": self._project.job_table() if self._project is not None else None
@@ -123,8 +123,8 @@ class OutputsOnlyAtoms(Node, ABC):
         pass
 
     @property
-    def representations(self) -> dict:
-        return {"plot3d": self.output(0).plot3d(), "print": self.output(0)}
+    def extra_representations(self) -> dict:
+        return {"plot3d": self.output(0).plot3d()}
 
 
 class BulkStructure_Node(OutputsOnlyAtoms):
@@ -331,7 +331,7 @@ class Lammps_Node(Node):
             self._update_potential_choices()
 
     @property
-    def representations(self) -> dict:
+    def extra_representations(self) -> dict:
         return {"job": BeautifulHasGroups(self.output(1))}
 
 

--- a/ironflow/utils.py
+++ b/ironflow/utils.py
@@ -1,0 +1,21 @@
+"""
+Stuff that doesn't fit anywhere yet.
+"""
+from __future__ import annotations
+
+from IPython.core.display import HTML
+
+
+def display_string(string):
+    """
+    Format a python string to look nice in an IPython.display.display context.
+
+    If we just pass a string, `display` doesn't resolve newlines.
+    If we pass a `print`ed string, `display` also shows the `None` value returned by `print`
+    So we use this ugly hack.
+    """
+    return HTML(
+        string.replace("\n", "<br>")
+        .replace("\t", "&emsp;")
+        .replace(" ", "&nbsp;")
+    )

--- a/ironflow/utils.py
+++ b/ironflow/utils.py
@@ -15,7 +15,5 @@ def display_string(string):
     So we use this ugly hack.
     """
     return HTML(
-        string.replace("\n", "<br>")
-        .replace("\t", "&emsp;")
-        .replace(" ", "&nbsp;")
+        string.replace("\n", "<br>").replace("\t", "&emsp;").replace(" ", "&nbsp;")
     )


### PR DESCRIPTION
Add node source code to the standard representations.

Also changes representations a little bit, so now the standard representations are always available (unless explicitly overwritten), and users add representations by overriding the `extra_representations` property.

Resolves an aside in #82 