### PR TITLE
Match the list signature from colab

### DIFF
--- a/ironflow/gui/workflows/boxes/node_interface/representation.py
+++ b/ironflow/gui/workflows/boxes/node_interface/representation.py
@@ -58,7 +58,7 @@ class NodePresenter(DrawsWidgets):
             self._widgets = self._build_widgets(representations_dict)
             self._toggles = self._build_toggles(representations_dict)
 
-        for (toggle, widget, representation) in zip(
+        for toggle, widget, representation in zip(
             self._toggles, self._widgets, representations_dict.values()
         ):
             widget.clear_output()

--- a/ironflow/model/node.py
+++ b/ironflow/model/node.py
@@ -37,8 +37,8 @@ class PortList(list):
         (i.e. when `running_with_executor`).
     """
 
-    def __init__(self, seq=()):
-        super().__init__(self, seq=seq)
+    def __init__(self, *args, **kwargs):
+        super().__init__(self, *args, **kwargs)
         self._port_finder = PortFinder(self)
         self._value_finder = ValueFinder(self)
         # This additional mis-direction is necessary so that ports can have the same labels as list class methods

--- a/ironflow/model/node.py
+++ b/ironflow/model/node.py
@@ -187,7 +187,6 @@ class Node(NodeCore):
         # A streamlined version of the ryvencore method which exploits our NodeInput
         # and NodeOutput classes instead, and for which all ports have a dtype
         if not inputs_data and not outputs_data:
-
             for i in range(len(self.init_inputs)):
                 inp = self.init_inputs[i]
                 self.create_input(

--- a/ironflow/nodes/built_in.py
+++ b/ironflow/nodes/built_in.py
@@ -39,7 +39,6 @@ class GetVar_Node(NodeBase):
 
     def update_event(self, input_called=-1):
         if self.input(0) != self.var_name:
-
             if self.var_name != "":  # disconnect old var val update connection
                 self.unregister_var_receiver(self.var_name, self.var_val_changed)
 
@@ -133,7 +132,6 @@ class Val_Node(NodeBase):
         self.val = data["val"]
 
         if version is None:
-
             self.display_title = ""
 
             self.create_input_dt(dtype=dtypes.Data(size="s"))
@@ -171,15 +169,12 @@ class SetVar_Node(NodeBase):
         self.num_vars = 1
 
     def update_event(self, input_called=-1):
-
         if self.active and input_called == 0:
-
             if self.set_var_val(self.input(1), self.input(2)):
                 self.set_output_val(1, self.input(2))
             self.exec_output(0)
 
         elif not self.active:
-
             self.var_name = self.input(0)
             if self.set_var_val(self.input(0), self.input(1)):
                 self.set_output_val(0, self.get_var_val(self.var_name))
@@ -244,7 +239,6 @@ class SetVarsPassive_Node(NodeBase):
         self.rebuild_remove_actions()
 
     def rebuild_remove_actions(self):
-
         remove_keys = []
         for k, v in self.actions.items():
             if k.startswith("remove var"):
@@ -260,7 +254,6 @@ class SetVarsPassive_Node(NodeBase):
             }
 
     def update_event(self, input_called=-1):
-
         var_names = [self.input(i) for i in range(0, len(self.inputs), 2)]
         values = [self.input(i) for i in range(1, len(self.inputs), 2)]
 

--- a/ironflow/nodes/pyiron/atomistics_nodes.py
+++ b/ironflow/nodes/pyiron/atomistics_nodes.py
@@ -292,7 +292,6 @@ class ApplyStrain_Node(OutputsOnlyAtoms):
 
 
 class AtomisticTaker(JobTaker, ABC):
-
     valid_job_classes = [Lammps]
     init_outputs = JobTaker.init_outputs + [
         NodeOutputBP(

--- a/ironflow/nodes/std/basic_operators.py
+++ b/ironflow/nodes/std/basic_operators.py
@@ -2,7 +2,6 @@ from ironflow.node_tools import dtypes, Node, NodeInputBP, NodeOutputBP
 
 
 class OperatorNodeBase(Node):
-
     version = "v0.0"
 
     init_inputs = [
@@ -46,7 +45,6 @@ class OperatorNodeBase(Node):
         self.num_inputs += 1
 
     def rebuild_remove_actions(self):
-
         remove_keys = []
         for k, v in self.actions.items():
             if k.startswith("remove input"):

--- a/ironflow/nodes/std/control_structures.py
+++ b/ironflow/nodes/std/control_structures.py
@@ -78,7 +78,6 @@ class ForLoop_Node(CSNodeBase):
         self.rebuild_remove_actions()
 
     def rebuild_remove_actions(self):
-
         remove_keys = []
         for k, v in self.actions.items():
             if k.startswith("remove dimension"):
@@ -105,14 +104,12 @@ class ForLoop_Node(CSNodeBase):
             self.exec_output(len(self.outputs) - 1)
 
     def iterate(self, dim):
-
         inp_index = self.input_from_dim(dim)
 
         exec_out_index = self.output_from_dim(dim)
         data_out_index = exec_out_index + 1
 
         for i in range(self.input(inp_index), self.input(inp_index + 1)):
-
             self.set_output_val(data_out_index, i)
             self.exec_output(exec_out_index)
 

--- a/ironflow/nodes/std/special_nodes.py
+++ b/ironflow/nodes/std/special_nodes.py
@@ -281,7 +281,6 @@ class Clock_Node(NodeBase):
         self.actions["stop"] = {"method": self.stop}
 
         if self.session.gui:
-
             from qtpy.QtCore import QTimer
 
             self.timer = QTimer(self)
@@ -353,7 +352,6 @@ class Slider_Node(NodeBase):
         self.update()
 
     def update_event(self, inp=-1):
-
         v = self.input(0) * self.val
         if self.input(1):
             v = round(v)


### PR DESCRIPTION
My local python installation allows a `seq` kwarg to list, which caused an error on my binder. I'm still not 100% if this is some pycharm magic (unlikely) or a change between 3.8 and 3.11 (likely). Interestingly, even the mybinder help for `list??` erroneously states `Init signature: list(iterable=(), /)`. In fact, no kwargs are possible. Only a single (iterable) arg is allowable, but I'm just going to follow the colab `list??` and allow the full generic signature and let users hit the error themselves.