### PR TITLE
Onto codevelopment

### DIFF
--- a/ironflow/model/node.py
+++ b/ironflow/model/node.py
@@ -8,18 +8,18 @@ from abc import ABC, abstractmethod
 from typing import Callable, Optional
 
 import numpy as np
+from owlready2 import Thing
 from pyiron_atomistics import Project
 from pyiron_base import GenericJob
 from ryvencore import Node as NodeCore
 from ryvencore.Base import Event
 from ryvencore.InfoMsgs import InfoMsgs
 from ryvencore.NodePort import NodePort
-from ryvencore.NodePortBP import NodeInputBP
 from ryvencore.utils import deserialize
 
 from ironflow.gui.workflows.canvas_widgets.nodes import NodeWidget
 from ironflow.model import dtypes
-from ironflow.model.port import NodeInput, NodeOutput, NodeOutputBP
+from ironflow.model.port import NodeInput, NodeInputBP, NodeOutput, NodeOutputBP
 from ironflow.utils import display_string
 
 
@@ -156,11 +156,17 @@ class Node(NodeCore):
         label: str = "",
         add_data: Optional[dict] = None,
         dtype: Optional[dtypes.DType] = None,
+        otype: Optional[Thing] = None,
         insert: Optional[int] = None,
     ):
         """Creates and add a new input port"""
         inp = NodeInput(
-            node=self, type_=type_, label_str=label, add_data=add_data, dtype=dtype
+            node=self,
+            type_=type_,
+            label_str=label,
+            add_data=add_data,
+            dtype=dtype,
+            otype=otype,
         )
         self._add_io(self.inputs, inp, insert=insert)
 
@@ -177,10 +183,17 @@ class Node(NodeCore):
         type_: str = "data",
         label: str = "",
         dtype: Optional[dtypes.DType] = None,
+        otype: Optional[Thing] = None,
         insert: Optional[int] = None,
     ):
         """Create and add a new output port"""
-        out = NodeOutput(node=self, type_=type_, label_str=label, dtype=dtype)
+        out = NodeOutput(
+            node=self,
+            type_=type_,
+            label_str=label,
+            dtype=dtype,
+            otype=otype,
+        )
         self._add_io(self.outputs, out, insert=insert)
 
     def setup_ports(self, inputs_data=None, outputs_data=None):
@@ -195,11 +208,17 @@ class Node(NodeCore):
                     label=inp.label,
                     add_data=inp.add_data,
                     dtype=inp.dtype,
+                    otype=inp.otype,
                 )
 
             for o in range(len(self.init_outputs)):
                 out = self.init_outputs[o]
-                self.create_output(type_=out.type_, label=out.label, dtype=out.dtype)
+                self.create_output(
+                    type_=out.type_,
+                    label=out.label,
+                    dtype=out.dtype,
+                    otype=out.otype,
+                )
 
         else:
             # load from data

--- a/ironflow/model/port.py
+++ b/ironflow/model/port.py
@@ -10,8 +10,11 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import Optional, TYPE_CHECKING
 
+from owlready2 import Thing
 from ryvencore.NodePort import NodeInput as NodeInputCore, NodeOutput as NodeOutputCore
-from ryvencore.NodePortBP import NodeOutputBP as NodeOutputBPCore
+from ryvencore.NodePortBP import (
+    NodeOutputBP as NodeOutputBPCore, NodeInputBP as NodeInputBPCore
+)
 from ryvencore.utils import serialize
 
 from ironflow.model.dtypes import DType, Untyped
@@ -42,6 +45,7 @@ class NodeInput(NodeInputCore, HasDType):
         label_str: str = "",
         add_data: Optional[dict] = None,
         dtype: Optional[DType] = None,
+        otype: Optional[Thing] = None,
     ):
         super().__init__(
             node=node,
@@ -50,6 +54,7 @@ class NodeInput(NodeInputCore, HasDType):
             add_data=add_data if add_data is not None else {},
             dtype=Untyped() if dtype is None else deepcopy(dtype),
         )
+        self.otype = otype
 
     def _update_node(self):
         self.node.update(self.node.inputs.index(self))
@@ -70,9 +75,17 @@ class NodeInput(NodeInputCore, HasDType):
 
 
 class NodeOutput(NodeOutputCore, HasDType):
-    def __init__(self, node, type_="data", label_str="", dtype: Optional[DType] = None):
+    def __init__(
+            self,
+            node,
+            type_="data",
+            label_str="",
+            dtype: Optional[DType] = None,
+            otype: Optional[Thing] = None
+    ):
         super().__init__(node=node, type_=type_, label_str=label_str)
         self.dtype = Untyped() if dtype is None else deepcopy(dtype)
+        self.otype = otype
 
     def data(self) -> dict:
         data = super().data()
@@ -84,9 +97,28 @@ class NodeOutput(NodeOutputCore, HasDType):
         return data
 
 
