### PR TITLE
Extend ontology

### DIFF
--- a/ironflow/node_tools/__init__.py
+++ b/ironflow/node_tools/__init__.py
@@ -32,8 +32,10 @@ from ironflow.model.node import (
     Node,
     PlaceholderWidgetsContainer,
     PortList,
+    BatchingNode,
     DataNode,
     JobMaker,
+    JobNode,
     JobTaker,
 )
 from ironflow.model.port import NodeInputBP, NodeOutputBP

--- a/ironflow/nodes/pyiron/atomistics_nodes.py
+++ b/ironflow/nodes/pyiron/atomistics_nodes.py
@@ -111,7 +111,7 @@ class Project_Node(DataNode):
         NodeOutputBP(
             label="project",
             dtype=dtypes.Data(valid_classes=Project),
-            otype=ONTO.Project,
+            otype=ONTO.project_output_atomistics_project,
         ),
     ]
     color = "#aabb44"
@@ -140,7 +140,7 @@ class JobTable_Node(Node):
         NodeInputBP(
             dtype=dtypes.Data(valid_classes=Project),
             label="project",
-            # otype=ONTO.Project,  # Needs a specific onto input type, not the code
+            # otype=ONTO...  # Needs an individual of type Input with generic Project
         ),
     ]
     init_outputs = [NodeOutputBP(label="Table")]
@@ -286,7 +286,7 @@ class SlabStructure_Node(OutputsOnlyAtoms):
         a (float | None): Lattice constant.
 
     Returns:
-        pyiron_atomistics.atomistics.structure.atoms.Atoms instance: Required surface
+        pyiron_atomistics.atomistics.structure.atoms.Atoms instance: Requested surface
     """
 
     # this __doc__ string will be displayed as tooltip in the editor
@@ -303,8 +303,8 @@ class SlabStructure_Node(OutputsOnlyAtoms):
             dtype=dtypes.Choice(
                 default="bcc100",
                 items=[
-                    "add_adsorbate",
-                    "add_vacuum",
+                    # "add_adsorbate",
+                    # "add_vacuum",
                     "bcc100",
                     "bcc110",
                     "bcc111",
@@ -317,12 +317,12 @@ class SlabStructure_Node(OutputsOnlyAtoms):
                     "hcp0001",
                     "hcp10m10",
                     "mx2",
-                    "hcp0001_root",
-                    "fcc111_root",
-                    "bcc111_root",
-                    "root_surface",
-                    "root_surface_analysis",
-                    "ase_surf",
+                    # "hcp0001_root",
+                    # "fcc111_root",
+                    # "bcc111_root",
+                    # "root_surface",
+                    # "root_surface_analysis",
+                    # "ase_surf",
                 ],
                 allow_none=True,
             ),
@@ -341,7 +341,7 @@ class SlabStructure_Node(OutputsOnlyAtoms):
         NodeOutputBP(
             label="structure",
             dtype=dtypes.Data(valid_classes=Atoms),
-            otype=ONTO["CreateSurface/output/structure"],
+            otype=ONTO.surface_structure_output_structure,
         ),
     ]
 
@@ -567,7 +567,7 @@ class CalcMurnaghan_Node(JobNode):
         NodeInputBP(
             label="project",
             dtype=dtypes.Data(valid_classes=Project),
-            otype=ONTO["Murnaghan/input/project"],
+            otype=ONTO.murnaghan_input_project,
         ),
         NodeInputBP(
             label="engine",
@@ -705,7 +705,7 @@ class Lammps_Node(Engine):
         NodeInputBP(
             dtype=dtypes.Data(valid_classes=Project),
             label="project",
-            otype=ONTO["LAMMPS/input/project"],
+            otype=ONTO.lammps_input_project,
         ),
         NodeInputBP(
             label="structure",

--- a/ironflow/nodes/pyiron/atomistics_nodes.py
+++ b/ironflow/nodes/pyiron/atomistics_nodes.py
@@ -269,6 +269,105 @@ class BulkStructure_Node(OutputsOnlyAtoms):
         }
 
 
+class SlabStructure_Node(OutputsOnlyAtoms):
+    """
+    Generate a surface based on the ase.build.surface module.
+
+    Args:
+        element (str): The atomic symbol for the desired atoms. (Default is "Fe".)
+        surface_type (str): The string specifying the surface type generators available
+            through ase (fcc111, hcp0001 etc.)
+        size (tuple): Three-tuple of integers to give size (repetitions) of the surface
+        vacuum (float): Length of vacuum layer added to the surface along the z
+            direction
+        center (bool): Tells if the surface layers have to be at the center or at one
+            end along the z-direction.
+        orthogonal (bool): Construct orthogonal cell.
+        a (float | None): Lattice constant.
+
+    Returns:
+        pyiron_atomistics.atomistics.structure.atoms.Atoms instance: Required surface
+    """
+
+    # this __doc__ string will be displayed as tooltip in the editor
+
+    title = "SlabStructure"
+    init_inputs = [
+        NodeInputBP(
+            label="element",
+            dtype=dtypes.String(default="Fe"),
+            otype=ONTO["CreateStructureBulk/input/element"],
+        ),
+        NodeInputBP(
+            label="surface_type",
+            dtype=dtypes.Choice(
+                default="bcc100",
+                items=[
+                    "add_adsorbate",
+                    "add_vacuum",
+                    "bcc100",
+                    "bcc110",
+                    "bcc111",
+                    "diamond100",
+                    "diamond111",
+                    "fcc100",
+                    "fcc110",
+                    "fcc111",
+                    "fcc211",
+                    "hcp0001",
+                    "hcp10m10",
+                    "mx2",
+                    "hcp0001_root",
+                    "fcc111_root",
+                    "bcc111_root",
+                    "root_surface",
+                    "root_surface_analysis",
+                    "ase_surf",
+                ],
+                allow_none=True,
+            ),
+        ),
+        NodeInputBP(
+            label="size",
+            dtype=dtypes.List(default=(1, 1, 1), valid_classes=[int, np.int_]),
+        ),
+        NodeInputBP(label="vacuum", dtype=dtypes.Float(1.0)),
+        NodeInputBP(label="center", dtype=dtypes.Boolean(default=False)),
+        NodeInputBP(label="orthogonal", dtype=dtypes.Boolean(default=True)),
+        NodeInputBP(dtype=dtypes.Float(default=None, allow_none=True), label="a"),
+    ]
+
+    init_outputs = [
+        NodeOutputBP(
+            label="structure",
+            dtype=dtypes.Data(valid_classes=Atoms),
+            otype=ONTO["CreateSurface/output/structure"],
+        ),
+    ]
+
+    def node_function(
+        self,
+        element,
+        surface_type,
+        size,
+        vacuum,
+        center,
+        orthogonal,
+        a,
+    ) -> dict:
+        return {
+            "structure": STRUCTURE_FACTORY.surface(
+                element=element,
+                surface_type=surface_type,
+                size=size,
+                vacuum=vacuum,
+                center=center,
+                orthogonal=orthogonal,
+                a=a,
+            )
+        }
+
+
 class Repeat_Node(OutputsOnlyAtoms):
     """
     Repeat atomic structure supercell.

