### PR TITLE
Granular atomistic output control

### DIFF
--- a/ironflow/nodes/pyiron/atomistics_nodes.py
+++ b/ironflow/nodes/pyiron/atomistics_nodes.py
@@ -959,7 +959,7 @@ class AtomisticOutput_Node(DataNode):
         NodeInputBP(
             label="index",
             dtype=dtypes.Integer(default=None, allow_none=True),
-        )
+        ),
     ]
     init_outputs = [
         NodeOutputBP(

--- a/ironflow/nodes/pyiron/atomistics_nodes.py
+++ b/ironflow/nodes/pyiron/atomistics_nodes.py
@@ -955,6 +955,11 @@ class AtomisticOutput_Node(DataNode):
             ),
             label="field",
         ),
+        NodeInputBP(label="transpose", dtype=dtypes.Boolean(default=False)),
+        NodeInputBP(
+            label="index",
+            dtype=dtypes.Integer(default=None, allow_none=True),
+        )
     ]
     init_outputs = [
         NodeOutputBP(
@@ -963,8 +968,13 @@ class AtomisticOutput_Node(DataNode):
     ]
     color = "#c69a15"
 
-    def node_function(self, job, field, **kwargs) -> dict:
-        return {"output": job[f"output/generic/{field}"]}
+    def node_function(self, job, field, transpose, index, **kwargs) -> dict:
+        data = job[f"output/generic/{field}"]
+        if transpose:
+            data = data.T
+        if index is not None:
+            data = data[index]
+        return {"output": data}
 
 
 class IntRand_Node(DataNode):

--- a/notebooks/example.ipynb
+++ b/notebooks/example.ipynb
@@ -10,50 +10,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "a0a60e2d",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "* Owlready2 * Warning: optimized Cython parser module 'owlready2_optimized' is not available, defaulting to slower Python implementation\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
-      ],
-      "text/plain": []
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"></pre>\n"
-      ],
-      "text/plain": []
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d5dfcda92a5c417e802dfbb27471e21f",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": []
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "%matplotlib inline\n",
     "from ironflow import GUI"
@@ -61,7 +21,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "e8da0476-4a99-4da3-8fe3-e12c646893e8",
    "metadata": {},
    "outputs": [],
@@ -71,25 +31,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "08ae0940-638e-4dde-a226-b15ea0a28230",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bcf8e7d08f6942d59d196a1413cb15bd",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Tab(children=(VBox(children=(HBox(children=(Dropdown(layout=Layout(width='80px'), options=('data', 'exec'), va…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "gui.draw()"
    ]
@@ -104,7 +49,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "a9336fda-a194-4b59-a912-6019e000d579",
    "metadata": {},
    "outputs": [],
@@ -137,7 +82,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "7f753105-1669-4163-a338-6b7887b820b2",
    "metadata": {},
    "outputs": [],
@@ -147,25 +92,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "61bd0c78-a148-483a-b232-f1e51e2ef2d7",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8e6eac6c90f44d5091cc59f486f2fd86",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Tab(children=(VBox(children=(HBox(children=(Dropdown(layout=Layout(width='80px'), options=('data', 'exec'), va…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "gui2.draw()"
    ]

