### PR TITLE
Bugfix logging

### DIFF
--- a/ironflow/gui/log.py
+++ b/ironflow/gui/log.py
@@ -36,6 +36,7 @@ class LogScreen:
     def __init__(self, gui: GUI, enable_ryven_log: bool, log_to_display: bool):
         self._gui = gui
         self._stdoutput = StdOutPut()
+        self._stdoutput.output.layout.height = "430px"
         self._standard_stdout = sys.stdout
         self._standard_stderr = sys.stderr
 
@@ -59,7 +60,6 @@ class LogScreen:
                 widgets.HBox([self.display_log_button, self.ryven_log_button]),
                 self.output,
             ],
-            layout=widgets.Layout(height="470px"),
         )
 
     @property

--- a/ironflow/gui/log.py
+++ b/ironflow/gui/log.py
@@ -34,6 +34,7 @@ class LogController(metaclass=Singleton):
     """
     Singleton pattern ensures that whatever `sys.stdout/err` was at the beginning of the session gets preserved.
     """
+
     def __init__(self):
         self._stdoutput = StdOutPut()
         self._standard_stdout = sys.stdout
@@ -81,9 +82,9 @@ class LogScreen:
             [
                 widgets.HBox(
                     [self.display_log_button, self.ryven_log_button],
-                    layout=widgets.Layout(min_height="35px")
+                    layout=widgets.Layout(min_height="35px"),
                 ),
-                widgets.HBox([self.output], layout=widgets.Layout(height="435px"))
+                widgets.HBox([self.output], layout=widgets.Layout(height="435px")),
             ],
         )
 

--- a/ironflow/gui/log.py
+++ b/ironflow/gui/log.py
@@ -58,7 +58,7 @@ class LogScreen:
         return widgets.VBox(
             [
                 widgets.HBox([self.display_log_button, self.ryven_log_button]),
-                self.output,
+                widgets.HBox([self.output])
             ],
         )
 

--- a/ironflow/gui/log.py
+++ b/ironflow/gui/log.py
@@ -57,7 +57,10 @@ class LogScreen:
     def box(self):
         return widgets.VBox(
             [
-                widgets.HBox([self.display_log_button, self.ryven_log_button]),
+                widgets.HBox(
+                    [self.display_log_button, self.ryven_log_button],
+                    layout=widgets.Layout(min_height="35px")
+                ),
                 widgets.HBox([self.output])
             ],
         )

--- a/ironflow/gui/log.py
+++ b/ironflow/gui/log.py
@@ -11,6 +11,7 @@ import sys
 from io import TextIOBase
 
 import ipywidgets as widgets
+from pyiron_base.interfaces.singleton import Singleton
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -18,13 +19,37 @@ if TYPE_CHECKING:
 
 
 class StdOutPut(TextIOBase):
-    """Helper class that can be assigned to stdout and/or stderr,  passing string to a widget"""
+    """
+    Helper class that can be assigned to stdout and/or stderr,  passing string to a widget
+    """
 
     def __init__(self):
         self.output = widgets.Output()
 
     def write(self, s):
         self.output.append_stdout(s)
+
+
+class LogController(metaclass=Singleton):
+    """
+    Singleton pattern ensures that whatever `sys.stdout/err` was at the beginning of the session gets preserved.
+    """
+    def __init__(self):
+        self._stdoutput = StdOutPut()
+        self._standard_stdout = sys.stdout
+        self._standard_stderr = sys.stderr
+
+    @property
+    def output(self):
+        return self._stdoutput.output
+
+    def log_to_display(self):
+        sys.stdout = self._stdoutput
+        sys.stderr = self._stdoutput
+
+    def log_to_stdout(self):
+        sys.stdout = self._standard_stdout
+        sys.stderr = self._standard_stderr
 
 
 class LogScreen:
@@ -35,10 +60,7 @@ class LogScreen:
 
     def __init__(self, gui: GUI, enable_ryven_log: bool, log_to_display: bool):
         self._gui = gui
-        self._stdoutput = StdOutPut()
-        self._stdoutput.output.layout.height = "430px"
-        self._standard_stdout = sys.stdout
-        self._standard_stderr = sys.stderr
+        self._log_controller = LogController()
 
         if log_to_display:
             self.log_to_display()
@@ -61,21 +83,19 @@ class LogScreen:
                     [self.display_log_button, self.ryven_log_button],
                     layout=widgets.Layout(min_height="35px")
                 ),