--- a/ironflow/nodes/pyiron/atomistics_nodes.py
+++ b/ironflow/nodes/pyiron/atomistics_nodes.py
@@ -41,6 +41,7 @@ from ironflow.node_tools import (
     DataNode,
     dtypes,
     JobMaker,
+    JobNode,
     JobTaker,
     main_widgets,
     Node,
@@ -107,7 +108,11 @@ class Project_Node(DataNode):
         NodeInputBP(dtype=dtypes.String(default="."), label="name"),
     ]
     init_outputs = [
-        NodeOutputBP(label="project", dtype=dtypes.Data(valid_classes=Project)),
+        NodeOutputBP(
+            label="project",
+            dtype=dtypes.Data(valid_classes=Project),
+            otype=ONTO.Project,
+        ),
     ]
     color = "#aabb44"
 
@@ -132,7 +137,11 @@ class JobTable_Node(Node):
     title = "JobTable"
     init_inputs = [
         NodeInputBP(type_="exec", label="refresh"),
-        NodeInputBP(dtype=dtypes.Data(valid_classes=Project), label="project"),
+        NodeInputBP(
+            dtype=dtypes.Data(valid_classes=Project),
+            label="project",
+            # otype=ONTO.Project,  # Needs a specific onto input type, not the code
+        ),
     ]
     init_outputs = [NodeOutputBP(label="Table")]
     color = "#aabb44"
@@ -452,11 +461,16 @@ class CalcMD_Node(AtomisticTaker):
         return copied_job
 
 
-class CalcMurnaghan_Node(JobMaker):
+class CalcMurnaghan_Node(JobNode):
     title = "CalcMurnaghan"
     valid_job_classes = [pyiron_atomistics.atomistics.master.murnaghan.Murnaghan]
 
-    init_inputs = list(JobMaker.init_inputs) + [
+    init_inputs = list(JobNode.init_inputs) + [
+        NodeInputBP(
+            label="project",
+            dtype=dtypes.Data(valid_classes=Project),
+            otype=ONTO["Murnaghan/input/project"],
+        ),
         NodeInputBP(
             label="engine",
             dtype=dtypes.Data(valid_classes=AtomisticGenericJob),
@@ -590,7 +604,11 @@ class Lammps_Node(Engine):
     title = "Lammps"
     version = "v0.2"
     init_inputs = [
-        NodeInputBP(dtype=dtypes.Data(valid_classes=Project), label="project"),
+        NodeInputBP(
+            dtype=dtypes.Data(valid_classes=Project),
+            label="project",
+            otype=ONTO["LAMMPS/input/project"],
+        ),
         NodeInputBP(
             label="structure",
             dtype=dtypes.Data(valid_classes=Atoms),


### PR DESCRIPTION
Towards a minimal working example for the surface energy problem

Right now this adds typing to the project variables, and introduces a slab structure node.

I want to get all the bulk modulus stuff merged before building a surface energy node. The underlying logic might take some fiddling in order to find a generalized way to extract the surface area of the slab.