### PR TITLE
Fix port recommendations

### DIFF
--- a/ironflow/gui/workflows/canvas_widgets/flow.py
+++ b/ironflow/gui/workflows/canvas_widgets/flow.py
@@ -265,27 +265,19 @@ class FlowCanvas:
         if selected.port.otype is None:
             return
 
-        compatible_port_widgets = self._get_ontologically_compatible_ports(selected.port)
+        compatible_port_widgets = self._get_port_widgets_ontologically_compatible_with(
+            selected.port
+        )
 
         for port_widget in compatible_port_widgets:
             port_widget.highlight()
         self._highlighted_ports = compatible_port_widgets
 
-    def _get_ontologically_compatible_ports(self, compatible_with):
-        compatible_port_widgets = []
-        for subwidget in self._port_widgets:
-            if (
-                isinstance(subwidget, PortWidget)
-                and subwidget.port.otype is not None
-            ):
-                if isinstance(compatible_with, NodeInput):
-                    if compatible_with.can_receive_other_with_otype(subwidget.port):
-                        compatible_port_widgets.append(subwidget)
-                elif isinstance(compatible_with, NodeOutput):
-                    if compatible_with.otype in subwidget.port.otype.get_sources():
-                        if subwidget.port.can_receive_other_with_otype(compatible_with):
-                            compatible_port_widgets.append(subwidget)
-        return compatible_port_widgets
+    def _get_port_widgets_ontologically_compatible_with(self, port):
+        return [
+            subwidget for subwidget in self._port_widgets
+            if port.can_make_ontologically_valid_connection(subwidget.port)
+        ]
 
     @property
     def _port_widgets(self):

--- a/ironflow/gui/workflows/canvas_widgets/flow.py
+++ b/ironflow/gui/workflows/canvas_widgets/flow.py
@@ -274,10 +274,26 @@ class FlowCanvas:
         self._highlighted_ports = compatible_port_widgets
 
     def _get_port_widgets_ontologically_compatible_with(self, port):
-        return [
-            subwidget for subwidget in self._port_widgets
-            if port.can_make_ontologically_valid_connection(subwidget.port)
-        ]
+        if isinstance(port, NodeInput):
+            input_tree = port.otype.get_source_tree(
+                additional_requirements=port.get_downstream_requirements()
+            )
+            return [
+                subwidget for subwidget in self._port_widgets
+                if isinstance(subwidget.port, NodeOutput)
+                and subwidget.port.all_connections_found_in(input_tree)
+            ]
+        elif isinstance(port, NodeOutput):
+            return [
+                subwidget for subwidget in self._port_widgets
+                if subwidget.port.otype is not None  # Progressively expensive checks
+                and port.otype in subwidget.port.otype.get_sources()
+                and subwidget.port.workflow_tree_contains_connections_of(port)
+            ]
+        else:
+            raise TypeError(
+                f"Expected a {NodeInput} or {NodeOutput} but got {type(port)}"
+            )
 
     @property
     def _port_widgets(self):

--- a/ironflow/gui/workflows/canvas_widgets/nodes.py
+++ b/ironflow/gui/workflows/canvas_widgets/nodes.py
@@ -30,7 +30,7 @@ from ironflow.gui.workflows.canvas_widgets.ports import PortWidget
 if TYPE_CHECKING:
     from ironflow.gui.workflows.canvas_widgets.flow import FlowCanvas
     from ironflow.gui.workflows.canvas_widgets.base import Number
-    from ironflow.model import NodeInputBP, NodeOutputBP
+    from ironflow.model.port import NodeInputBP, NodeOutputBP
     from ironflow.model.node import Node
 
 