--- a/notebooks/example.json
+++ b/notebooks/example.json
@@ -366,76 +366,6 @@
                         "pos y": 102.4835164835165
                     },
                     {
-                        "identifier": "AtomisticOutput_Node",
-                        "version": "v0.1",
-                        "state data": "gAR9lC4=",
-                        "additional data": {},
-                        "inputs": [
-                            {
-                                "type": "data",
-                                "label": "job",
-                                "GID": 50,
-                                "dtype": "DType.Data",
-                                "dtype state": "gASVpgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCpweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLmpvYi5hdG9taXN0aWOUjBNBdG9taXN0aWNHZW5lcmljSm9ilJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "field",
-                                "GID": 51,
-                                "val": "gASVCQAAAAAAAACMBXN0ZXBzlC4=",
-                                "dtype": "DType.Choice",
-                                "dtype state": "gASVUgEAAAAAAAB9lCiMB2RlZmF1bHSUjAVzdGVwc5SMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZSMCGJ1aWx0aW5zlIwDc3RylJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlI+UKIwTdW53cmFwcGVkX3Bvc2l0aW9uc5SMDWRpc3BsYWNlbWVudHOUjAlmb3JjZV9tYXiUaAKMBWNlbGxzlIwLdGVtcGVyYXR1cmWUjBBjb21wdXRhdGlvbl90aW1llIwJcG9zaXRpb25zlIwJcHJlc3N1cmVzlIwKZW5lcmd5X3BvdJSMEWdldF9kaXNwbGFjZW1lbnRzlIwHaW5kaWNlc5SME3RvdGFsX2Rpc3BsYWNlbWVudHOUjAZmb3JjZXOUjAZ2b2x1bWWUjAplbmVyZ3lfdG90lJB1Lg=="
-                            }
-                        ],
-                        "outputs": [
-                            {
-                                "type": "data",
-                                "label": "output",
-                                "GID": 52,
-                                "dtype": "DType.List",
-                                "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANpbnSUk5RoCIwFZmxvYXSUk5SMBW51bXB5lIwGbnVtYmVylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIl1Lg=="
-                            }
-                        ],
-                        "GID": 49,
-                        "pos x": 1169.6132913205386,
-                        "pos y": 58.08791208791209
-                    },
-                    {
-                        "identifier": "AtomisticOutput_Node",
-                        "version": "v0.1",
-                        "state data": "gAR9lC4=",
-                        "additional data": {},
-                        "inputs": [
-                            {
-                                "type": "data",
-                                "label": "job",
-                                "GID": 54,
-                                "dtype": "DType.Data",
-                                "dtype state": "gASVpgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCpweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLmpvYi5hdG9taXN0aWOUjBNBdG9taXN0aWNHZW5lcmljSm9ilJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "field",
-                                "GID": 55,
-                                "val": "gASVDwAAAAAAAACMC3RlbXBlcmF0dXJllC4=",
-                                "dtype": "DType.Choice",
-                                "dtype state": "gASVUgEAAAAAAAB9lCiMB2RlZmF1bHSUjAVzdGVwc5SMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZSMCGJ1aWx0aW5zlIwDc3RylJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlI+UKIwTdW53cmFwcGVkX3Bvc2l0aW9uc5SMDWRpc3BsYWNlbWVudHOUjAlmb3JjZV9tYXiUaAKMBWNlbGxzlIwLdGVtcGVyYXR1cmWUjBBjb21wdXRhdGlvbl90aW1llIwJcG9zaXRpb25zlIwJcHJlc3N1cmVzlIwKZW5lcmd5X3BvdJSMEWdldF9kaXNwbGFjZW1lbnRzlIwHaW5kaWNlc5SME3RvdGFsX2Rpc3BsYWNlbWVudHOUjAZmb3JjZXOUjAZ2b2x1bWWUjAplbmVyZ3lfdG90lJB1Lg=="
-                            }
-                        ],
-                        "outputs": [
-                            {
-                                "type": "data",
-                                "label": "output",
-                                "GID": 56,
-                                "dtype": "DType.List",
-                                "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANpbnSUk5RoCIwFZmxvYXSUk5SMBW51bXB5lIwGbnVtYmVylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIl1Lg=="
-                            }
-                        ],
-                        "GID": 53,
-                        "pos x": 1169.6132913205386,
-                        "pos y": 247.09890109890108
-                    },
-                    {
                         "identifier": "Matplot_Node",
                         "version": "v0.1",
                         "state data": "gAR9lC4=",
@@ -556,6 +486,108 @@
                         "GID": 57,
                         "pos x": 1527.2071039816672,
                         "pos y": 158.24175824175825
+                    },
+                    {
+                        "identifier": "AtomisticOutput_Node",
+                        "version": "v0.1",
+                        "state data": "gAR9lC4=",
+                        "additional data": {},
+                        "inputs": [
+                            {
+                                "type": "data",
+                                "label": "job",
+                                "GID": 248,
+                                "dtype": "DType.Data",
+                                "dtype state": "gASVpgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCpweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLmpvYi5hdG9taXN0aWOUjBNBdG9taXN0aWNHZW5lcmljSm9ilJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "field",
+                                "GID": 249,
+                                "val": "gASVCQAAAAAAAACMBXN0ZXBzlC4=",
+                                "dtype": "DType.Choice",
+                                "dtype state": "gASVUgEAAAAAAAB9lCiMB2RlZmF1bHSUjAVzdGVwc5SMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZSMCGJ1aWx0aW5zlIwDc3RylJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlI+UKIwGZm9yY2VzlIwHaW5kaWNlc5SMEGNvbXB1dGF0aW9uX3RpbWWUjAlmb3JjZV9tYXiUjAplbmVyZ3lfcG90lIwTdG90YWxfZGlzcGxhY2VtZW50c5RoAowJcHJlc3N1cmVzlIwTdW53cmFwcGVkX3Bvc2l0aW9uc5SMDWRpc3BsYWNlbWVudHOUjAt0ZW1wZXJhdHVyZZSMCXBvc2l0aW9uc5SMEWdldF9kaXNwbGFjZW1lbnRzlIwKZW5lcmd5X3RvdJSMBnZvbHVtZZSMBWNlbGxzlJB1Lg=="
+                            },
+                            {
+                                "type": "data",
+                                "label": "transpose",
+                                "GID": 250,
+                                "val": "gASJLg==",
+                                "dtype": "DType.Boolean",
+                                "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "index",
+                                "GID": 251,
+                                "val": "gAROLg==",
+                                "dtype": "DType.Integer",
+                                "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANpbnSUk5SMBW51bXB5lIwHaW50ZWdlcpSTlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
+                            }
+                        ],
+                        "outputs": [
+                            {
+                                "type": "data",
+                                "label": "output",
+                                "GID": 252,
+                                "dtype": "DType.List",
+                                "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANpbnSUk5RoCIwFZmxvYXSUk5SMBW51bXB5lIwGbnVtYmVylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIl1Lg=="
+                            }
+                        ],
+                        "GID": 247,
+                        "pos x": 1212.6152964766543,
+                        "pos y": 98.9010989010989
+                    },
+                    {
+                        "identifier": "AtomisticOutput_Node",
+                        "version": "v0.1",
+                        "state data": "gAR9lC4=",
+                        "additional data": {},
+                        "inputs": [
+                            {
+                                "type": "data",
+                                "label": "job",
+                                "GID": 254,
+                                "dtype": "DType.Data",
+                                "dtype state": "gASVpgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCpweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLmpvYi5hdG9taXN0aWOUjBNBdG9taXN0aWNHZW5lcmljSm9ilJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "field",
+                                "GID": 255,
+                                "val": "gASVDwAAAAAAAACMC3RlbXBlcmF0dXJllC4=",
+                                "dtype": "DType.Choice",
+                                "dtype state": "gASVUgEAAAAAAAB9lCiMB2RlZmF1bHSUjAVzdGVwc5SMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZSMCGJ1aWx0aW5zlIwDc3RylJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlI+UKIwGZm9yY2VzlIwHaW5kaWNlc5SMEGNvbXB1dGF0aW9uX3RpbWWUjAlmb3JjZV9tYXiUjAplbmVyZ3lfcG90lIwTdG90YWxfZGlzcGxhY2VtZW50c5RoAowJcHJlc3N1cmVzlIwTdW53cmFwcGVkX3Bvc2l0aW9uc5SMDWRpc3BsYWNlbWVudHOUjAt0ZW1wZXJhdHVyZZSMCXBvc2l0aW9uc5SMEWdldF9kaXNwbGFjZW1lbnRzlIwKZW5lcmd5X3RvdJSMBnZvbHVtZZSMBWNlbGxzlJB1Lg=="
+                            },
+                            {
+                                "type": "data",
+                                "label": "transpose",
+                                "GID": 256,
+                                "val": "gASJLg==",
+                                "dtype": "DType.Boolean",
+                                "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "index",
+                                "GID": 257,
+                                "val": "gAROLg==",
+                                "dtype": "DType.Integer",
+                                "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANpbnSUk5SMBW51bXB5lIwHaW50ZWdlcpSTlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
+                            }
+                        ],
+                        "outputs": [
+                            {
+                                "type": "data",
+                                "label": "output",
+                                "GID": 258,
+                                "dtype": "DType.List",
+                                "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANpbnSUk5RoCIwFZmxvYXSUk5SMBW51bXB5lIwGbnVtYmVylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIl1Lg=="
+                            }
+                        ],
+                        "GID": 253,
+                        "pos x": 1225.8149527356059,
+                        "pos y": 358.24175824175825
                     }
                 ],
                 "connections": [
@@ -588,31 +620,31 @@
                         "connected input port index": 3
                     },
                     {
-                        "GID": 76,
-                        "parent node index": 4,
-                        "output port index": 1,
-                        "connected node": 5,
-                        "connected input port index": 0
-                    },
-                    {
-                        "GID": 77,
+                        "GID": 259,
                         "parent node index": 4,
                         "output port index": 1,
                         "connected node": 6,
                         "connected input port index": 0
                     },
                     {
-                        "GID": 78,
-                        "parent node index": 5,
-                        "output port index": 0,
+                        "GID": 260,
+                        "parent node index": 4,
+                        "output port index": 1,
                         "connected node": 7,
                         "connected input port index": 0
                     },
                     {
-                        "GID": 79,
+                        "GID": 261,
                         "parent node index": 6,
                         "output port index": 0,
-                        "connected node": 7,
+                        "connected node": 5,
+                        "connected input port index": 0
+                    },
+                    {
+                        "GID": 262,
+                        "parent node index": 7,
+                        "output port index": 0,
+                        "connected node": 5,
                         "connected input port index": 1
                     }
                 ],
