### PR TITLE
:bug: Don't crash the control view

### DIFF
--- a/ironflow/gui/boxes/node_interface/control.py
+++ b/ironflow/gui/boxes/node_interface/control.py
@@ -69,7 +69,9 @@ class NodeController(NodeInterfaceBase):
                         # `inp.data()` winds up calling `serialize` on `inp.get_val()`
                         # This serialization is a pickle dump, which fails with structures (`Atoms`)
                         # Just gloss over it for now
-                        dtype_state = {"val": "Serialization error -- please reconnect an input"}
+                        dtype_state = {
+                            "val": "Serialization error -- please reconnect an input"
+                        }
                     if inp.val is None:
                         inp.val = dtype_state["val"]
                     if dtype == "Integer":

--- a/ironflow/gui/boxes/node_interface/control.py
+++ b/ironflow/gui/boxes/node_interface/control.py
@@ -63,7 +63,13 @@ class NodeController(NodeInterfaceBase):
             for i_c, inp in enumerate(self.node.inputs[:]):
                 if inp.dtype is not None:
                     dtype = str(inp.dtype).split(".")[-1]
-                    dtype_state = deserialize(inp.data()["dtype state"])
+                    try:
+                        dtype_state = deserialize(inp.data()["dtype state"])
+                    except TypeError:
+                        # `inp.data()` winds up calling `serialize` on `inp.get_val()`
+                        # This serialization is a pickle dump, which fails with structures (`Atoms`)
+                        # Just gloss over it for now
+                        dtype_state = {"val": "Serialization error -- please reconnect an input"}
                     if inp.val is None:
                         inp.val = dtype_state["val"]
                     if dtype == "Integer":


### PR DESCRIPTION
when a port's `data()` method fails, just keep going. This method tries to serialize (pickle) `get_val()` which was a problem when that value was an `Atoms` object.

Closes #121 