-                widgets.HBox([self.output])
+                widgets.HBox([self.output], layout=widgets.Layout(height="435px"))
             ],
         )
 
     @property
     def output(self):
-        return self._stdoutput.output
+        return self._log_controller.output
 
     def log_to_display(self):
-        sys.stdout = self._stdoutput
-        sys.stderr = self._stdoutput
+        self._log_controller.log_to_display()
 
     def log_to_stdout(self):
-        sys.stdout = self._standard_stdout
-        sys.stderr = self._standard_stderr
+        self._log_controller.log_to_stdout()
 
     def _toggle_ryven_log(self, change: dict):
         if change["name"] == "value":

--- a/tests/unit/test_log_controller.py
+++ b/tests/unit/test_log_controller.py
@@ -1,0 +1,37 @@
+# coding: utf-8
+# Copyright (c) Max-Planck-Institut für Eisenforschung GmbH - Computational Materials Design (CM) Department
+# Distributed under the terms of "New BSD License", see the LICENSE file.
+
+import sys
+from unittest import TestCase
+
+from ironflow.gui.log import LogController
+
+
+class TestLogController(TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.og_stdout = sys.stdout
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        sys.stdout = cls.og_stdout
+
+    def setUp(self) -> None:
+        sys.stdout = self.og_stdout
+
+    def test_on_off(self):
+        lc = LogController()
+        self.assertNotEqual(sys.stdout, lc._stdoutput, msg="Expected to start 'off'")
+        lc.log_to_display()
+        self.assertEqual(sys.stdout, lc._stdoutput, msg="Failed to turn 'on'")
+        lc.log_to_stdout()
+        self.assertNotEqual(sys.stdout, lc._stdoutput, msg="Failed to turn  'off'")
+
+    def test_preservation_of_original_stream(self):
+        lc = LogController()
+        self.assertEqual(self.og_stdout, lc._standard_stdout)
+        lc.log_to_display()
+        lc2 = LogController()
+        self.assertEqual(self.og_stdout, lc._standard_stdout)
+        lc2.log_to_stdout()  # Clean up

--- a/tests/unit/test_log_controller.py
+++ b/tests/unit/test_log_controller.py
@@ -11,27 +11,25 @@ from ironflow.gui.log import LogController
 class TestLogController(TestCase):
     @classmethod
     def setUpClass(cls) -> None:
-        cls.og_stdout = sys.stdout
-
-    @classmethod
-    def tearDownClass(cls) -> None:
-        sys.stdout = cls.og_stdout
+        cls.lc = LogController()
 
     def setUp(self) -> None:
-        sys.stdout = self.og_stdout
+        self.lc.log_to_stdout()
+
+    def tearDown(self) -> None:
+        self.lc.log_to_stdout()
 
     def test_on_off(self):
-        lc = LogController()
-        self.assertNotEqual(sys.stdout, lc._stdoutput, msg="Expected to start 'off'")
-        lc.log_to_display()
-        self.assertEqual(sys.stdout, lc._stdoutput, msg="Failed to turn 'on'")
-        lc.log_to_stdout()
-        self.assertNotEqual(sys.stdout, lc._stdoutput, msg="Failed to turn  'off'")
+        self.assertNotEqual(sys.stdout, self.lc._stdoutput, msg="Expected to start 'off'")
+        self.lc.log_to_display()
+        self.assertEqual(sys.stdout, self.lc._stdoutput, msg="Failed to turn 'on'")
+        self.lc.log_to_stdout()
+        self.assertNotEqual(sys.stdout, self.lc._stdoutput, msg="Failed to turn  'off'")
 
     def test_preservation_of_original_stream(self):
-        lc = LogController()
-        self.assertEqual(self.og_stdout, lc._standard_stdout)
-        lc.log_to_display()
+        self.assertEqual(sys.stdout, self.lc._standard_stdout)
+        self.assertNotEqual(self.lc._stdoutput, self.lc._standard_stdout)
+        self.lc.log_to_display()
         lc2 = LogController()
-        self.assertEqual(self.og_stdout, lc._standard_stdout)
-        lc2.log_to_stdout()  # Clean up
+        self.assertEqual(sys.stdout, lc2._stdoutput)
+        self.assertNotEqual(lc2._stdoutput, lc2._standard_stdout)


### PR DESCRIPTION
- The original IO streams are now preserved and recovered when "Route stdout to ironflow" is turned off
- The logger control toggles now properly stay at the top of the log screen regardless of what the log output is doing