@@ -914,130 +946,6 @@
                         "pos y": 31.087912087912088
                     },
                     {
-                        "identifier": "Transpose_Node",
-                        "version": null,
-                        "state data": "gAR9lC4=",
-                        "additional data": {},
-                        "inputs": [
-                            {
-                                "type": "data",
-                                "label": "array",
-                                "GID": 120,
-                                "dtype": "DType.List",
-                                "dtype state": "gASVbAAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAhidWlsdGluc5SMBm9iamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJdS4="
-                            }
-                        ],
-                        "outputs": [
-                            {
-                                "type": "data",
-                                "label": "transposed",
-                                "GID": 121,
-                                "dtype": "DType.List",
-                                "dtype state": "gASVbAAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAhidWlsdGluc5SMBm9iamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJdS4="
-                            }
-                        ],
-                        "GID": 119,
-                        "pos x": 1427.0065883700945,
-                        "pos y": 29.329670329670336
-                    },
-                    {
-                        "identifier": "Transpose_Node",
-                        "version": null,
-                        "state data": "gAR9lC4=",
-                        "additional data": {},
-                        "inputs": [
-                            {
-                                "type": "data",
-                                "label": "array",
-                                "GID": 123,
-                                "dtype": "DType.List",
-                                "dtype state": "gASVbAAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAhidWlsdGluc5SMBm9iamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJdS4="
-                            }
-                        ],
-                        "outputs": [
-                            {
-                                "type": "data",
-                                "label": "transposed",
-                                "GID": 124,
-                                "dtype": "DType.List",
-                                "dtype state": "gASVbAAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAhidWlsdGluc5SMBm9iamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJdS4="
-                            }
-                        ],
-                        "GID": 122,
-                        "pos x": 934.2194213692351,
-                        "pos y": 367.7912087912088
-                    },
-                    {
-                        "identifier": "Select_Node",
-                        "version": null,
-                        "state data": "gAR9lC4=",
-                        "additional data": {},
-                        "inputs": [
-                            {
-                                "type": "data",
-                                "label": "array",
-                                "GID": 126,
-                                "dtype": "DType.List",
-                                "dtype state": "gASVbAAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAhidWlsdGluc5SMBm9iamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJdS4="
-                            },
-                            {
-                                "type": "data",
-                                "label": "i",
-                                "GID": 127,
-                                "val": "gARLAC4=",
-                                "dtype": "DType.Integer",
-                                "dtype state": "gASViwAAAAAAAAB9lCiMB2RlZmF1bHSUSwCMA3ZhbJRLAIwDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA2ludJSTlIwFbnVtcHmUjAdpbnRlZ2VylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
-                            }
-                        ],
-                        "outputs": [
-                            {
-                                "type": "data",
-                                "label": "item",
-                                "GID": 128,
-                                "dtype": "DType.Data",
-                                "dtype state": "gASVdwAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAhidWlsdGluc5SMBm9iamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
-                            }
-                        ],
-                        "GID": 125,
-                        "pos x": 936.4193640790604,
-                        "pos y": 488.8571428571429
-                    },
-                    {
-                        "identifier": "Select_Node",
-                        "version": null,
-                        "state data": "gAR9lC4=",
-                        "additional data": {},
-                        "inputs": [
-                            {
-                                "type": "data",
-                                "label": "array",
-                                "GID": 130,
-                                "dtype": "DType.List",
-                                "dtype state": "gASVbAAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAhidWlsdGluc5SMBm9iamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJdS4="
-                            },
-                            {
-                                "type": "data",
-                                "label": "i",
-                                "GID": 131,
-                                "val": "gARLAC4=",
-                                "dtype": "DType.Integer",
-                                "dtype state": "gASViwAAAAAAAAB9lCiMB2RlZmF1bHSUSwCMA3ZhbJRLAIwDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA2ludJSTlIwFbnVtcHmUjAdpbnRlZ2VylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
-                            }
-                        ],
-                        "outputs": [
-                            {
-                                "type": "data",
-                                "label": "item",
-                                "GID": 132,
-                                "dtype": "DType.Data",
-                                "dtype state": "gASVdwAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAhidWlsdGluc5SMBm9iamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
-                            }
-                        ],
-                        "GID": 129,
-                        "pos x": 1427.0065883700945,
-                        "pos y": 128.41758241758242
-                    },
-                    {
                         "identifier": "Matplot_Node",
                         "version": "v0.1",
                         "state data": "gAR9lC4=",
@@ -1168,31 +1076,47 @@
                             {
                                 "type": "data",
                                 "label": "job",
-                                "GID": 149,
+                                "GID": 264,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVpgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCpweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLmpvYi5hdG9taXN0aWOUjBNBdG9taXN0aWNHZW5lcmljSm9ilJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIiMBHNpemWUjAFtlHUu"
                             },
                             {
                                 "type": "data",
                                 "label": "field",
-                                "GID": 150,
+                                "GID": 265,
                                 "val": "gASVCgAAAAAAAACMBnZvbHVtZZQu",
                                 "dtype": "DType.Choice",
-                                "dtype state": "gASVUgEAAAAAAAB9lCiMB2RlZmF1bHSUjAVzdGVwc5SMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZSMCGJ1aWx0aW5zlIwDc3RylJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlI+UKIwTdW53cmFwcGVkX3Bvc2l0aW9uc5SMDWRpc3BsYWNlbWVudHOUjAlmb3JjZV9tYXiUaAKMBWNlbGxzlIwLdGVtcGVyYXR1cmWUjBBjb21wdXRhdGlvbl90aW1llIwJcG9zaXRpb25zlIwJcHJlc3N1cmVzlIwKZW5lcmd5X3BvdJSMEWdldF9kaXNwbGFjZW1lbnRzlIwHaW5kaWNlc5SME3RvdGFsX2Rpc3BsYWNlbWVudHOUjAZmb3JjZXOUjAZ2b2x1bWWUjAplbmVyZ3lfdG90lJB1Lg=="
+                                "dtype state": "gASVUgEAAAAAAAB9lCiMB2RlZmF1bHSUjAVzdGVwc5SMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZSMCGJ1aWx0aW5zlIwDc3RylJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlI+UKIwGZm9yY2VzlIwHaW5kaWNlc5SMEGNvbXB1dGF0aW9uX3RpbWWUjAlmb3JjZV9tYXiUjAplbmVyZ3lfcG90lIwTdG90YWxfZGlzcGxhY2VtZW50c5RoAowJcHJlc3N1cmVzlIwTdW53cmFwcGVkX3Bvc2l0aW9uc5SMDWRpc3BsYWNlbWVudHOUjAt0ZW1wZXJhdHVyZZSMCXBvc2l0aW9uc5SMEWdldF9kaXNwbGFjZW1lbnRzlIwKZW5lcmd5X3RvdJSMBnZvbHVtZZSMBWNlbGxzlJB1Lg=="
+                            },
+                            {
+                                "type": "data",
+                                "label": "transpose",
+                                "GID": 266,
+                                "val": "gASILg==",
+                                "dtype": "DType.Boolean",
+                                "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "index",
+                                "GID": 267,
+                                "val": "gAROLg==",
+                                "dtype": "DType.Integer",
+                                "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANpbnSUk5SMBW51bXB5lIwHaW50ZWdlcpSTlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
                             }
                         ],
                         "outputs": [
                             {
                                 "type": "data",
                                 "label": "output",
-                                "GID": 151,
+                                "GID": 268,
                                 "dtype": "DType.List",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANpbnSUk5RoCIwFZmxvYXSUk5SMBW51bXB5lIwGbnVtYmVylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIh1Lg=="
                             }
                         ],