+class NodeInputBP(NodeInputBPCore):
+    def __init__(
+            self,
+            label: str = "",
+            type_: str = "data",
+            dtype: DType = None,
+            add_data={},
+            otype: Optional[Thing] = None,
+    ):
+        super().__init__(label=label, type_=type_, dtype=dtype, add_data=add_data)
+        self.otype = otype
+
+
 class NodeOutputBP(NodeOutputBPCore):
     def __init__(
-        self, label: str = "", type_: str = "data", dtype: Optional[DType] = None
+            self,
+            label: str = "",
+            type_: str = "data",
+            dtype: Optional[DType] = None,
+            otype: Optional[Thing] = None,
     ):
         super().__init__(label=label, type_=type_)
         self.dtype = dtype
+        print(f"{label} received otype argument {otype}")
+        self.otype = otype

--- a/ironflow/node_tools/__init__.py
+++ b/ironflow/node_tools/__init__.py
@@ -27,7 +27,7 @@ Example:
 
 import ironflow.node_tools.input_widgets
 import ironflow.node_tools.main_widgets
-from ironflow.model import dtypes, NodeInputBP
+from ironflow.model import dtypes
 from ironflow.model.node import (
     Node,
     PlaceholderWidgetsContainer,
@@ -36,4 +36,4 @@ from ironflow.model.node import (
     JobMaker,
     JobTaker,
 )
-from ironflow.model.port import NodeOutputBP
+from ironflow.model.port import NodeInputBP, NodeOutputBP

--- a/ironflow/nodes/pyiron/atomistics_nodes.py
+++ b/ironflow/nodes/pyiron/atomistics_nodes.py
@@ -445,7 +445,9 @@ class CalcMurnaghan_Node(JobMaker):
 
     init_inputs = list(JobMaker.init_inputs) + [
         NodeInputBP(
-            label="engine", dtype=dtypes.Data(valid_classes=AtomisticGenericJob)
+            label="engine",
+            dtype=dtypes.Data(valid_classes=AtomisticGenericJob),
+            otype=onto["Murnaghan/ref_job"]
         ),
         NodeInputBP(label="num_points", dtype=dtypes.Integer(default=11)),
         NodeInputBP(
@@ -470,8 +472,16 @@ class CalcMurnaghan_Node(JobMaker):
     init_outputs = list(JobMaker.init_outputs) + [
         NodeOutputBP(label="eq_energy", dtype=dtypes.Float()),
         NodeOutputBP(label="eq_volume", dtype=dtypes.Float()),
-        NodeOutputBP(label="eq_bulk_modulus", dtype=dtypes.Float()),
-        NodeOutputBP(label="eq_b_prime", dtype=dtypes.Float()),
+        NodeOutputBP(
+            label="eq_bulk_modulus",
+            dtype=dtypes.Float(),
+            otype=onto["Murnaghan/output/equilibrium_bulk_modulus"],
+        ),
+        NodeOutputBP(
+            label="eq_b_prime",
+            dtype=dtypes.Float(),
+            otype=onto["Murnaghan/output/equilibrium_b_prime"]
+        ),
         NodeOutputBP(label="volumes", dtype=dtypes.List(valid_classes=float)),
         NodeOutputBP(label="energies", dtype=dtypes.List(valid_classes=float)),
     ]


### PR DESCRIPTION
This is the base PR for integrating ontological typing with [pyiron_ontology](https://github.com/pyiron/pyiron_ontology). The ontology module is still under active development and not even available as a dependency on conda forge yet. This will stay as a draft until that dependency is available.

WARNING: the binder link will fail because the `pyiron_ontology` dependency is not yet listed!

Since the ontology module is still  quite new, I'll be actively developing it together with ironflow until I'm satisfied enough to release it on conda. To get far enough along the ironflow development to really know what I even need from pyiron_ontology would make this a beast of a PR, so I'll use the stacked-PR paradigm again.

In this particular PR, I lay the most fundamental groundwork:
-[x] Introduce a new port field, `otype`, to track ontological typing
-[x] Add a new node for selecting material properties from the ontology, and convert input to generic units in output
-[x] Add available ontological typing to the Murnaghan node

Note that for now I plan to keep all the type checking with the dtype.
On the one hand, this makes node definitions a bit verbose, as both `dtype` and `otype` should be defined. 
On the other hand...
- I can imagine many places where a value could come from a typed port...or it could just come from, like, a `np.linspace` as user input. There *is* a field in the ontology for user input, so we could get fancy here at some point, but for now let's keep it simple and let users manually feed in data of the correct dtype if they want.
- Type checking also watches for batched/unbatched data conflicts, but in terms of ontological hinting it will be very useful to get node suggestions that ignore this since you can always index/batch those fields to change their effective batch status.
So for the time being I want to keep separate the idea of using ontological typing for workflow *construction hints and suggestions*, and data typing for workflow *connection requirements*.

As of this PR, you can send Murnaghan output to the material property node and get it correctly converted to the generic units.