--- a/ironflow/model/__init__.py
+++ b/ironflow/model/__init__.py
@@ -11,5 +11,4 @@ un-typed ports) and that these dtypes can be used for meaningful type checking w
 making connections.
 """
 
-from ryvencore import NodeInputBP
 from ryvencore.NodePort import NodePort

--- a/ironflow/model/dtypes.py
+++ b/ironflow/model/dtypes.py
@@ -36,7 +36,7 @@ def isiterable(obj):
 
 
 def other_classes_are_subset(other, reference):
-    return all([any([issubclass(o, ref) for ref in reference]) for o in other])
+    return all(any(issubclass(o, ref) for ref in reference) for o in other)
 
 
 class DType(DTypeCore, ABC):
@@ -233,11 +233,11 @@ class Data(DType):
             return False
 
     def _accepts_non_none_instance(self, val: Any):
-        return any([isinstance(val, c) for c in self.valid_classes])
+        return any(isinstance(val, c) for c in self.valid_classes)
 
     def _batch_accepts_instance(self, val: Any):
         if hasattr(val, "__iter__"):
-            if any([v is None for v in val]) and not self.allow_none:
+            if any(v is None for v in val) and not self.allow_none:
                 return False
             else:
                 return self._classes_are_subset(
@@ -409,7 +409,7 @@ class Choice(DType):
 
     def _batch_accepts_instance(self, val: Any):
         return isinstance(val, (list, np.ndarray)) and all(
-            [self._accepts_non_none_instance(v) for v in val]
+            self._accepts_non_none_instance(v) for v in val
         )
 
 
@@ -475,10 +475,10 @@ class List(DType):
 
     def _accepts_non_none_instance(self, val: Any):
         return isiterable(val) and all(
-            [any([isinstance(v, c) for c in self.valid_classes]) for v in val]
+            any(isinstance(v, c) for c in self.valid_classes) for v in val
         )
 
     def _batch_accepts_instance(self, val: Any):
         return isiterable(val) and all(
-            [self._accepts_none(v) or self._accepts_non_none_instance(v) for v in val]
+            self._accepts_none(v) or self._accepts_non_none_instance(v) for v in val
         )

--- a/ironflow/model/model.py
+++ b/ironflow/model/model.py
@@ -261,7 +261,7 @@ class HasSession(ABC):
         elif isinstance(source, types.ModuleType):
             self.register_nodes_from_module(source, node_group=node_group)
         elif isinstance(source, (list, tuple)) and all(
-            [issubclass(item, Node) for item in source]
+            issubclass(item, Node) for item in source
         ):
             for node_class in source:
                 self.register_node(node_class, node_group=node_group)
@@ -281,7 +281,7 @@ class HasSession(ABC):
         return {
             node.title: node
             for node in self.session.nodes
-            if any([out.otype in sources for out in node.init_outputs])
+            if any(out.otype in sources for out in node.init_outputs)
         }
 
     def _get_nodes_taking_matching_input(self, port: NodeOutput):
@@ -289,11 +289,9 @@ class HasSession(ABC):
             node.title: node
             for node in self.session.nodes
             if any(
-                [
-                    port.otype in inp.otype.get_sources()
-                    for inp in node.init_inputs
-                    if inp.otype is not None
-                ]
+                port.otype in inp.otype.get_sources()
+                for inp in node.init_inputs
+                if inp.otype is not None
             )
         }
 

--- a/ironflow/model/node.py
+++ b/ironflow/model/node.py
@@ -262,7 +262,7 @@ class Node(NodeCore):
 
     @property
     def all_input_is_valid(self):
-        return all([p.valid_val for p in self.inputs.ports])
+        return all(p.valid_val for p in self.inputs.ports)
 
     def place_event(self):
         # place_event() is executed *before* the connections are built

--- a/tests/integration/test_mutability.py
+++ b/tests/integration/test_mutability.py
@@ -4,9 +4,10 @@
 
 from unittest import TestCase
 
-from ironflow.model import dtypes, NodeInputBP
+from ironflow.model import dtypes
 from ironflow.model.model import HasSession
 from ironflow.model.node import Node
+from ironflow.model.port import NodeInputBP
 
 
 class Choice_Node(Node):


### PR DESCRIPTION
Node recommendations were easy because we just needed to check if a node _could_ support the demands. Port recommendations are harder because we need to check if a node instance _does_ support the demands, i.e. we need to check if the current workflow graph is a subset of all possible ontological workflow trees.

With the more complex surface energy example, I discovered that some of the transitive demands were not being passed in the old, simpler port recommendation. So here we really do the graph-to-graph comparison described above. It's working great, and you can even invalidate a bunch of upstream stuff on-the-fly by re-wiring it to the wrong sort of downstream input. _However_ the already un-performant task of selecting a new node is even worse; from something like an 0.7s delay to something like a 1.5s delay. I want feature and functionality before efficiency, so let's keep this and make it more performant in a follow-up.