-                        "GID": 148,
-                        "pos x": 1134.4142079633343,
-                        "pos y": 27.318681318681314
+                        "GID": 263,
+                        "pos x": 1204.8123746777428,
+                        "pos y": 35.48351648351648
                     },
                     {
                         "identifier": "AtomisticOutput_Node",
@@ -1203,31 +1127,47 @@
                             {
                                 "type": "data",
                                 "label": "job",
-                                "GID": 153,
+                                "GID": 270,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVpgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCpweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLmpvYi5hdG9taXN0aWOUjBNBdG9taXN0aWNHZW5lcmljSm9ilJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIiMBHNpemWUjAFtlHUu"
                             },
                             {
                                 "type": "data",
                                 "label": "field",
-                                "GID": 154,
+                                "GID": 271,
                                 "val": "gASVDgAAAAAAAACMCmVuZXJneV9wb3SULg==",
                                 "dtype": "DType.Choice",
-                                "dtype state": "gASVUgEAAAAAAAB9lCiMB2RlZmF1bHSUjAVzdGVwc5SMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZSMCGJ1aWx0aW5zlIwDc3RylJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlI+UKIwTdW53cmFwcGVkX3Bvc2l0aW9uc5SMDWRpc3BsYWNlbWVudHOUjAlmb3JjZV9tYXiUaAKMBWNlbGxzlIwLdGVtcGVyYXR1cmWUjBBjb21wdXRhdGlvbl90aW1llIwJcG9zaXRpb25zlIwJcHJlc3N1cmVzlIwKZW5lcmd5X3BvdJSMEWdldF9kaXNwbGFjZW1lbnRzlIwHaW5kaWNlc5SME3RvdGFsX2Rpc3BsYWNlbWVudHOUjAZmb3JjZXOUjAZ2b2x1bWWUjAplbmVyZ3lfdG90lJB1Lg=="
+                                "dtype state": "gASVUgEAAAAAAAB9lCiMB2RlZmF1bHSUjAVzdGVwc5SMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZSMCGJ1aWx0aW5zlIwDc3RylJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlI+UKIwGZm9yY2VzlIwHaW5kaWNlc5SMEGNvbXB1dGF0aW9uX3RpbWWUjAlmb3JjZV9tYXiUjAplbmVyZ3lfcG90lIwTdG90YWxfZGlzcGxhY2VtZW50c5RoAowJcHJlc3N1cmVzlIwTdW53cmFwcGVkX3Bvc2l0aW9uc5SMDWRpc3BsYWNlbWVudHOUjAt0ZW1wZXJhdHVyZZSMCXBvc2l0aW9uc5SMEWdldF9kaXNwbGFjZW1lbnRzlIwKZW5lcmd5X3RvdJSMBnZvbHVtZZSMBWNlbGxzlJB1Lg=="
+                            },
+                            {
+                                "type": "data",
+                                "label": "transpose",
+                                "GID": 272,
+                                "val": "gASILg==",
+                                "dtype": "DType.Boolean",
+                                "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "index",
+                                "GID": 273,
+                                "val": "gAROLg==",
+                                "dtype": "DType.Integer",
+                                "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANpbnSUk5SMBW51bXB5lIwHaW50ZWdlcpSTlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
                             }
                         ],
                         "outputs": [
                             {
                                 "type": "data",
                                 "label": "output",
-                                "GID": 155,
+                                "GID": 274,
                                 "dtype": "DType.List",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANpbnSUk5RoCIwFZmxvYXSUk5SMBW51bXB5lIwGbnVtYmVylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIh1Lg=="
                             }
                         ],
