### PR TITLE
Expose selected object

### DIFF
--- a/ironflow/gui/gui.py
+++ b/ironflow/gui/gui.py
@@ -117,6 +117,12 @@ class GUI(HasSession):
         return self.flow_canvases[self.active_script_index]
 
     @property
+    def selected_node(self) -> Node | None:
+        selected = self.flow_canvas.get_selected_objects()
+        return selected[0].node if len(selected) > 0 else None
+
+
+    @property
     def new_node_class(self):
         return self.flow_box.node_selector.new_node_class
 


### PR DESCRIPTION
Exposes the currently selected node (if any) at the top level of the gui object.
Together with #118, power-users can now play around with individual nodes in the notebook by selecting the node in question and then running calls like `gui.selected_node.outputs.values.structure`. Closes #105 