### PR TITLE
Beware mutability

### DIFF
--- a/ironflow/model/node.py
+++ b/ironflow/model/node.py
@@ -3,11 +3,17 @@
 # Distributed under the terms of "New BSD License", see the LICENSE file.
 from __future__ import annotations
 
+from copy import deepcopy
+from typing import TYPE_CHECKING
+
 from ryvencore import Node as NodeCore
 from ryvencore.Base import Event
 from ryvencore.NodePort import NodePort
 
 from ironflow.gui.canvas_widgets import NodeWidget
+
+if TYPE_CHECKING:
+    from ironflow.model.dtypes import DType
 
 
 class PortList(list):
@@ -118,6 +124,15 @@ class Node(NodeCore):
 
         self.representation_updated = False
         self.after_update.connect(self._representation_update)
+
+    def create_input(self, label: str = '', type_: str = 'data', add_data=None, insert: int = None):
+        add_data = add_data if add_data is not None else {}
+        super().create_input(label=label, type_=type_, add_data=add_data, insert=insert)
+
+    def create_input_dt(self, dtype: DType, label: str = '', add_data=None, insert: int = None):
+        """Be more careful with mutables"""
+        add_data = add_data if add_data is not None else {}
+        super().create_input_dt(dtype=deepcopy(dtype), label=label, add_data=add_data, insert=insert)
 
     def place_event(self):
         # place_event() is executed *before* the connections are built

--- a/ironflow/model/node.py
+++ b/ironflow/model/node.py
@@ -127,14 +127,20 @@ class Node(NodeCore):
         self.representation_updated = False
         self.after_update.connect(self._representation_update)
 
-    def create_input(self, label: str = '', type_: str = 'data', add_data=None, insert: int = None):
+    def create_input(
+        self, label: str = "", type_: str = "data", add_data=None, insert: int = None
+    ):
         add_data = add_data if add_data is not None else {}
         super().create_input(label=label, type_=type_, add_data=add_data, insert=insert)
 
-    def create_input_dt(self, dtype: DType, label: str = '', add_data=None, insert: int = None):
+    def create_input_dt(
+        self, dtype: DType, label: str = "", add_data=None, insert: int = None
+    ):
         """Be more careful with mutables"""
         add_data = add_data if add_data is not None else {}
-        super().create_input_dt(dtype=deepcopy(dtype), label=label, add_data=add_data, insert=insert)
+        super().create_input_dt(
+            dtype=deepcopy(dtype), label=label, add_data=add_data, insert=insert
+        )
 
     def place_event(self):
         # place_event() is executed *before* the connections are built

--- a/tests/integration/test_mutability.py
+++ b/tests/integration/test_mutability.py
@@ -1,0 +1,46 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+from unittest import TestCase
+
+from ironflow.model import dtypes, NodeInputBP, NodeOutputBP
+from ironflow.model.model import HasSession
+from ironflow.model.node import Node
+
+
+class Choice_Node(Node):
+    init_inputs = [
+        NodeInputBP(
+            dtype=dtypes.Choice(
+                default="Initial choice", items=["Initial choice"]
+            ),
+            label="choices",
+        )
+    ]
+
+
+class TestMutability(TestCase):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.model = HasSession("integration", extra_nodes_packages=[[Choice_Node]])
+        cls.model.create_script()
+
+    def tearDown(self) -> None:
+        self.model.delete_script()
+
+    def test_dtype_mutability(self):
+        self.model.flow.create_node(Choice_Node)
+        self.model.flow.create_node(Choice_Node)
+
+        p0 = self.model.flow.nodes[0].inputs.ports.choices
+        p1 = self.model.flow.nodes[1].inputs.ports.choices
+
+        self.assertNotEqual(p0, p1, msg="Ports should be unique instances")
+        self.assertNotEqual(p0.dtype, p1.dtype, msg="DTypes should be unique instances")
+        p1.dtype.val = "New choice"
+        p1.dtype.items = ["Initial choice", "New choice"]
+        self.assertNotEqual(
+            p0.dtype.items, p1.dtype.items, msg="Mutable attributes of DTypes should be unique instances"
+        )

--- a/tests/integration/test_mutability.py
+++ b/tests/integration/test_mutability.py
@@ -4,7 +4,7 @@
 
 from unittest import TestCase
 
-from ironflow.model import dtypes, NodeInputBP, NodeOutputBP
+from ironflow.model import dtypes, NodeInputBP
 from ironflow.model.model import HasSession
 from ironflow.model.node import Node
 


### PR DESCRIPTION
Issues with the drop-down menu for potentials in the Lammps node revealed that separate port instances had the same object for their DType; since some DTypes (e.g. the `Choice` type used for selecting a Lammps potential) are mutable, this is no good.

Patched and tested.