### PR TITLE
Use updated actions

### DIFF
--- a/.github/workflows/pr-labeled.yml
+++ b/.github/workflows/pr-labeled.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/pr-labeled.yml@main
+    uses: pyiron/actions/.github/workflows/pr-labeled.yml@46de4039b7c6ea32083e84c5c96b2f38e4ce21b3
     secrets: inherit


### PR DESCRIPTION
Over in #145 I can't for the life of me get ironflow [to stop using](https://github.com/pyiron/ironflow/actions/runs/3632804498/jobs/6129071771) `python-codacy-coverage` and start using the new workflow, even though I am explicitly pointing the pr-labeled workflow the latest commit here and not main, and that change [is reflected in the "workflow usage"](https://github.com/pyiron/ironflow/actions/runs/3632804498/workflow). My only thought is that the pyiron/actions workflow is being cached somewhere by github. I haven't had any luck googling such a discrepancy either.

Here I'm just trying again with a totally clean PR and hoping that the "workflow used" and the actual workflow commands actually sync up.