### PR TITLE
Keep representation control at top

### DIFF
--- a/ironflow/gui/workflows/boxes/node_interface/representation.py
+++ b/ironflow/gui/workflows/boxes/node_interface/representation.py
@@ -85,7 +85,7 @@ class NodePresenter(NodeInterfaceBase):
                 widgets.VBox(
                     [
                         widgets.HBox(self._toggles, layout={"flex_flow": "row wrap"}),
-                        *representations,
+                        widgets.VBox(representations, layout={"max_height": "325px"}),
                     ]
                 )
             )


### PR DESCRIPTION
Layouts are not perfect, but at least the control toggles float at the top now.

Closes #134 