-                        "GID": 152,
-                        "pos x": 923.2197078201089,
-                        "pos y": 229.5164835164835
+                        "GID": 269,
+                        "pos x": 987.0180464050416,
+                        "pos y": 308.010989010989
                     }
                 ],
                 "connections": [
@@ -1260,60 +1200,32 @@
                         "connected input port index": 3
                     },
                     {
-                        "GID": 160,
+                        "GID": 275,
                         "parent node index": 4,
                         "output port index": 1,
-                        "connected node": 10,
+                        "connected node": 6,
                         "connected input port index": 0
                     },
                     {
-                        "GID": 161,
+                        "GID": 276,
                         "parent node index": 4,
                         "output port index": 1,
-                        "connected node": 11,
-                        "connected input port index": 0
-                    },
-                    {
-                        "GID": 162,
-                        "parent node index": 5,
-                        "output port index": 0,
-                        "connected node": 8,
-                        "connected input port index": 0
-                    },
-                    {
-                        "GID": 163,
-                        "parent node index": 6,
-                        "output port index": 0,
                         "connected node": 7,
                         "connected input port index": 0
                     },
                     {
-                        "GID": 164,
-                        "parent node index": 7,
-                        "output port index": 0,
-                        "connected node": 9,
-                        "connected input port index": 1
-                    },
-                    {
-                        "GID": 165,
-                        "parent node index": 8,
-                        "output port index": 0,
-                        "connected node": 9,
-                        "connected input port index": 0
-                    },
-                    {
-                        "GID": 166,
-                        "parent node index": 10,
+                        "GID": 278,
+                        "parent node index": 6,
                         "output port index": 0,
                         "connected node": 5,
                         "connected input port index": 0
                     },
                     {
-                        "GID": 167,
-                        "parent node index": 11,
+                        "GID": 277,
+                        "parent node index": 7,
                         "output port index": 0,
-                        "connected node": 6,
-                        "connected input port index": 0
+                        "connected node": 5,
+                        "connected input port index": 1
                     }
                 ],
                 "GID": 86
