### PR TITLE
Add a new screen for logging

### DIFF
--- a/ironflow/gui/gui.py
+++ b/ironflow/gui/gui.py
@@ -244,8 +244,9 @@ class GUI(HasSession):
             ]
         )
 
-        window = widgets.Tab([flow_screen])
+        window = widgets.Tab([flow_screen, self._stdoutput.output])
         window.set_title(0, "Workflow")
+        window.set_title(1, "Log")
         return window
 
     # Type hinting for unused `change` argument in callbacks taken from ipywidgets docs:

--- a/ironflow/gui/gui.py
+++ b/ironflow/gui/gui.py
@@ -44,6 +44,7 @@ class GUI(HasSession):
         session_title: str,
         extra_nodes_packages: Optional[list] = None,
         script_title: Optional[str] = None,
+        enable_ryven_log: bool = True,
     ):
         """
         Create a new gui instance.

--- a/ironflow/gui/gui.py
+++ b/ironflow/gui/gui.py
@@ -234,7 +234,7 @@ class GUI(HasSession):
         self.toolbar.buttons.zoom_out.on_click(self._click_zoom_out)
         self.flow_box.script_tabs.observe(self._change_script_tabs)
 
-        return widgets.VBox(
+        flow_screen = widgets.VBox(
             [
                 self.toolbar.box,
                 self.input.box,
@@ -243,6 +243,10 @@ class GUI(HasSession):
                 widgets.HBox([self.node_controller.box, self.node_presenter.box]),
             ]
         )
+
+        window = widgets.Tab([flow_screen])
+        window.set_title(0, "Workflow")
+        return window
 
     # Type hinting for unused `change` argument in callbacks taken from ipywidgets docs:
     # https://ipywidgets.readthedocs.io/en/latest/examples/Widget%20Events.html#Traitlet-events

--- a/ironflow/gui/gui.py
+++ b/ironflow/gui/gui.py
@@ -64,6 +64,8 @@ class GUI(HasSession):
                 separate output widget. (Default is True.)
         """
         self.log_screen = LogScreen(gui=self, enable_ryven_log=enable_ryven_log, log_to_display=log_to_display)
+        # Log screen needs to be instantiated before the rest of the init so we know whether to look at the ryven log
+        # as we boot
 
         super().__init__(
             session_title=session_title, extra_nodes_packages=extra_nodes_packages, enable_ryven_log=enable_ryven_log

--- a/ironflow/gui/log.py
+++ b/ironflow/gui/log.py
@@ -1,0 +1,92 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+"""
+Control the underlying Ryven logging system, and route logs to a widget.
+"""
+
+from __future__ import annotations
+
+import sys
+from io import TextIOBase
+
+import ipywidgets as widgets
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ironflow.gui.gui import GUI
+
+
+class StdOutPut(TextIOBase):
+    """Helper class that can be assigned to stdout and/or stderr,  passing string to a widget"""
+    def __init__(self):
+        self.output = widgets.Output()
+
+    def write(self, s):
+        self.output.append_stdout(s)
+
+
+class LogScreen:
+    """
+    A class that can redirect stdout and stderr to a widget, and gives controls for both this and toggling the
+    Ryven logger.
+    """
+    def __init__(self, gui: GUI, enable_ryven_log: bool, log_to_display: bool):
+        self._gui = gui
+        self._stdoutput = StdOutPut()
+        self._standard_stdout = sys.stdout
+        self._standard_stderr = sys.stderr
+
+        if log_to_display:
+            self.log_to_display()
+
+        self.ryven_log_button = widgets.Checkbox(
+            value=enable_ryven_log,
+            description="Use Ryven's InfoMsgs system"
+        )
+        self.display_log_button = widgets.Checkbox(
+            value=log_to_display,
+            description="Route stdout to the ironflow log screen"
+        )
+
+        self.ryven_log_button.observe(self._toggle_ryven_log)
+        self.display_log_button.observe(self._toggle_display_log)
+
+    @property
+    def box(self):
+        return widgets.VBox(
+            [
+                widgets.HBox([
+                    self.display_log_button,
+                    self.ryven_log_button
+                ]),
+                self.output
+            ]
+        )
+
+    @property
+    def output(self):
+        return self._stdoutput.output
+
+    def log_to_display(self):
+        sys.stdout = self._stdoutput
+        sys.stderr = self._stdoutput
+
+    def log_to_stdout(self):
+        sys.stdout = self._standard_stdout
+        sys.stderr = self._standard_stderr
+
+    def _toggle_ryven_log(self, change: dict):
+        if change["name"] == "value":
+            if change["new"] == True:
+                self._gui.session.info_messenger().enable()
+            else:
+                self._gui.session.info_messenger().disable()
+
+    def _toggle_display_log(self, change: dict):
+        if change["name"] == "value":
+            if change["new"] == True:
+                self.log_to_display()
+            else:
+                self.log_to_stdout()
+

--- a/ironflow/gui/log.py
+++ b/ironflow/gui/log.py
@@ -61,7 +61,8 @@ class LogScreen:
                     self.ryven_log_button
                 ]),
                 self.output
-            ]
+            ],
+            layout=widgets.Layout(height="470px")
         )
 
     @property

--- a/ironflow/gui/log.py
+++ b/ironflow/gui/log.py
@@ -78,14 +78,14 @@ class LogScreen:
 
     def _toggle_ryven_log(self, change: dict):
         if change["name"] == "value":
-            if change["new"] == True:
+            if change["new"]:
                 self._gui.session.info_messenger().enable()
             else:
                 self._gui.session.info_messenger().disable()
 
     def _toggle_display_log(self, change: dict):
         if change["name"] == "value":
-            if change["new"] == True:
+            if change["new"]:
                 self.log_to_display()
             else:
                 self.log_to_stdout()

--- a/ironflow/model/model.py
+++ b/ironflow/model/model.py
@@ -24,10 +24,18 @@ from ironflow.model.node import Node
 class HasSession(ABC):
     """Mixin for an object which has a Ryven session as the underlying model"""
 
-    def __init__(self, session_title: str, extra_nodes_packages: Optional[list] = None):
+    def __init__(
+            self,
+            session_title: str,
+            extra_nodes_packages: Optional[list] = None,
+            enable_ryven_log: bool = True,
+    ):
         self._session = Session()
         self.session_title = session_title
         self._active_script_index = 0
+
+        if enable_ryven_log:
+            self.session.info_messenger().enable()
 
         self.nodes_dictionary = {}
         from ironflow.nodes import built_in


### PR DESCRIPTION
Gets stdout re-routed to a screen in the gui. In combination with the ryven logger, errors from the nodes themselves (which are normally supressed/ignored to prevent ryven from crashing when a single node borks) are also available. Default is to activate the ryven logger and shove everything over to this logging widget, but there are toggles on the screen to change both these behaviours.

Addresses elements of #105 and #60 