### PR TITLE
More performant logging

### DIFF
--- a/ironflow/gui/gui.py
+++ b/ironflow/gui/gui.py
@@ -39,7 +39,7 @@ class GUI(HasSession, DrawsWidgets):
         *args,
         extra_nodes_packages: Optional[list] = None,
         script_title: Optional[str] = None,
-        enable_ryven_log: bool = True,
+        enable_ryven_log: bool = False,
         log_to_display: bool = True,
         **kwargs,
     ):

--- a/ironflow/gui/log.py
+++ b/ironflow/gui/log.py
@@ -26,10 +26,19 @@ class StdOutPut(TextIOBase):
     """
 
     def __init__(self):
-        self.output = widgets.Output()
+        self.output = widgets.HTML()
+        self.messages = ""
 
     def write(self, s):
-        self.output.append_stdout(s)
+        self.messages += s
+        self.output.value = "<style>p{" \
+                            "word-wrap: break-word; " \
+                            "margin: 0px; " \
+                            "font-family: monospace;" \
+                            "white-space: pre" \
+                            "}</style> <p>" \
+                            + self.messages \
+                            + " </p>"
 
 
 class LogController(metaclass=Singleton):
@@ -53,6 +62,11 @@ class LogController(metaclass=Singleton):
     def log_to_stdout(self):
         sys.stdout = self._standard_stdout
         sys.stderr = self._standard_stderr
+
+    def clear_log(self):
+        self.stdoutput.messages = ""
+        self.stdoutput.output.value = ""
+        self.stdoutput.flush()
 
 
 class LogGUI(DrawsWidgets):
@@ -129,5 +143,4 @@ class LogGUI(DrawsWidgets):
                 self.log_to_stdout()
 
     def _click_clear(self, button: widgets.Button):
-        self.output.clear_output()
-        self._log_controller.stdoutput.flush()
+        self._log_controller.clear_log()

--- a/ironflow/gui/log.py
+++ b/ironflow/gui/log.py
@@ -31,14 +31,14 @@ class StdOutPut(TextIOBase):
 
     def write(self, s):
         self.messages += s
-        self.output.value = "<style>p{" \
-                            "word-wrap: break-word; " \
-                            "margin: 0px; " \
-                            "font-family: monospace;" \
-                            "white-space: pre" \
-                            "}</style> <p>" \
-                            + self.messages \
-                            + " </p>"
+        self.output.value = (
+            "<style>p{"
+            "word-wrap: break-word; "
+            "margin: 0px; "
+            "font-family: monospace;"
+            "white-space: pre"
+            "}</style> <p>" + self.messages + " </p>"
+        )
 
 
 class LogController(metaclass=Singleton):

--- a/ironflow/model/model.py
+++ b/ironflow/model/model.py
@@ -31,7 +31,7 @@ class HasSession(ABC):
         session_title: str,
         *args,
         extra_nodes_packages: Optional[list] = None,
-        enable_ryven_log: bool = True,
+        enable_ryven_log: bool = False,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
Using `ipywidgets.Output` with `append_stdout` scaled absolutely terribly as the log history grows. There is still a bit of scaling in node instatiation time as the number of nodes in the flow gets bigger, but this happens even with the logging off and not re-routed to the gui, so I believe it is unrelated.

`ipywidgets.Output.append_stdout` and the corresponding updates to the widget was really taking on the order of seconds once the log had hundreds or thousands of lines in it. `HTML` brings this down to a couple hundred ms for a big node (`CalcMurnaghan`) in an existing graph (the ontology example), almost independent of how long the log is.

At the end of the day, writing stdout is just expensive and turning off the ryven logger drops the cost from O(100ms) to O(10ms) -- i.e. from annoying but usable to very snappy and responsive. Of course we still need the log, but I'm going to turn it off by default. Errors, etc. will still get written, just not the ryven "INFO" stuff.