@@ -1687,103 +1599,6 @@
                         "pos y": 48.35164835164835
                     },
                     {
-                        "identifier": "AtomisticOutput_Node",
-                        "version": "v0.1",
-                        "state data": "gAR9lC4=",
-                        "additional data": {},
-                        "inputs": [
-                            {
-                                "type": "data",
-                                "label": "job",
-                                "GID": 217,
-                                "dtype": "DType.Data",
-                                "dtype state": "gASVpgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCpweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLmpvYi5hdG9taXN0aWOUjBNBdG9taXN0aWNHZW5lcmljSm9ilJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIiMBHNpemWUjAFtlHUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "field",
-                                "GID": 218,
-                                "val": "gASVCgAAAAAAAACMBnZvbHVtZZQu",
-                                "dtype": "DType.Choice",
-                                "dtype state": "gASVUgEAAAAAAAB9lCiMB2RlZmF1bHSUjAVzdGVwc5SMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZSMCGJ1aWx0aW5zlIwDc3RylJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlI+UKIwTdW53cmFwcGVkX3Bvc2l0aW9uc5SMDWRpc3BsYWNlbWVudHOUjAlmb3JjZV9tYXiUaAKMBWNlbGxzlIwLdGVtcGVyYXR1cmWUjBBjb21wdXRhdGlvbl90aW1llIwJcG9zaXRpb25zlIwJcHJlc3N1cmVzlIwKZW5lcmd5X3BvdJSMEWdldF9kaXNwbGFjZW1lbnRzlIwHaW5kaWNlc5SME3RvdGFsX2Rpc3BsYWNlbWVudHOUjAZmb3JjZXOUjAZ2b2x1bWWUjAplbmVyZ3lfdG90lJB1Lg=="
-                            }
-                        ],
-                        "outputs": [
-                            {
-                                "type": "data",
-                                "label": "output",
-                                "GID": 219,
-                                "dtype": "DType.List",
-                                "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANpbnSUk5RoCIwFZmxvYXSUk5SMBW51bXB5lIwGbnVtYmVylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIh1Lg=="
-                            }
-                        ],
-                        "GID": 216,
-                        "pos x": 1533.806932111143,
-                        "pos y": 54.94505494505494
-                    },
-                    {
-                        "identifier": "Transpose_Node",
-                        "version": null,
-                        "state data": "gAR9lC4=",
-                        "additional data": {},
-                        "inputs": [
-                            {
-                                "type": "data",
-                                "label": "array",
-                                "GID": 221,
-                                "dtype": "DType.List",
-                                "dtype state": "gASVbAAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAhidWlsdGluc5SMBm9iamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJdS4="
-                            }
-                        ],
-                        "outputs": [
-                            {
-                                "type": "data",
-                                "label": "transposed",
-                                "GID": 222,
-                                "dtype": "DType.List",
-                                "dtype state": "gASVbAAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAhidWlsdGluc5SMBm9iamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJdS4="
-                            }
-                        ],
-                        "GID": 220,
-                        "pos x": 1531.6069894013176,
-                        "pos y": 239.56043956043956
-                    },
-                    {
-                        "identifier": "Select_Node",
-                        "version": null,
-                        "state data": "gAR9lC4=",
-                        "additional data": {},
-                        "inputs": [
-                            {
-                                "type": "data",
-                                "label": "array",
-                                "GID": 224,
-                                "dtype": "DType.List",
-                                "dtype state": "gASVbAAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAhidWlsdGluc5SMBm9iamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJdS4="
-                            },
-                            {
-                                "type": "data",
-                                "label": "i",
-                                "GID": 225,
-                                "val": "gASVBgAAAAAAAABK/////y4=",
-                                "dtype": "DType.Integer",
-                                "dtype state": "gASViwAAAAAAAAB9lCiMB2RlZmF1bHSUSwCMA3ZhbJRLAIwDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA2ludJSTlIwFbnVtcHmUjAdpbnRlZ2VylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
-                            }
-                        ],
-                        "outputs": [
-                            {
-                                "type": "data",
-                                "label": "item",
-                                "GID": 226,
-                                "dtype": "DType.Data",
-                                "dtype state": "gASVdwAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAhidWlsdGluc5SMBm9iamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
-                            }
-                        ],
-                        "GID": 223,
-                        "pos x": 1538.2068175307934,
-                        "pos y": 373.6263736263736
-                    },
-                    {
                         "identifier": "QuickPlot_Node",
                         "version": null,
                         "state data": "gAR9lC4=",
@@ -1861,6 +1676,57 @@
                         "GID": 232,
                         "pos x": 943.0191922085362,
                         "pos y": 255.8901098901099
+                    },
+                    {
+                        "identifier": "AtomisticOutput_Node",
+                        "version": "v0.1",
+                        "state data": "gAR9lC4=",
+                        "additional data": {},
+                        "inputs": [
+                            {
+                                "type": "data",
+                                "label": "job",
+                                "GID": 280,
+                                "dtype": "DType.Data",
+                                "dtype state": "gASVpgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCpweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLmpvYi5hdG9taXN0aWOUjBNBdG9taXN0aWNHZW5lcmljSm9ilJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIiMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "field",
+                                "GID": 281,
+                                "val": "gASVCgAAAAAAAACMBnZvbHVtZZQu",
+                                "dtype": "DType.Choice",
+                                "dtype state": "gASVUgEAAAAAAAB9lCiMB2RlZmF1bHSUjAVzdGVwc5SMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZSMCGJ1aWx0aW5zlIwDc3RylJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlI+UKIwGZm9yY2VzlIwHaW5kaWNlc5SMEGNvbXB1dGF0aW9uX3RpbWWUjAlmb3JjZV9tYXiUjAplbmVyZ3lfcG90lIwTdG90YWxfZGlzcGxhY2VtZW50c5RoAowJcHJlc3N1cmVzlIwTdW53cmFwcGVkX3Bvc2l0aW9uc5SMDWRpc3BsYWNlbWVudHOUjAt0ZW1wZXJhdHVyZZSMCXBvc2l0aW9uc5SMEWdldF9kaXNwbGFjZW1lbnRzlIwKZW5lcmd5X3RvdJSMBnZvbHVtZZSMBWNlbGxzlJB1Lg=="
+                            },
+                            {
+                                "type": "data",
+                                "label": "transpose",
+                                "GID": 282,
+                                "val": "gASILg==",
+                                "dtype": "DType.Boolean",
+                                "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "index",
+                                "GID": 283,
+                                "val": "gASVBgAAAAAAAABK/////y4=",
+                                "dtype": "DType.Integer",
+                                "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANpbnSUk5SMBW51bXB5lIwHaW50ZWdlcpSTlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
+                            }
+                        ],
+                        "outputs": [
+                            {
+                                "type": "data",
+                                "label": "output",
+                                "GID": 284,
+                                "dtype": "DType.List",
+                                "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANpbnSUk5RoCIwFZmxvYXSUk5SMBW51bXB5lIwGbnVtYmVylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIh1Lg=="
+                            }
+                        ],
+                        "GID": 279,
+                        "pos x": 1533.806932111143,
+                        "pos y": 81.31868131868131
                     }
                 ],
                 "connections": [
@@ -1893,53 +1759,39 @@
                         "connected input port index": 0
                     },
                     {
-                        "GID": 246,
+                        "GID": 240,
                         "parent node index": 3,
                         "output port index": 0,
                         "connected node": 4,
                         "connected input port index": 2
                     },
                     {
-                        "GID": 240,
+                        "GID": 241,
                         "parent node index": 4,
                         "output port index": 0,
                         "connected node": 5,
                         "connected input port index": 3
                     },
                     {
-                        "GID": 241,
+                        "GID": 285,
                         "parent node index": 5,
                         "output port index": 1,
-                        "connected node": 6,
-                        "connected input port index": 0
-                    },
-                    {
-                        "GID": 242,
-                        "parent node index": 6,
-                        "output port index": 0,
-                        "connected node": 7,
-                        "connected input port index": 0
-                    },
-                    {
-                        "GID": 243,
-                        "parent node index": 7,
-                        "output port index": 0,
                         "connected node": 8,
                         "connected input port index": 0
                     },
                     {
-                        "GID": 244,
-                        "parent node index": 8,
-                        "output port index": 0,
-                        "connected node": 9,
-                        "connected input port index": 0
-                    },
-                    {
-                        "GID": 245,
-                        "parent node index": 10,
+                        "GID": 246,
+                        "parent node index": 7,
                         "output port index": 0,
                         "connected node": 5,
                         "connected input port index": 7
+                    },
+                    {
+                        "GID": 286,
+                        "parent node index": 8,
+                        "output port index": 0,
+                        "connected node": 6,
+                        "connected input port index": 0
                     }
                 ],
                 "GID": 174


### PR DESCRIPTION
Adds transposing and indexing as input options to the `AtomisticOutput` node, as suggested by @JNmpi in #189. Makes the examples much more compact!