### PR TITLE
Managing pyiron jobs

### DIFF
--- a/ironflow/model/node.py
+++ b/ironflow/model/node.py
@@ -524,7 +524,7 @@ class JobNode(BatchingNode, ABC):
     valid_job_classes = None
     init_inputs = [
         NodeInputBP(type_="exec", label="run"),
-        NodeInputBP(type_="exec", label="remove"),
+        NodeInputBP(type_="exec", label="reset"),
         NodeInputBP(dtype=dtypes.String(default="calc"), label="name"),
     ]
     init_outputs = [

--- a/ironflow/nodes/pyiron/atomistics_nodes.py
+++ b/ironflow/nodes/pyiron/atomistics_nodes.py
@@ -127,8 +127,7 @@ class Project_Node(DataNode):
             if self.inputs.values.enable_remove:
                 if self.inputs.values.remove_all:
                     self.outputs.values.project.remove_jobs(
-                        recursive=self.inputs.values.recursive,
-                        silently=True
+                        recursive=self.inputs.values.recursive, silently=True
                     )
                 else:
                     self.outputs.values.project.remove_job(

--- a/ironflow/nodes/pyiron/atomistics_nodes.py
+++ b/ironflow/nodes/pyiron/atomistics_nodes.py
@@ -134,6 +134,10 @@ class Project_Node(DataNode):
                     self.outputs.values.project.remove_job(
                         self.inputs.values.remove_name
                     )
+            else:
+                InfoMsgs.write(
+                    "`enable_remove` must be set to `True` before removing jobs."
+                )
         super().update_event(inp=inp)
 
     def node_function(self, name, **kwargs) -> dict:

--- a/ironflow/nodes/pyiron/atomistics_nodes.py
+++ b/ironflow/nodes/pyiron/atomistics_nodes.py
@@ -107,6 +107,11 @@ class Project_Node(DataNode):
     title = "Project"
     init_inputs = [
         NodeInputBP(dtype=dtypes.String(default="."), label="name"),
+        NodeInputBP(label="remove", type_="exec"),
+        NodeInputBP(label="enable_remove", dtype=dtypes.Boolean(default=False)),
+        NodeInputBP(label="remove_name", dtype=dtypes.String()),
+        NodeInputBP(label="remove_all", dtype=dtypes.Boolean(default=False)),
+        NodeInputBP(label="recursive", dtype=dtypes.Boolean(default=True)),
     ]
     init_outputs = [
         NodeOutputBP(
@@ -116,6 +121,20 @@ class Project_Node(DataNode):
         ),
     ]
     color = "#aabb44"
+
+    def update_event(self, inp=-1):
+        if inp == 1:
+            if self.inputs.values.enable_remove:
+                if self.inputs.values.remove_all:
+                    self.outputs.values.project.remove_jobs(
+                        recursive=self.inputs.values.recursive,
+                        silently=True
+                    )
+                else:
+                    self.outputs.values.project.remove_job(
+                        self.inputs.values.remove_name
+                    )
+        super().update_event(inp=inp)
 
     def node_function(self, name, **kwargs) -> dict:
         return {"project": Project(name)}

--- a/notebooks/bulk_modulus.ipynb
+++ b/notebooks/bulk_modulus.ipynb
@@ -46,7 +46,6 @@
     "   - Observe: Without knowing a-priori which nodes we need to use, we simply follow recommendations to populate our graph\n",
     "   - Observe: When `Lammps.outputs.engine` is connected to `CalcMurnaghan.inputs.engine`, the only recommendation for `Lammps.inputs.structure` is `BulkStructure` -- but when we disconnect these, Lammps sees both `BulkStructure` _and_ `SlabStructure`! This is because the requirements of the Murnaghan job to be calculated on a bulk structure get propogated upstream by the graph and processed by the ontology reasoner. \n",
     "11. Run the `CalcMurnaghan` job\n",
-    "   - Observe: If you use `SHOW` to investigate the `CalcMurnaghan` and `MaterialProperty` node outputs, you'll see that the bulk modulus gets converted from the Murnaghan units of GPa to the ontology's units of MPa.\n",
     "12. Select `MaterialProperty` again, and choose `B_prime` from the `property` dropdown.\n",
     "   - Observe: The `eq_bulk_modulus` output of `CalcMurnaghan` still has a green (valid) output port, but the `source` input port of `MaterialProperty` is now red (invalid) -- this is because the provided ontological type no longer matches the requested property.\n",
     "13. Click on the `source` input port again; disconnect it from `eq_bulk_modulus` and reconnect it to the recommended port."

--- a/notebooks/example.json
+++ b/notebooks/example.json
@@ -7,36 +7,6 @@
                 "algorithm mode": "data",
                 "nodes": [
                     {
-                        "identifier": "Project_Node",
-                        "version": null,
-                        "state data": "gAR9lC4=",
-                        "additional data": {},
-                        "inputs": [
-                            {
-                                "type": "data",
-                                "label": "name",
-                                "GID": 9,
-                                "val": "gASVCwAAAAAAAACMB2V4YW1wbGWULg==",
-                                "dtype": "DType.String",
-                                "dtype state": "gASVigAAAAAAAAB9lCiMB2RlZmF1bHSUjAEulIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwDc3RylJOUjAVudW1weZSMBHN0cl+Uk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
-                            }
-                        ],
-                        "outputs": [
-                            {
-                                "type": "data",
-                                "label": "project",
-                                "GID": 10,
-                                "dtype": "DType.Data",
-                                "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjBlweWlyb25fYXRvbWlzdGljcy5wcm9qZWN0lIwHUHJvamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg==",
-                                "otype_namespace": "atomistics",
-                                "otype_name": "project_output_atomistics_project"
-                            }
-                        ],
-                        "GID": 8,
-                        "pos x": 86.42384105960265,
-                        "pos y": 59.701492537313435
-                    },
-                    {
                         "identifier": "BulkStructure_Node",
                         "version": null,
                         "state data": "gAR9lC4=",
@@ -208,164 +178,6 @@
                         "pos y": 248.4835164835165
                     },
                     {
-                        "identifier": "CalcMD_Node",
-                        "version": null,
-                        "state data": "gAR9lC4=",
-                        "additional data": {},
-                        "inputs": [
-                            {
-                                "type": "exec",
-                                "label": "run",
-                                "GID": 31,
-                                "val": "gAROLg==",
-                                "dtype": "DType.Untyped",
-                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
-                            },
-                            {
-                                "type": "exec",
-                                "label": "remove",
-                                "GID": 32,
-                                "val": "gAROLg==",
-                                "dtype": "DType.Untyped",
-                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "name",
-                                "GID": 33,
-                                "val": "gASVCwAAAAAAAACMB2NhbGNfbWSULg==",
-                                "dtype": "DType.String",
-                                "dtype state": "gASVjQAAAAAAAAB9lCiMB2RlZmF1bHSUjARjYWxjlIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwDc3RylJOUjAVudW1weZSMBHN0cl+Uk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
-                            },
-                            {
-                                "type": "data",
-                                "label": "job",
-                                "GID": 34,
-                                "dtype": "DType.Data",
-                                "dtype state": "gASVjgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjB9weWlyb25fYXRvbWlzdGljcy5sYW1tcHMubGFtbXBzlIwGTGFtbXBzlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu",
-                                "otype_namespace": "atomistics",
-                                "otype_name": "atomistic_taker_job"
-                            },
-                            {
-                                "type": "data",
-                                "label": "temperature",
-                                "GID": 35,
-                                "val": "gASVCgAAAAAAAABHQHQwAAAAAAAu",
-                                "dtype": "DType.Float",
-                                "dtype state": "gASVmQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZSMCGRlY2ltYWxzlEsKdS4="
-                            },
-                            {
-                                "type": "data",
-                                "label": "pressure",
-                                "GID": 36,
-                                "val": "gAROLg==",
-                                "dtype": "DType.Data",
-                                "dtype state": "gASVlgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlGgIjARsaXN0lJOUjAVudW1weZSMB25kYXJyYXmUk5RljAphbGxvd19ub25llIiMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
-                            },
-                            {
-                                "type": "data",
-                                "label": "n_ionic_steps",
-                                "GID": 37,
-                                "val": "gASVBAAAAAAAAABN6AMu",
-                                "dtype": "DType.Integer",
-                                "dtype state": "gASVjQAAAAAAAAB9lCiMB2RlZmF1bHSUTegDjAN2YWyUTegDjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwDaW50lJOUjAVudW1weZSMB2ludGVnZXKUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
-                            },
-                            {
-                                "type": "data",
-                                "label": "time_step",
-                                "GID": 38,
-                                "val": "gASVCgAAAAAAAABHP/AAAAAAAAAu",
-                                "dtype": "DType.Float",
-                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURz/wAAAAAAAAjAN2YWyURz/wAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "n_print",
-                                "GID": 39,
-                                "val": "gARLCi4=",
-                                "dtype": "DType.Integer",
-                                "dtype state": "gASViwAAAAAAAAB9lCiMB2RlZmF1bHSUS2SMA3ZhbJRLZIwDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA2ludJSTlIwFbnVtcHmUjAdpbnRlZ2VylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "temperature_damping_timescale",
-                                "GID": 40,
-                                "val": "gASVCgAAAAAAAABHQFkAAAAAAAAu",
-                                "dtype": "DType.Float",
-                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSUR0BZAAAAAAAAjAN2YWyUR0BZAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "pressure_damping_timescale",
-                                "GID": 41,
-                                "val": "gASVCgAAAAAAAABHQI9AAAAAAAAu",
-                                "dtype": "DType.Float",
-                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSUR0CPQAAAAAAAjAN2YWyUR0CPQAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "seed",
-                                "GID": 42,
-                                "val": "gAROLg==",
-                                "dtype": "DType.Integer",
-                                "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANpbnSUk5SMBW51bXB5lIwHaW50ZWdlcpSTlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
-                            },
-                            {
-                                "type": "data",
-                                "label": "initial_temperature",
-                                "GID": 43,
-                                "val": "gAROLg==",
-                                "dtype": "DType.Float",
-                                "dtype state": "gASVmQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZSMCGRlY2ltYWxzlEsKdS4="
-                            },
-                            {
-                                "type": "data",
-                                "label": "dynamics",
-                                "GID": 44,
-                                "val": "gASVDAAAAAAAAACMCGxhbmdldmlulC4=",
-                                "dtype": "DType.Choice",
-                                "dtype state": "gASVfAAAAAAAAAB9lCiMB2RlZmF1bHSUjAhsYW5nZXZpbpSMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZSMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjAVpdGVtc5RdlChoAowLbm9zZS1ob292ZXKUZXUu"
-                            }
-                        ],
-                        "outputs": [
-                            {
-                                "type": "exec",
-                                "label": "ran",
-                                "GID": 45,
-                                "dtype": "DType.Untyped",
-                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "job",
-                                "GID": 46,
-                                "dtype": "DType.Data",
-                                "dtype state": "gASVjgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjB9weWlyb25fYXRvbWlzdGljcy5sYW1tcHMubGFtbXBzlIwGTGFtbXBzlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "energy_pot",
-                                "GID": 47,
-                                "dtype": "DType.Float",
-                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURwAAAAAAAAAAjAN2YWyURwAAAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu",
-                                "otype_namespace": "atomistics",
-                                "otype_name": "atomistic_taker_output_energy_pot"
-                            },
-                            {
-                                "type": "data",
-                                "label": "forces",
-                                "GID": 48,
-                                "dtype": "DType.List",
-                                "dtype state": "gASVgQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJdS4=",
-                                "otype_namespace": "atomistics",
-                                "otype_name": "atomistic_taker_output_forces"
-                            }
-                        ],
-                        "GID": 30,
-                        "pos x": 879.2208536236036,
-                        "pos y": 102.4835164835165
-                    },
-                    {
                         "identifier": "Matplot_Node",
                         "version": "v0.1",
                         "state data": "gAR9lC4=",
@@ -374,21 +186,21 @@
                             {
                                 "type": "data",
                                 "label": "x",
-                                "GID": 58,
+                                "GID": 50,
                                 "dtype": "DType.Untyped",
                                 "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
                             },
                             {
                                 "type": "data",
                                 "label": "y",
-                                "GID": 59,
+                                "GID": 51,
                                 "dtype": "DType.Untyped",
                                 "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
                             },
                             {
                                 "type": "data",
                                 "label": "fig",
-                                "GID": 60,
+                                "GID": 52,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVgAAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjBFtYXRwbG90bGliLmZpZ3VyZZSMBkZpZ3VyZZSTlGGMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
@@ -396,7 +208,7 @@
                             {
                                 "type": "data",
                                 "label": "marker",
-                                "GID": 61,
+                                "GID": 53,
                                 "val": "gASVBQAAAAAAAACMAW+ULg==",
                                 "dtype": "DType.Choice",
                                 "dtype state": "gASVzgAAAAAAAAB9lCiMB2RlZmF1bHSUjAFvlIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlIwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlF2UKIwEbm9uZZSMAS6UjAEslGgCjAF2lIwBXpSMATyUjAE+lIwBMZSMATKUjAEzlIwBNJSMATiUjAFzlIwBcJSMAVCUjAEqlIwBaJSMAUiUjAErlIwBeJSMAViUjAFklIwBRJSMAXyUjAFflGV1Lg=="
@@ -404,7 +216,7 @@
                             {
                                 "type": "data",
                                 "label": "linestyle",
-                                "GID": 62,
+                                "GID": 54,
                                 "val": "gASVCAAAAAAAAACMBG5vbmWULg==",
                                 "dtype": "DType.Choice",
                                 "dtype state": "gASVjgAAAAAAAAB9lCiMB2RlZmF1bHSUjARub25llIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlIwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlF2UKGgCjAVzb2xpZJSMBmRvdHRlZJSMBmRhc2hlZJSMB2Rhc2hkb3SUZXUu"
@@ -412,7 +224,7 @@
                             {
                                 "type": "data",
                                 "label": "color",
-                                "GID": 63,
+                                "GID": 55,
                                 "val": "gAROLg==",
                                 "dtype": "DType.String",
                                 "dtype state": "gASVhgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANzdHKUk5SMBW51bXB5lIwEc3RyX5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
@@ -420,7 +232,7 @@
                             {
                                 "type": "data",
                                 "label": "alpha",
-                                "GID": 64,
+                                "GID": 56,
                                 "val": "gASVCgAAAAAAAABHP/AAAAAAAAAu",
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURz/wAAAAAAAAjAN2YWyURz/wAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
@@ -428,7 +240,7 @@
                             {
                                 "type": "data",
                                 "label": "label",
-                                "GID": 65,
+                                "GID": 57,
                                 "val": "gAROLg==",
                                 "dtype": "DType.String",
                                 "dtype state": "gASVhgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANzdHKUk5SMBW51bXB5lIwEc3RyX5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
@@ -436,7 +248,7 @@
                             {
                                 "type": "data",
                                 "label": "xlabel",
-                                "GID": 66,
+                                "GID": 58,
                                 "val": "gAROLg==",
                                 "dtype": "DType.String",
                                 "dtype state": "gASVhgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANzdHKUk5SMBW51bXB5lIwEc3RyX5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
@@ -444,7 +256,7 @@
                             {
                                 "type": "data",
                                 "label": "ylabel",
-                                "GID": 67,
+                                "GID": 59,
                                 "val": "gAROLg==",
                                 "dtype": "DType.String",
                                 "dtype state": "gASVhgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANzdHKUk5SMBW51bXB5lIwEc3RyX5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
@@ -452,7 +264,7 @@
                             {
                                 "type": "data",
                                 "label": "title",
-                                "GID": 68,
+                                "GID": 60,
                                 "val": "gAROLg==",
                                 "dtype": "DType.String",
                                 "dtype state": "gASVhgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANzdHKUk5SMBW51bXB5lIwEc3RyX5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
@@ -460,7 +272,7 @@
                             {
                                 "type": "data",
                                 "label": "legend",
-                                "GID": 69,
+                                "GID": 61,
                                 "val": "gASJLg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -468,7 +280,7 @@
                             {
                                 "type": "data",
                                 "label": "tight_layout",
-                                "GID": 70,
+                                "GID": 62,
                                 "val": "gASILg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiIwDdmFslIiMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -478,12 +290,12 @@
                             {
                                 "type": "data",
                                 "label": "fig",
-                                "GID": 71,
+                                "GID": 63,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVgAAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjBFtYXRwbG90bGliLmZpZ3VyZZSMBkZpZ3VyZZSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
                             }
                         ],
-                        "GID": 57,
+                        "GID": 49,
                         "pos x": 1527.2071039816672,
                         "pos y": 158.24175824175825
                     },
@@ -496,22 +308,22 @@
                             {
                                 "type": "data",
                                 "label": "job",
-                                "GID": 248,
+                                "GID": 65,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVpgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCpweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLmpvYi5hdG9taXN0aWOUjBNBdG9taXN0aWNHZW5lcmljSm9ilJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
                             },
                             {
                                 "type": "data",
                                 "label": "field",
-                                "GID": 249,
+                                "GID": 66,
                                 "val": "gASVCQAAAAAAAACMBXN0ZXBzlC4=",
                                 "dtype": "DType.Choice",
-                                "dtype state": "gASVUgEAAAAAAAB9lCiMB2RlZmF1bHSUjAVzdGVwc5SMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZSMCGJ1aWx0aW5zlIwDc3RylJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlI+UKIwGZm9yY2VzlIwHaW5kaWNlc5SMEGNvbXB1dGF0aW9uX3RpbWWUjAlmb3JjZV9tYXiUjAplbmVyZ3lfcG90lIwTdG90YWxfZGlzcGxhY2VtZW50c5RoAowJcHJlc3N1cmVzlIwTdW53cmFwcGVkX3Bvc2l0aW9uc5SMDWRpc3BsYWNlbWVudHOUjAt0ZW1wZXJhdHVyZZSMCXBvc2l0aW9uc5SMEWdldF9kaXNwbGFjZW1lbnRzlIwKZW5lcmd5X3RvdJSMBnZvbHVtZZSMBWNlbGxzlJB1Lg=="
+                                "dtype state": "gASVUgEAAAAAAAB9lCiMB2RlZmF1bHSUjAVzdGVwc5SMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZSMCGJ1aWx0aW5zlIwDc3RylJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlI+UKIwKZW5lcmd5X3BvdJSMC3RlbXBlcmF0dXJllIwKZW5lcmd5X3RvdJRoAowQY29tcHV0YXRpb25fdGltZZSME3RvdGFsX2Rpc3BsYWNlbWVudHOUjAlwb3NpdGlvbnOUjAdpbmRpY2VzlIwFY2VsbHOUjA1kaXNwbGFjZW1lbnRzlIwGZm9yY2VzlIwJcHJlc3N1cmVzlIwGdm9sdW1llIwTdW53cmFwcGVkX3Bvc2l0aW9uc5SMCWZvcmNlX21heJSMEWdldF9kaXNwbGFjZW1lbnRzlJB1Lg=="
                             },
                             {
                                 "type": "data",
                                 "label": "transpose",
-                                "GID": 250,
+                                "GID": 67,
                                 "val": "gASJLg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -519,7 +331,7 @@
                             {
                                 "type": "data",
                                 "label": "index",
-                                "GID": 251,
+                                "GID": 68,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Integer",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANpbnSUk5SMBW51bXB5lIwHaW50ZWdlcpSTlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
@@ -529,12 +341,12 @@
                             {
                                 "type": "data",
                                 "label": "output",
-                                "GID": 252,
+                                "GID": 69,
                                 "dtype": "DType.List",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANpbnSUk5RoCIwFZmxvYXSUk5SMBW51bXB5lIwGbnVtYmVylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIl1Lg=="
                             }
                         ],
-                        "GID": 247,
+                        "GID": 64,
                         "pos x": 1212.6152964766543,
                         "pos y": 98.9010989010989
                     },
@@ -547,22 +359,22 @@
                             {
                                 "type": "data",
                                 "label": "job",
-                                "GID": 254,
+                                "GID": 71,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVpgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCpweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLmpvYi5hdG9taXN0aWOUjBNBdG9taXN0aWNHZW5lcmljSm9ilJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
                             },
                             {
                                 "type": "data",
                                 "label": "field",
-                                "GID": 255,
+                                "GID": 72,
                                 "val": "gASVDwAAAAAAAACMC3RlbXBlcmF0dXJllC4=",
                                 "dtype": "DType.Choice",
-                                "dtype state": "gASVUgEAAAAAAAB9lCiMB2RlZmF1bHSUjAVzdGVwc5SMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZSMCGJ1aWx0aW5zlIwDc3RylJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlI+UKIwGZm9yY2VzlIwHaW5kaWNlc5SMEGNvbXB1dGF0aW9uX3RpbWWUjAlmb3JjZV9tYXiUjAplbmVyZ3lfcG90lIwTdG90YWxfZGlzcGxhY2VtZW50c5RoAowJcHJlc3N1cmVzlIwTdW53cmFwcGVkX3Bvc2l0aW9uc5SMDWRpc3BsYWNlbWVudHOUjAt0ZW1wZXJhdHVyZZSMCXBvc2l0aW9uc5SMEWdldF9kaXNwbGFjZW1lbnRzlIwKZW5lcmd5X3RvdJSMBnZvbHVtZZSMBWNlbGxzlJB1Lg=="
+                                "dtype state": "gASVUgEAAAAAAAB9lCiMB2RlZmF1bHSUjAVzdGVwc5SMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZSMCGJ1aWx0aW5zlIwDc3RylJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlI+UKIwKZW5lcmd5X3BvdJSMC3RlbXBlcmF0dXJllIwKZW5lcmd5X3RvdJRoAowQY29tcHV0YXRpb25fdGltZZSME3RvdGFsX2Rpc3BsYWNlbWVudHOUjAlwb3NpdGlvbnOUjAdpbmRpY2VzlIwFY2VsbHOUjA1kaXNwbGFjZW1lbnRzlIwGZm9yY2VzlIwJcHJlc3N1cmVzlIwGdm9sdW1llIwTdW53cmFwcGVkX3Bvc2l0aW9uc5SMCWZvcmNlX21heJSMEWdldF9kaXNwbGFjZW1lbnRzlJB1Lg=="
                             },
                             {
                                 "type": "data",
                                 "label": "transpose",
-                                "GID": 256,
+                                "GID": 73,
                                 "val": "gASJLg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -570,7 +382,7 @@
                             {
                                 "type": "data",
                                 "label": "index",
-                                "GID": 257,
+                                "GID": 74,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Integer",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANpbnSUk5SMBW51bXB5lIwHaW50ZWdlcpSTlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
@@ -580,72 +392,300 @@
                             {
                                 "type": "data",
                                 "label": "output",
-                                "GID": 258,
+                                "GID": 75,
                                 "dtype": "DType.List",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANpbnSUk5RoCIwFZmxvYXSUk5SMBW51bXB5lIwGbnVtYmVylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIl1Lg=="
                             }
                         ],
-                        "GID": 253,
+                        "GID": 70,
                         "pos x": 1225.8149527356059,
                         "pos y": 358.24175824175825
+                    },
+                    {
+                        "identifier": "Project_Node",
+                        "version": null,
+                        "state data": "gAR9lC4=",
+                        "additional data": {},
+                        "inputs": [
+                            {
+                                "type": "data",
+                                "label": "name",
+                                "GID": 231,
+                                "val": "gASVCwAAAAAAAACMB2V4YW1wbGWULg==",
+                                "dtype": "DType.String",
+                                "dtype state": "gASVigAAAAAAAAB9lCiMB2RlZmF1bHSUjAEulIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwDc3RylJOUjAVudW1weZSMBHN0cl+Uk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
+                            },
+                            {
+                                "type": "exec",
+                                "label": "remove",
+                                "GID": 232,
+                                "val": "gAROLg==",
+                                "dtype": "DType.Untyped",
+                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "enable_remove",
+                                "GID": 233,
+                                "val": "gASJLg==",
+                                "dtype": "DType.Boolean",
+                                "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "remove_name",
+                                "GID": 234,
+                                "val": "gASVBAAAAAAAAACMAJQu",
+                                "dtype": "DType.String",
+                                "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUjACUjAN2YWyUaAKMA2RvY5RoAowGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA3N0cpSTlIwFbnVtcHmUjARzdHJflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "remove_all",
+                                "GID": 235,
+                                "val": "gASJLg==",
+                                "dtype": "DType.Boolean",
+                                "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "recursive",
+                                "GID": 236,
+                                "val": "gASILg==",
+                                "dtype": "DType.Boolean",
+                                "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiIwDdmFslIiMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            }
+                        ],
+                        "outputs": [
+                            {
+                                "type": "data",
+                                "label": "project",
+                                "GID": 237,
+                                "dtype": "DType.Data",
+                                "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjBlweWlyb25fYXRvbWlzdGljcy5wcm9qZWN0lIwHUHJvamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg==",
+                                "otype_namespace": "atomistics",
+                                "otype_name": "project_output_atomistics_project"
+                            }
+                        ],
+                        "GID": 230,
+                        "pos x": 86.42384105960265,
+                        "pos y": 44.776119402985074
+                    },
+                    {
+                        "identifier": "CalcMD_Node",
+                        "version": null,
+                        "state data": "gAR9lC4=",
+                        "additional data": {},
+                        "inputs": [
+                            {
+                                "type": "exec",
+                                "label": "run",
+                                "GID": 239,
+                                "val": "gAROLg==",
+                                "dtype": "DType.Untyped",
+                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
+                            },
+                            {
+                                "type": "exec",
+                                "label": "reset",
+                                "GID": 240,
+                                "val": "gAROLg==",
+                                "dtype": "DType.Untyped",
+                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "name",
+                                "GID": 241,
+                                "val": "gASVCwAAAAAAAACMB2NhbGNfbWSULg==",
+                                "dtype": "DType.String",
+                                "dtype state": "gASVjQAAAAAAAAB9lCiMB2RlZmF1bHSUjARjYWxjlIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwDc3RylJOUjAVudW1weZSMBHN0cl+Uk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
+                            },
+                            {
+                                "type": "data",
+                                "label": "job",
+                                "GID": 242,
+                                "dtype": "DType.Data",
+                                "dtype state": "gASVjgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjB9weWlyb25fYXRvbWlzdGljcy5sYW1tcHMubGFtbXBzlIwGTGFtbXBzlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu",
+                                "otype_namespace": "atomistics",
+                                "otype_name": "atomistic_taker_job"
+                            },
+                            {
+                                "type": "data",
+                                "label": "temperature",
+                                "GID": 243,
+                                "val": "gASVCgAAAAAAAABHQHLAAAAAAAAu",
+                                "dtype": "DType.Float",
+                                "dtype state": "gASVmQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZSMCGRlY2ltYWxzlEsKdS4="
+                            },
+                            {
+                                "type": "data",
+                                "label": "pressure",
+                                "GID": 244,
+                                "val": "gAROLg==",
+                                "dtype": "DType.Data",
+                                "dtype state": "gASVlgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlGgIjARsaXN0lJOUjAVudW1weZSMB25kYXJyYXmUk5RljAphbGxvd19ub25llIiMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
+                            },
+                            {
+                                "type": "data",
+                                "label": "n_ionic_steps",
+                                "GID": 245,
+                                "val": "gASVBAAAAAAAAABN6AMu",
+                                "dtype": "DType.Integer",
+                                "dtype state": "gASVjQAAAAAAAAB9lCiMB2RlZmF1bHSUTegDjAN2YWyUTegDjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwDaW50lJOUjAVudW1weZSMB2ludGVnZXKUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
+                            },
+                            {
+                                "type": "data",
+                                "label": "time_step",
+                                "GID": 246,
+                                "val": "gASVCgAAAAAAAABHP/AAAAAAAAAu",
+                                "dtype": "DType.Float",
+                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURz/wAAAAAAAAjAN2YWyURz/wAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "n_print",
+                                "GID": 247,
+                                "val": "gARLCi4=",
+                                "dtype": "DType.Integer",
+                                "dtype state": "gASViwAAAAAAAAB9lCiMB2RlZmF1bHSUS2SMA3ZhbJRLZIwDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA2ludJSTlIwFbnVtcHmUjAdpbnRlZ2VylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "temperature_damping_timescale",
+                                "GID": 248,
+                                "val": "gASVCgAAAAAAAABHQFkAAAAAAAAu",
+                                "dtype": "DType.Float",
+                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSUR0BZAAAAAAAAjAN2YWyUR0BZAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "pressure_damping_timescale",
+                                "GID": 249,
+                                "val": "gASVCgAAAAAAAABHQI9AAAAAAAAu",
+                                "dtype": "DType.Float",
+                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSUR0CPQAAAAAAAjAN2YWyUR0CPQAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "seed",
+                                "GID": 250,
+                                "val": "gAROLg==",
+                                "dtype": "DType.Integer",
+                                "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANpbnSUk5SMBW51bXB5lIwHaW50ZWdlcpSTlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
+                            },
+                            {
+                                "type": "data",
+                                "label": "initial_temperature",
+                                "GID": 251,
+                                "val": "gAROLg==",
+                                "dtype": "DType.Float",
+                                "dtype state": "gASVmQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZSMCGRlY2ltYWxzlEsKdS4="
+                            },
+                            {
+                                "type": "data",
+                                "label": "dynamics",
+                                "GID": 252,
+                                "val": "gASVDAAAAAAAAACMCGxhbmdldmlulC4=",
+                                "dtype": "DType.Choice",
+                                "dtype state": "gASVfAAAAAAAAAB9lCiMB2RlZmF1bHSUjAhsYW5nZXZpbpSMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZSMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjAVpdGVtc5RdlChoAowLbm9zZS1ob292ZXKUZXUu"
+                            }
+                        ],
+                        "outputs": [
+                            {
+                                "type": "exec",
+                                "label": "ran",
+                                "GID": 253,
+                                "dtype": "DType.Untyped",
+                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "job",
+                                "GID": 254,
+                                "dtype": "DType.Data",
+                                "dtype state": "gASVjgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjB9weWlyb25fYXRvbWlzdGljcy5sYW1tcHMubGFtbXBzlIwGTGFtbXBzlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "energy_pot",
+                                "GID": 255,
+                                "dtype": "DType.Float",
+                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURwAAAAAAAAAAjAN2YWyURwAAAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu",
+                                "otype_namespace": "atomistics",
+                                "otype_name": "atomistic_taker_output_energy_pot"
+                            },
+                            {
+                                "type": "data",
+                                "label": "forces",
+                                "GID": 256,
+                                "dtype": "DType.List",
+                                "dtype state": "gASVgQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJdS4=",
+                                "otype_namespace": "atomistics",
+                                "otype_name": "atomistic_taker_output_forces"
+                            }
+                        ],
+                        "GID": 238,
+                        "pos x": 918.8198224004584,
+                        "pos y": 100.28571428571428
                     }
                 ],
                 "connections": [
                     {
-                        "GID": 72,
+                        "GID": 77,
                         "parent node index": 0,
+                        "output port index": 0,
+                        "connected node": 1,
+                        "connected input port index": 0
+                    },
+                    {
+                        "GID": 78,
+                        "parent node index": 1,
+                        "output port index": 0,
+                        "connected node": 2,
+                        "connected input port index": 1
+                    },
+                    {
+                        "GID": 257,
+                        "parent node index": 2,
+                        "output port index": 0,
+                        "connected node": 7,
+                        "connected input port index": 3
+                    },
+                    {
+                        "GID": 82,
+                        "parent node index": 4,
                         "output port index": 0,
                         "connected node": 3,
                         "connected input port index": 0
                     },
                     {
-                        "GID": 73,
-                        "parent node index": 1,
+                        "GID": 83,
+                        "parent node index": 5,
+                        "output port index": 0,
+                        "connected node": 3,
+                        "connected input port index": 1
+                    },
+                    {
+                        "GID": 260,
+                        "parent node index": 6,
                         "output port index": 0,
                         "connected node": 2,
                         "connected input port index": 0
                     },
                     {
-                        "GID": 74,
-                        "parent node index": 2,
-                        "output port index": 0,
-                        "connected node": 3,
-                        "connected input port index": 1
-                    },
-                    {
-                        "GID": 75,
-                        "parent node index": 3,
-                        "output port index": 0,
+                        "GID": 258,
+                        "parent node index": 7,
+                        "output port index": 1,
                         "connected node": 4,
-                        "connected input port index": 3
+                        "connected input port index": 0
                     },
                     {
                         "GID": 259,
-                        "parent node index": 4,
-                        "output port index": 1,
-                        "connected node": 6,
-                        "connected input port index": 0
-                    },
-                    {
-                        "GID": 260,
-                        "parent node index": 4,
-                        "output port index": 1,
-                        "connected node": 7,
-                        "connected input port index": 0
-                    },
-                    {
-                        "GID": 261,
-                        "parent node index": 6,
-                        "output port index": 0,
-                        "connected node": 5,
-                        "connected input port index": 0
-                    },
-                    {
-                        "GID": 262,
                         "parent node index": 7,
-                        "output port index": 0,
+                        "output port index": 1,
                         "connected node": 5,
-                        "connected input port index": 1
+                        "connected input port index": 0
                     }
                 ],
                 "GID": 7
@@ -659,36 +699,6 @@
                 "algorithm mode": "data",
                 "nodes": [
                     {
-                        "identifier": "Project_Node",
-                        "version": null,
-                        "state data": "gAR9lC4=",
-                        "additional data": {},
-                        "inputs": [
-                            {
-                                "type": "data",
-                                "label": "name",
-                                "GID": 88,
-                                "val": "gASVBQAAAAAAAACMAS6ULg==",
-                                "dtype": "DType.String",
-                                "dtype state": "gASVigAAAAAAAAB9lCiMB2RlZmF1bHSUjAEulIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwDc3RylJOUjAVudW1weZSMBHN0cl+Uk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
-                            }
-                        ],
-                        "outputs": [
-                            {
-                                "type": "data",
-                                "label": "project",
-                                "GID": 89,
-                                "dtype": "DType.Data",
-                                "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjBlweWlyb25fYXRvbWlzdGljcy5wcm9qZWN0lIwHUHJvamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg==",
-                                "otype_namespace": "atomistics",
-                                "otype_name": "project_output_atomistics_project"
-                            }
-                        ],
-                        "GID": 87,
-                        "pos x": 19.043254081924943,
-                        "pos y": 22.736263736263737
-                    },
-                    {
                         "identifier": "Linspace_Node",
                         "version": null,
                         "state data": "gAR9lC4=",
@@ -697,7 +707,7 @@
                             {
                                 "type": "data",
                                 "label": "min",
-                                "GID": 91,
+                                "GID": 95,
                                 "val": "gASVCgAAAAAAAABHQA5mZmZmZmYu",
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURz/wAAAAAAAAjAN2YWyURz/wAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
@@ -705,7 +715,7 @@
                             {
                                 "type": "data",
                                 "label": "max",
-                                "GID": 92,
+                                "GID": 96,
                                 "val": "gASVCgAAAAAAAABHQBDMzMzMzM0u",
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSUR0AAAAAAAAAAjAN2YWyUR0AAAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
@@ -713,7 +723,7 @@
                             {
                                 "type": "data",
                                 "label": "steps",
-                                "GID": 93,
+                                "GID": 97,
                                 "val": "gARLCS4=",
                                 "dtype": "DType.Integer",
                                 "dtype state": "gASViwAAAAAAAAB9lCiMB2RlZmF1bHSUSwqMA3ZhbJRLCowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA2ludJSTlIwFbnVtcHmUjAdpbnRlZ2VylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -723,12 +733,12 @@
                             {
                                 "type": "data",
                                 "label": "linspace",
-                                "GID": 94,
+                                "GID": 98,
                                 "dtype": "DType.List",
                                 "dtype state": "gASVawAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAVudW1weZSMCGZsb2F0aW5nlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIl1Lg=="
                             }
                         ],
-                        "GID": 90,
+                        "GID": 94,
                         "pos x": 21.243196791750222,
                         "pos y": 305.6263736263736
                     },
@@ -741,7 +751,7 @@
                             {
                                 "type": "data",
                                 "label": "element",
-                                "GID": 96,
+                                "GID": 100,
                                 "val": "gASVBgAAAAAAAACMAkFslC4=",
                                 "dtype": "DType.String",
                                 "dtype state": "gASViwAAAAAAAAB9lCiMB2RlZmF1bHSUjAJGZZSMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA3N0cpSTlIwFbnVtcHmUjARzdHJflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu",
@@ -751,7 +761,7 @@
                             {
                                 "type": "data",
                                 "label": "crystal_structure",
-                                "GID": 97,
+                                "GID": 101,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Choice",
                                 "dtype state": "gASVwgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiYwFaXRlbXOUXZQoTowCc2OUjANmY2OUjANiY2OUjANoY3CUjAdkaWFtb25klIwKemluY2JsZW5kZZSMCHJvY2tzYWx0lIwOY2VzaXVtY2hsb3JpZGWUjAhmbHVvcml0ZZSMCHd1cnR6aXRllGV1Lg=="
@@ -759,14 +769,14 @@
                             {
                                 "type": "data",
                                 "label": "a",
-                                "GID": 98,
+                                "GID": 102,
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVmQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSIjARzaXpllIwBbZSMCGRlY2ltYWxzlEsKdS4="
                             },
                             {
                                 "type": "data",
                                 "label": "c",
-                                "GID": 99,
+                                "GID": 103,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVmQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZSMCGRlY2ltYWxzlEsKdS4="
@@ -774,7 +784,7 @@
                             {
                                 "type": "data",
                                 "label": "c_over_a",
-                                "GID": 100,
+                                "GID": 104,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVmQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZSMCGRlY2ltYWxzlEsKdS4="
@@ -782,7 +792,7 @@
                             {
                                 "type": "data",
                                 "label": "u",
-                                "GID": 101,
+                                "GID": 105,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVmQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZSMCGRlY2ltYWxzlEsKdS4="
@@ -790,7 +800,7 @@
                             {
                                 "type": "data",
                                 "label": "orthorhombic",
-                                "GID": 102,
+                                "GID": 106,
                                 "val": "gASJLg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -798,7 +808,7 @@
                             {
                                 "type": "data",
                                 "label": "cubic",
-                                "GID": 103,
+                                "GID": 107,
                                 "val": "gASJLg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -808,14 +818,14 @@
                             {
                                 "type": "data",
                                 "label": "structure",
-                                "GID": 104,
+                                "GID": 108,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVmgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCxweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLnN0cnVjdHVyZS5hdG9tc5SMBUF0b21zlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIiMBHNpemWUjAFtlHUu",
                                 "otype_namespace": "atomistics",
                                 "otype_name": "bulk_structure_output_structure"
                             }
                         ],
-                        "GID": 95,
+                        "GID": 99,
                         "pos x": 294.03609281008306,
                         "pos y": 178.08791208791212
                     },
@@ -828,7 +838,7 @@
                             {
                                 "type": "data",
                                 "label": "project",
-                                "GID": 106,
+                                "GID": 110,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjBlweWlyb25fYXRvbWlzdGljcy5wcm9qZWN0lIwHUHJvamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg==",
                                 "otype_namespace": "atomistics",
@@ -837,7 +847,7 @@
                             {
                                 "type": "data",
                                 "label": "structure",
-                                "GID": 107,
+                                "GID": 111,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVmgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCxweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLnN0cnVjdHVyZS5hdG9tc5SMBUF0b21zlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIiMBHNpemWUjAFtlHUu",
                                 "otype_namespace": "atomistics",
@@ -846,7 +856,7 @@
                             {
                                 "type": "data",
                                 "label": "potential",
-                                "GID": 108,
+                                "GID": 112,
                                 "val": "gASVKwAAAAAAAACMJzE5OTUtLUFuZ2Vsby1KLUUtLU5pLUFsLUgtLUxBTU1QUy0taXByMZQu",
                                 "dtype": "DType.Choice",
                                 "dtype state": "gASVnxsAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAhidWlsdGluc5SMA3N0cpSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjAVpdGVtc5RdlCiMJzE5OTUtLUFuZ2Vsby1KLUUtLU5pLUFsLUgtLUxBTU1QUy0taXByMZSMJjE5OTYtLUZhcmthcy1ELS1OYi1UaS1BbC0tTEFNTVBTLS1pcHIxlIwiMTk5Ny0tTGl1LVgtWS0tQWwtTWctLUxBTU1QUy0taXByMZSMIjE5OTgtLUxpdS1YLVktLUFsLU1nLS1MQU1NUFMtLWlwcjGUjCIxOTk5LS1MaXUtWC1ZLS1BbC1DdS0tTEFNTVBTLS1pcHIxlIwgMTk5OS0tTWlzaGluLVktLUFsLS1MQU1NUFMtLWlwcjGUjCIyMDAwLS1MYW5kYS1BLS1BbC1QYi0tTEFNTVBTLS1pcHIxlIwkMjAwMC0tU3R1cmdlb24tSi1CLS1BbC0tTEFNTVBTLS1pcHIxlIwjMjAwMi0tTWlzaGluLVktLU5pLUFsLS1MQU1NUFMtLWlwcjGUjB8yMDAzLS1MZWUtQi1KLS1BbC0tTEFNTVBTLS1pcHIxlIwgMjAwMy0tWm9wZS1SLVItLUFsLS1MQU1NUFMtLWlwcjGUjCMyMDAzLS1ab3BlLVItUi0tVGktQWwtLUxBTU1QUy0taXByMZSMHzIwMDQtLUxpdS1YLVktLUFsLS1MQU1NUFMtLWlwcjGUjCMyMDA0LS1NaXNoaW4tWS0tTmktQWwtLUxBTU1QUy0taXByMZSMIzIwMDQtLU1pc2hpbi1ZLS1OaS1BbC0tTEFNTVBTLS1pcHIylIwgMjAwNC0tWmhvdS1YLVctLUFsLS1MQU1NUFMtLWlwcjKUjCcyMDA1LS1NZW5kZWxldi1NLUktLUFsLUZlLS1MQU1NUFMtLWlwcjGUjCQyMDA3LS1TaWx2YS1BLUMtLUFsLU5pLS1MQU1NUFMtLWlwcjGUjCQyMDA4LS1NZW5kZWxldi1NLUktLUFsLS1MQU1NUFMtLWlwcjGUjCIyMDA5LS1LaW0tWS1NLS1NZy1BbC0tTEFNTVBTLS1pcHIxlIwnMjAwOS0tTWVuZGVsZXYtTS1JLS1BbC1NZy0tTEFNTVBTLS1pcHIxlIwoMjAwOS0tUHVyamEtUHVuLUctUC0tTmktQWwtLUxBTU1QUy0taXByMZSMJzIwMDktLVpoYWtob3Zza2lpLVYtVi0tQWwtLUxBTU1QUy0taXByMpSMIDIwMTAtLUxlZS1FLS1GZS1BbC0tTEFNTVBTLS1pcHIxlIwwMjAxMC0tTWVuZGVsZXYtTS1JLS1maWN0aW9uYWwtQWwtMS0tTEFNTVBTLS1pcHIxlIwwMjAxMC0tTWVuZGVsZXYtTS1JLS1maWN0aW9uYWwtQWwtMi0tTEFNTVBTLS1pcHIxlIwwMjAxMC0tTWVuZGVsZXYtTS1JLS1maWN0aW9uYWwtQWwtMy0tTEFNTVBTLS1pcHIxlIwhMjAxMC0tV2luZXktSi1NLS1BbC0tTEFNTVBTLS1pcHIxlIwkMjAxMS0tQXBvc3RvbC1GLS1BbC1DdS0tTEFNTVBTLS1pcHIxlIwgMjAxMS0tS28tVy1TLS1BbC1ILS1MQU1NUFMtLWlwcjGUjCMyMDEyLS1Eb25nLVctUC0tQ28tQWwtLUxBTU1QUy0taXByMZSMLTIwMTItLUplbGluZWstQi0tQWwtU2ktTWctQ3UtRmUtLUxBTU1QUy0taXByMpSMJjIwMTItLVNjaG9wZi1ELS1BbC1Nbi1QZC0tTEFNTVBTLS1pcHIxlIwiMjAxMy0tU2hpbS1KLUgtLVYtQWwtLUxBTU1QUy0taXByMZSMJDIwMTMtLVNoaW0tSi1ILS1WLUFsLUgtLUxBTU1QUy0taXByMZSMIzIwMTUtLUNob3VkaGFyeS1LLS1BbC0tTEFNTVBTLS1pcHIxlIwlMjAxNS0tQ2hvdWRoYXJ5LUstLUFsLU8tLUxBTU1QUy0taXByMZSMJTIwMTUtLUtpbS1ZLUstLU5pLUFsLUNvLS1MQU1NUFMtLWlwcjGUjCIyMDE1LS1LdW1hci1BLS1BbC1OaS0tTEFNTVBTLS1pcHIxlIwkMjAxNS0tS3VtYXItQS0tQWwtTmktTy0tTEFNTVBTLS1pcHIxlIwnMjAxNS0tTWVuZGVsZXYtTS1JLS1BbC1TbS0tTEFNTVBTLS1pcHIxlIwjMjAxNS0tUGFzY3VldC1NLUktLUFsLS1MQU1NUFMtLWlwcjGUjCUyMDE1LS1QYXNjdWV0LU0tSS0tQWwtVS0tTEFNTVBTLS1pcHIylIwoMjAxNS0tUHVyamEtUHVuLUctUC0tQWwtQ28tLUxBTU1QUy0taXByMpSMKzIwMTUtLVB1cmphLVB1bi1HLVAtLU5pLUFsLUNvLS1MQU1NUFMtLWlwcjKUjCIyMDE2LS1LaW0tWS1LLS1BbC1UaS0tTEFNTVBTLS1pcHIxlIwjMjAxNi0tWmhvdS1YLVctLUFsLUN1LS1MQU1NUFMtLWlwcjKUjB4yMDE3LS1Cb3R1LVYtLUFsLS1MQU1NUFMtLWlwcjGUjCIyMDE3LS1LaW0tSi1TLS1QdC1BbC0tTEFNTVBTLS1pcHIxlIwlMjAxNy0tS2ltLVktSy0tTmktQWwtVGktLUxBTU1QUy0taXByMZSMKDIwMTgtLURpY2tlbC1ELUUtLU1nLUFsLVpuLS1MQU1NUFMtLWlwcjGUjCQyMDE4LS1KZW9uZy1HLVUtLVBkLUFsLS1MQU1NUFMtLWlwcjGUjCUyMDE4LS1aaG91LVgtVy0tQWwtQ3UtSC0tTEFNTVBTLS1pcHIxlIwmMjAxOS0tUGx1bW1lci1HLS1UaS1BbC1DLS1MQU1NUFMtLWlwcjGUjCwyMDIwLS1GYXJrYXMtRC0tRmUtTmktQ3ItQ28tQWwtLUxBTU1QUy0taXByMZSMJTIwMjAtLVB1cmphLVB1bi1HLVAtLUFsLS1MQU1NUFMtLWlwcjGUjCgyMDIwLS1TdGFyaWtvdi1TLS1TaS1BdS1BbC0tTEFNTVBTLS1pcHIxlIwoMjAyMC0tU3Rhcmlrb3YtUy0tU2ktQXUtQWwtLUxBTU1QUy0taXByMpSMJjIwMjEtLVBsdW1tZXItRy0tVGktQWwtQy0tTEFNTVBTLS1pcHIxlIwhMjAyMS0tU29uZy1ILS1BbC1TbS0tTEFNTVBTLS1pcHIxlIwqMjAyMi0tRmVyZWlkb25uZWphZC1SLS1BbC1IZi0tTEFNTVBTLS1pcHIxlIwqMjAyMi0tRmVyZWlkb25uZWphZC1SLS1BbC1OYi0tTEFNTVBTLS1pcHIxlIwqMjAyMi0tRmVyZWlkb25uZWphZC1SLS1BbC1UYS0tTEFNTVBTLS1pcHIxlIwqMjAyMi0tRmVyZWlkb25uZWphZC1SLS1BbC1UaS0tTEFNTVBTLS1pcHIxlIwqMjAyMi0tRmVyZWlkb25uZWphZC1SLS1BbC1aci0tTEFNTVBTLS1pcHIxlIwjMjAyMi0tTWFoYXRhLUEtLUFsLUN1LS1MQU1NUFMtLWlwcjGUjCMyMDIyLS1NYWhhdGEtQS0tQWwtRmUtLUxBTU1QUy0taXByMZSMIzIwMjItLU1haGF0YS1BLS1BbC1OaS0tTEFNTVBTLS1pcHIxlIwnMjAyMi0tTWVuZGVsZXYtTS1JLS1OaS1BbC0tTEFNTVBTLS1pcHIxlIxCRUFNX0N1YmljTmF0dXJhbFNwbGluZV9FcmNvbGVzc2lBZGFtc18xOTk0X0FsX19NT184MDA1MDk0NTg3MTJfMDAylIw8RUFNX0R5bmFtb19BbmdlbG9Nb29keUJhc2tlc18xOTk1X05pQWxIX19NT180MTg5NzgyMzcwNThfMDA1lIwvRUFNX0R5bmFtb19DYWlZZV8xOTk2X0FsQ3VfX01PXzk0MjU1MTA0MDA0N18wMDWUjDZFQU1fRHluYW1vX0VyY29sZXNzaUFkYW1zXzE5OTRfQWxfX01PXzEyMzYyOTQyMjA0NV8wMDWUjDdFQU1fRHluYW1vX0Zhcmthc0pvbmVzXzE5OTZfTmJUaUFsX19NT18wNDI2OTEzNjc3ODBfMDAwlIw8RUFNX0R5bmFtb19KYWNvYnNlbk5vcnNrb3ZQdXNrYV8xOTg3X0FsX19NT180MTE2OTIxMzMzNjZfMDAwlIw9RUFNX0R5bmFtb19MYW5kYVd5bmJsYXR0U2llZ2VsXzIwMDBfQWxQYl9fTU9fNjk5MTM3Mzk2MzgxXzAwNZSMMkVBTV9EeW5hbW9fTGl1QWRhbXNfMTk5OF9BbE1nX19NT18wMTk4NzM3MTU3ODZfMDAwlIw5RUFNX0R5bmFtb19MaXVFcmNvbGVzc2lBZGFtc18yMDA0X0FsX19NT18wNTExNTc2NzE1MDVfMDAwlIw3RUFNX0R5bmFtb19MaXVMaXVCb3J1Y2tpXzE5OTlfQWxDdV9fTU9fMDIwODUxMDY5NTcyXzAwMJSMO0VBTV9EeW5hbW9fTGl1T2hvdG5pY2t5QWRhbXNfMTk5N19BbE1nX19NT181NTk4NzA2MTM1NDlfMDAwlIw8RUFNX0R5bmFtb19NZW5kZWxldkFzdGFSYWhtYW5fMjAwOV9BbE1nX19NT182NTgyNzg1NDk3ODRfMDA1lIw4RUFNX0R5bmFtb19NZW5kZWxldkZhbmdZZV8yMDE1X0FsU21fX01PXzMzODYwMDIwMDczOV8wMDCUjDxFQU1fRHluYW1vX01lbmRlbGV2S3JhbWVyQmVja2VyXzIwMDhfQWxfX01PXzEwNjk2OTcwMTAyM18wMDWUjEJFQU1fRHluYW1vX01lbmRlbGV2U3JvbG92aXR6QWNrbGFuZF8yMDA1X0FsRmVfX01PXzU3NzQ1Mzg5MTk0MV8wMDWUjDhFQU1fRHluYW1vX01pc2hpbkZhcmthc01laGxfMTk5OV9BbF9fTU9fNjUxODAxNDg2Njc5XzAwNZSMR0VBTV9EeW5hbW9fTWlzaGluTWVobFBhcGFjb25zdGFudG9wb3Vsb3NfMjAwMl9OaUFsX19NT18xMDk5MzM1NjE1MDdfMDA1lIwwRUFNX0R5bmFtb19NaXNoaW5fMjAwNF9OaUFsX19NT18xMDEyMTQzMTA2ODlfMDA1lIwzRUFNX0R5bmFtb19QdW5NaXNoaW5fMjAwOV9OaUFsX19NT183NTEzNTQ0MDM3OTFfMDA1lIw6RUFNX0R5bmFtb19QdW5ZYW1ha292TWlzaGluXzIwMTNfQWxDb19fTU9fNjc4OTUyNjEyNDEzXzAwMJSMPEVBTV9EeW5hbW9fUHVuWWFtYWtvdk1pc2hpbl8yMDEzX05pQWxDb19fTU9fODI2NTkxMzU5NTA4XzAwMJSMP0VBTV9EeW5hbW9fU2Nob3BmQnJvbW1lckZyaWdhbl8yMDEyX0FsTW5QZF9fTU9fMTM3NTcyODE3ODQyXzAwMJSMNUVBTV9EeW5hbW9fU3R1cmdlb25MYWlyZF8yMDAwX0FsX19NT18xMjA4MDg4MDU1NDFfMDA1lIw2RUFNX0R5bmFtb19WYWlsaGVGYXJrYXNfMTk5N19Db0FsX19NT18yODQ5NjMxNzk0OThfMDA1lIw4RUFNX0R5bmFtb19XaW5leUt1Ym90YUd1cHRhXzIwMTBfQWxfX01PXzE0OTMxNjg2NTYwOF8wMDWUjDJFQU1fRHluYW1vX1poYWtob3Zza3lfMjAwOV9BbF9fTU9fNTE5NjEzODkzMTk2XzAwMJSMSUVBTV9EeW5hbW9fWmhvdUpvaG5zb25XYWRsZXlfMjAwNE5JU1RyZXRhYnVsYXRpb25fQWxfX01PXzA2MDU2Nzg2ODU1OF8wMDCUjDlFQU1fRHluYW1vX1pob3VKb2huc29uV2FkbGV5XzIwMDRfQWxfX01PXzEzMTY1MDI2MTUxMF8wMDWUjDlFQU1fRHluYW1vX1pob3VXYWRsZXlKb2huc29uXzIwMDFfQWxfX01PXzA0OTI0MzQ5ODU1NV8wMDCUjDJFQU1fRHluYW1vX1pvcGVNaXNoaW5fMjAwM19BbF9fTU9fNjY0NDcwMTE0MzExXzAwNZSMNEVBTV9EeW5hbW9fWm9wZU1pc2hpbl8yMDAzX1RpQWxfX01PXzExNzY1Njc4Njc2MF8wMDWUjC9FQU1fRXJjb2xlc3NpQWRhbXNfMTk5NF9BbF9fTU9fMzI0NTA3NTM2MzQ1XzAwM5SMOEVBTV9JTURfQnJvbW1lckdhZWhsZXJfMjAwNkFfQWxOaUNvX19NT18xMjI3MDM3MDAyMjNfMDAzlIw4RUFNX0lNRF9Ccm9tbWVyR2FlaGxlcl8yMDA2Ql9BbE5pQ29fX01PXzEyODAzNzQ4NTI3Nl8wMDOUjDxFQU1fSU1EX1NjaG9wZkJyb21tZXJGcmlnYW5fMjAxMl9BbE1uUGRfX01PXzg3ODcxMjk3ODA2Ml8wMDOUjERFQU1fUXVpbnRpY0NsYW1wZWRTcGxpbmVfRXJjb2xlc3NpQWRhbXNfMTk5NF9BbF9fTU9fNDUwMDkzNzI3Mzk2XzAwMpSMREVBTV9RdWludGljSGVybWl0ZVNwbGluZV9FcmNvbGVzc2lBZGFtc18xOTk0X0FsX19NT183ODExMzg2NzE4NjNfMDAylIxRRU1UX0FzYXBfU3RhbmRhcmRfSmFjb2JzZW5TdG9sdHplTm9yc2tvdl8xOTk2X0FsQWdBdUN1TmlQZFB0X19NT18xMTUzMTY3NTA5ODZfMDAxlIxFRU1UX0FzYXBfU3RhbmRhcmRfSmFjb2JzZW5TdG9sdHplTm9yc2tvdl8xOTk2X0FsX19NT182MjMzNzYxMjQ4NjJfMDAxlIxHTUVBTV9MQU1NUFNfQWxteXJhc1Nhbmdpb3Zhbm5pU2FyYWtpbm9zXzIwMTlfTkFsVGlfX01PXzk1ODM5NTE5MDYyN18wMDCUjD9NRUFNX0xBTU1QU19Db3N0YUFncmVuQ2xhdmFndWVyYV8yMDA3X0FsTmlfX01PXzEzMTY0Mjc2ODI4OF8wMDCUjDRNRUFNX0xBTU1QU19Eb25nS2ltS29fMjAxMl9Db0FsX19NT18wOTk3MTY0MTYyMTZfMDAwlIxHTUVBTV9MQU1NUFNfSmVsaW5la0dyb2hIb3JzdGVtZXllcl8yMDEyX0FsU2lNZ0N1RmVfX01PXzI2MjUxOTUyMDY3OF8wMDCUjDZNRUFNX0xBTU1QU19KZW9uZ1BhcmtEb18yMDE4X1BkQWxfX01PXzYxNjQ4MjM1ODgwN18wMDCUjDdNRUFNX0xBTU1QU19LaW1KdW5nTGVlXzIwMTVfTmlBbENvX19NT184NzY2ODcxNjY1MTlfMDAwlIw1TUVBTV9MQU1NUFNfS2ltS2ltSnVuZ18yMDE2X0FsVGlfX01PXzYxODEzMzc2MzM3NV8wMDCUjDdNRUFNX0xBTU1QU19LaW1LaW1KdW5nXzIwMTdfTmlBbFRpX19NT180Nzg5NjcyNTU0MzVfMDAwlIw0TUVBTV9MQU1NUFNfS2ltS2ltTGVlXzIwMDlfQWxNZ19fTU9fMDU4NTM3MDg3Mzg0XzAwMJSMNE1FQU1fTEFNTVBTX0tpbVNlb2xKaV8yMDE3X1B0QWxfX01PXzc5MzE0MTAzNzcwNl8wMDCUjDNNRUFNX0xBTU1QU19Lb1NoaW1MZWVfMjAxMV9BbEhfX01PXzEyNzg0NzA4MDc1MV8wMDCUjDFNRUFNX0xBTU1QU19MZWVMZWVfMjAxMF9GZUFsX19NT18zMzIyMTE1MjIwNTBfMDAwlIw6TUVBTV9MQU1NUFNfUGFzY3VldEZlcm5hbmRlel8yMDE1X0FsVV9fTU9fNTk2MzAwNjczOTE3XzAwMJSMOU1FQU1fTEFNTVBTX1Bhc2N1ZXRGZXJuYW5kZXpfMjAxNV9BbF9fTU9fMzE1ODIwOTc0MTQ5XzAwMJSMNE1FQU1fTEFNTVBTX1NoaW1Lb0tpbV8yMDEzX0FsVkhfX01PXzM0NDcyNDE0NTMzOV8wMDCUjERNb3JzZV9TaGlmdGVkX0dpcmlmYWxjb1dlaXplcl8xOTU5SGlnaEN1dG9mZl9BbF9fTU9fMTQwMTc1NzQ4NjI2XzAwNJSMQ01vcnNlX1NoaWZ0ZWRfR2lyaWZhbGNvV2VpemVyXzE5NTlMb3dDdXRvZmZfQWxfX01PXzQxMTg5ODk1MzY2MV8wMDSUjENNb3JzZV9TaGlmdGVkX0dpcmlmYWxjb1dlaXplcl8xOTU5TWVkQ3V0b2ZmX0FsX19NT18yNzk1NDQ3NDYwOTdfMDA0lIw7U2ltX0xBTU1QU19BRFBfQXBvc3RvbE1pc2hpbl8yMDExX0FsQ3VfX1NNXzY2NzY5Njc2MzU2MV8wMDCUjEpTaW1fTEFNTVBTX0FEUF9TdGFyaWtvdkdvcmRlZXZMeXNvZ29yc2tpeV8yMDIwX1NpQXVBbF9fU01fMTEzODQzODMwNjAyXzAwMJSMPVNpbV9MQU1NUFNfQUdOSV9Cb3R1QmF0cmFDaGFwbWFuXzIwMTdfQWxfX1NNXzY2NjE4MzYzNjg5Nl8wMDCUjDxTaW1fTEFNTVBTX0JPUF9aaG91V2FyZEZvc3Rlcl8yMDE2X0FsQ3VfX1NNXzU2NjM5OTI1ODI3OV8wMDCUjEtTaW1fTEFNTVBTX01FQU1fQWxteXJhc1Nhbmdpb3Zhbm5pU2FyYWtpbm9zXzIwMTlfTkFsVGlfX1NNXzg3MTc5NTI0OTA1Ml8wMDCUjEtTaW1fTEFNTVBTX01FQU1fSmVsaW5la0dyb2hIb3JzdGVtZXllcl8yMDEyX0FsU2lNZ0N1RmVfX1NNXzY1NjUxNzM1MjQ4NV8wMDCUjD5TaW1fTEFNTVBTX01FQU1fUGFzY3VldEZlcm5hbmRlel8yMDE1X0FsVV9fU01fNzIxOTMwMzkxMDAzXzAwMJSMPVNpbV9MQU1NUFNfTUVBTV9QYXNjdWV0RmVybmFuZGV6XzIwMTVfQWxfX1NNXzgxMTU4ODk1NzE4N18wMDCUjEVTaW1fTEFNTVBTX1NNVEJRX1NhbGxlc1BvbGl0YW5vQW16YWxsYWdfMjAxNl9BbE9fX1NNXzg1Mzk2NzM1NTk3Nl8wMDCUjERTaW1fTEFNTVBTX1NNVEJRX1NhbGxlc1BvbGl0YW5vQW16YWxsYWdfMjAxNl9BbF9fU01fNDA0MDk3NjMzOTI0XzAwMJRldS4="
@@ -856,94 +866,16 @@
                             {
                                 "type": "data",
                                 "label": "engine",
-                                "GID": 109,
+                                "GID": 113,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVjgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjB9weWlyb25fYXRvbWlzdGljcy5sYW1tcHMubGFtbXBzlIwGTGFtbXBzlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIiMBHNpemWUjAFtlHUu",
                                 "otype_namespace": "atomistics",
                                 "otype_name": "lammps_output_job"
                             }
                         ],
-                        "GID": 105,
+                        "GID": 109,
                         "pos x": 577.8287023775423,
                         "pos y": 17.714285714285708
-                    },
-                    {
-                        "identifier": "CalcStatic_Node",
-                        "version": null,
-                        "state data": "gAR9lC4=",
-                        "additional data": {},
-                        "inputs": [
-                            {
-                                "type": "exec",
-                                "label": "run",
-                                "GID": 111,
-                                "val": "gAROLg==",
-                                "dtype": "DType.Untyped",
-                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
-                            },
-                            {
-                                "type": "exec",
-                                "label": "remove",
-                                "GID": 112,
-                                "val": "gAROLg==",
-                                "dtype": "DType.Untyped",
-                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "name",
-                                "GID": 113,
-                                "val": "gASVDwAAAAAAAACMC2NhbGNfc3RhdGljlC4=",
-                                "dtype": "DType.String",
-                                "dtype state": "gASVjQAAAAAAAAB9lCiMB2RlZmF1bHSUjARjYWxjlIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwDc3RylJOUjAVudW1weZSMBHN0cl+Uk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
-                            },
-                            {
-                                "type": "data",
-                                "label": "job",
-                                "GID": 114,
-                                "dtype": "DType.Data",
-                                "dtype state": "gASVjgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjB9weWlyb25fYXRvbWlzdGljcy5sYW1tcHMubGFtbXBzlIwGTGFtbXBzlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIiMBHNpemWUjAFtlHUu",
-                                "otype_namespace": "atomistics",
-                                "otype_name": "atomistic_taker_job"
-                            }
-                        ],
-                        "outputs": [
-                            {
-                                "type": "exec",
-                                "label": "ran",
-                                "GID": 115,
-                                "dtype": "DType.Untyped",
-                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "job",
-                                "GID": 116,
-                                "dtype": "DType.Data",
-                                "dtype state": "gASVjgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjB9weWlyb25fYXRvbWlzdGljcy5sYW1tcHMubGFtbXBzlIwGTGFtbXBzlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIiMBHNpemWUjAFtlHUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "energy_pot",
-                                "GID": 117,
-                                "dtype": "DType.Float",
-                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURwAAAAAAAAAAjAN2YWyURwAAAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiIwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu",
-                                "otype_namespace": "atomistics",
-                                "otype_name": "atomistic_taker_output_energy_pot"
-                            },
-                            {
-                                "type": "data",
-                                "label": "forces",
-                                "GID": 118,
-                                "dtype": "DType.List",
-                                "dtype state": "gASVgQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSIdS4=",
-                                "otype_namespace": "atomistics",
-                                "otype_name": "atomistic_taker_output_forces"
-                            }
-                        ],
-                        "GID": 110,
-                        "pos x": 830.8221140074477,
-                        "pos y": 31.087912087912088
                     },
                     {
                         "identifier": "Matplot_Node",
@@ -954,21 +886,21 @@
                             {
                                 "type": "data",
                                 "label": "x",
-                                "GID": 134,
+                                "GID": 124,
                                 "dtype": "DType.Untyped",
                                 "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
                             },
                             {
                                 "type": "data",
                                 "label": "y",
-                                "GID": 135,
+                                "GID": 125,
                                 "dtype": "DType.Untyped",
                                 "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
                             },
                             {
                                 "type": "data",
                                 "label": "fig",
-                                "GID": 136,
+                                "GID": 126,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVgAAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjBFtYXRwbG90bGliLmZpZ3VyZZSMBkZpZ3VyZZSTlGGMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
@@ -976,7 +908,7 @@
                             {
                                 "type": "data",
                                 "label": "marker",
-                                "GID": 137,
+                                "GID": 127,
                                 "val": "gASVBQAAAAAAAACMAW+ULg==",
                                 "dtype": "DType.Choice",
                                 "dtype state": "gASVzgAAAAAAAAB9lCiMB2RlZmF1bHSUjAFvlIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlIwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlF2UKIwEbm9uZZSMAS6UjAEslGgCjAF2lIwBXpSMATyUjAE+lIwBMZSMATKUjAEzlIwBNJSMATiUjAFzlIwBcJSMAVCUjAEqlIwBaJSMAUiUjAErlIwBeJSMAViUjAFklIwBRJSMAXyUjAFflGV1Lg=="
@@ -984,7 +916,7 @@
                             {
                                 "type": "data",
                                 "label": "linestyle",
-                                "GID": 138,
+                                "GID": 128,
                                 "val": "gASVCAAAAAAAAACMBG5vbmWULg==",
                                 "dtype": "DType.Choice",
                                 "dtype state": "gASVjgAAAAAAAAB9lCiMB2RlZmF1bHSUjARub25llIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlIwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlF2UKGgCjAVzb2xpZJSMBmRvdHRlZJSMBmRhc2hlZJSMB2Rhc2hkb3SUZXUu"
@@ -992,7 +924,7 @@
                             {
                                 "type": "data",
                                 "label": "color",
-                                "GID": 139,
+                                "GID": 129,
                                 "val": "gAROLg==",
                                 "dtype": "DType.String",
                                 "dtype state": "gASVhgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANzdHKUk5SMBW51bXB5lIwEc3RyX5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
@@ -1000,7 +932,7 @@
                             {
                                 "type": "data",
                                 "label": "alpha",
-                                "GID": 140,
+                                "GID": 130,
                                 "val": "gASVCgAAAAAAAABHP/AAAAAAAAAu",
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURz/wAAAAAAAAjAN2YWyURz/wAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
@@ -1008,7 +940,7 @@
                             {
                                 "type": "data",
                                 "label": "label",
-                                "GID": 141,
+                                "GID": 131,
                                 "val": "gAROLg==",
                                 "dtype": "DType.String",
                                 "dtype state": "gASVhgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANzdHKUk5SMBW51bXB5lIwEc3RyX5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
@@ -1016,7 +948,7 @@
                             {
                                 "type": "data",
                                 "label": "xlabel",
-                                "GID": 142,
+                                "GID": 132,
                                 "val": "gAROLg==",
                                 "dtype": "DType.String",
                                 "dtype state": "gASVhgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANzdHKUk5SMBW51bXB5lIwEc3RyX5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
@@ -1024,7 +956,7 @@
                             {
                                 "type": "data",
                                 "label": "ylabel",
-                                "GID": 143,
+                                "GID": 133,
                                 "val": "gAROLg==",
                                 "dtype": "DType.String",
                                 "dtype state": "gASVhgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANzdHKUk5SMBW51bXB5lIwEc3RyX5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
@@ -1032,7 +964,7 @@
                             {
                                 "type": "data",
                                 "label": "title",
-                                "GID": 144,
+                                "GID": 134,
                                 "val": "gAROLg==",
                                 "dtype": "DType.String",
                                 "dtype state": "gASVhgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANzdHKUk5SMBW51bXB5lIwEc3RyX5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
@@ -1040,7 +972,7 @@
                             {
                                 "type": "data",
                                 "label": "legend",
-                                "GID": 145,
+                                "GID": 135,
                                 "val": "gASJLg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -1048,7 +980,7 @@
                             {
                                 "type": "data",
                                 "label": "tight_layout",
-                                "GID": 146,
+                                "GID": 136,
                                 "val": "gASILg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiIwDdmFslIiMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -1058,12 +990,12 @@
                             {
                                 "type": "data",
                                 "label": "fig",
-                                "GID": 147,
+                                "GID": 137,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVgAAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjBFtYXRwbG90bGliLmZpZ3VyZZSMBkZpZ3VyZZSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
                             }
                         ],
-                        "GID": 133,
+                        "GID": 123,
                         "pos x": 1312.6095674591807,
                         "pos y": 306.6923076923077
                     },
@@ -1076,22 +1008,22 @@
                             {
                                 "type": "data",
                                 "label": "job",
-                                "GID": 264,
+                                "GID": 139,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVpgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCpweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLmpvYi5hdG9taXN0aWOUjBNBdG9taXN0aWNHZW5lcmljSm9ilJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIiMBHNpemWUjAFtlHUu"
                             },
                             {
                                 "type": "data",
                                 "label": "field",
-                                "GID": 265,
+                                "GID": 140,
                                 "val": "gASVCgAAAAAAAACMBnZvbHVtZZQu",
                                 "dtype": "DType.Choice",
-                                "dtype state": "gASVUgEAAAAAAAB9lCiMB2RlZmF1bHSUjAVzdGVwc5SMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZSMCGJ1aWx0aW5zlIwDc3RylJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlI+UKIwGZm9yY2VzlIwHaW5kaWNlc5SMEGNvbXB1dGF0aW9uX3RpbWWUjAlmb3JjZV9tYXiUjAplbmVyZ3lfcG90lIwTdG90YWxfZGlzcGxhY2VtZW50c5RoAowJcHJlc3N1cmVzlIwTdW53cmFwcGVkX3Bvc2l0aW9uc5SMDWRpc3BsYWNlbWVudHOUjAt0ZW1wZXJhdHVyZZSMCXBvc2l0aW9uc5SMEWdldF9kaXNwbGFjZW1lbnRzlIwKZW5lcmd5X3RvdJSMBnZvbHVtZZSMBWNlbGxzlJB1Lg=="
+                                "dtype state": "gASVUgEAAAAAAAB9lCiMB2RlZmF1bHSUjAVzdGVwc5SMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZSMCGJ1aWx0aW5zlIwDc3RylJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlI+UKIwKZW5lcmd5X3BvdJSMC3RlbXBlcmF0dXJllIwKZW5lcmd5X3RvdJRoAowQY29tcHV0YXRpb25fdGltZZSME3RvdGFsX2Rpc3BsYWNlbWVudHOUjAlwb3NpdGlvbnOUjAdpbmRpY2VzlIwFY2VsbHOUjA1kaXNwbGFjZW1lbnRzlIwGZm9yY2VzlIwJcHJlc3N1cmVzlIwGdm9sdW1llIwTdW53cmFwcGVkX3Bvc2l0aW9uc5SMCWZvcmNlX21heJSMEWdldF9kaXNwbGFjZW1lbnRzlJB1Lg=="
                             },
                             {
                                 "type": "data",
                                 "label": "transpose",
-                                "GID": 266,
+                                "GID": 141,
                                 "val": "gASILg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -1099,7 +1031,7 @@
                             {
                                 "type": "data",
                                 "label": "index",
-                                "GID": 267,
+                                "GID": 142,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Integer",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANpbnSUk5SMBW51bXB5lIwHaW50ZWdlcpSTlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
@@ -1109,12 +1041,12 @@
                             {
                                 "type": "data",
                                 "label": "output",
-                                "GID": 268,
+                                "GID": 143,
                                 "dtype": "DType.List",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANpbnSUk5RoCIwFZmxvYXSUk5SMBW51bXB5lIwGbnVtYmVylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIh1Lg=="
                             }
                         ],
-                        "GID": 263,
+                        "GID": 138,
                         "pos x": 1204.8123746777428,
                         "pos y": 35.48351648351648
                     },
@@ -1127,22 +1059,22 @@
                             {
                                 "type": "data",
                                 "label": "job",
-                                "GID": 270,
+                                "GID": 145,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVpgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCpweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLmpvYi5hdG9taXN0aWOUjBNBdG9taXN0aWNHZW5lcmljSm9ilJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIiMBHNpemWUjAFtlHUu"
                             },
                             {
                                 "type": "data",
                                 "label": "field",
-                                "GID": 271,
+                                "GID": 146,
                                 "val": "gASVDgAAAAAAAACMCmVuZXJneV9wb3SULg==",
                                 "dtype": "DType.Choice",
-                                "dtype state": "gASVUgEAAAAAAAB9lCiMB2RlZmF1bHSUjAVzdGVwc5SMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZSMCGJ1aWx0aW5zlIwDc3RylJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlI+UKIwGZm9yY2VzlIwHaW5kaWNlc5SMEGNvbXB1dGF0aW9uX3RpbWWUjAlmb3JjZV9tYXiUjAplbmVyZ3lfcG90lIwTdG90YWxfZGlzcGxhY2VtZW50c5RoAowJcHJlc3N1cmVzlIwTdW53cmFwcGVkX3Bvc2l0aW9uc5SMDWRpc3BsYWNlbWVudHOUjAt0ZW1wZXJhdHVyZZSMCXBvc2l0aW9uc5SMEWdldF9kaXNwbGFjZW1lbnRzlIwKZW5lcmd5X3RvdJSMBnZvbHVtZZSMBWNlbGxzlJB1Lg=="
+                                "dtype state": "gASVUgEAAAAAAAB9lCiMB2RlZmF1bHSUjAVzdGVwc5SMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZSMCGJ1aWx0aW5zlIwDc3RylJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlI+UKIwKZW5lcmd5X3BvdJSMC3RlbXBlcmF0dXJllIwKZW5lcmd5X3RvdJRoAowQY29tcHV0YXRpb25fdGltZZSME3RvdGFsX2Rpc3BsYWNlbWVudHOUjAlwb3NpdGlvbnOUjAdpbmRpY2VzlIwFY2VsbHOUjA1kaXNwbGFjZW1lbnRzlIwGZm9yY2VzlIwJcHJlc3N1cmVzlIwGdm9sdW1llIwTdW53cmFwcGVkX3Bvc2l0aW9uc5SMCWZvcmNlX21heJSMEWdldF9kaXNwbGFjZW1lbnRzlJB1Lg=="
                             },
                             {
                                 "type": "data",
                                 "label": "transpose",
-                                "GID": 272,
+                                "GID": 147,
                                 "val": "gASILg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -1150,7 +1082,7 @@
                             {
                                 "type": "data",
                                 "label": "index",
-                                "GID": 273,
+                                "GID": 148,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Integer",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANpbnSUk5SMBW51bXB5lIwHaW50ZWdlcpSTlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
@@ -1160,84 +1092,15 @@
                             {
                                 "type": "data",
                                 "label": "output",
-                                "GID": 274,
+                                "GID": 149,
                                 "dtype": "DType.List",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANpbnSUk5RoCIwFZmxvYXSUk5SMBW51bXB5lIwGbnVtYmVylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIh1Lg=="
                             }
                         ],
-                        "GID": 269,
+                        "GID": 144,
                         "pos x": 987.0180464050416,
                         "pos y": 308.010989010989
-                    }
-                ],
-                "connections": [
-                    {
-                        "GID": 156,
-                        "parent node index": 0,
-                        "output port index": 0,
-                        "connected node": 3,
-                        "connected input port index": 0
                     },
-                    {
-                        "GID": 157,
-                        "parent node index": 1,
-                        "output port index": 0,
-                        "connected node": 2,
-                        "connected input port index": 2
-                    },
-                    {
-                        "GID": 158,
-                        "parent node index": 2,
-                        "output port index": 0,
-                        "connected node": 3,
-                        "connected input port index": 1
-                    },
-                    {
-                        "GID": 159,
-                        "parent node index": 3,
-                        "output port index": 0,
-                        "connected node": 4,
-                        "connected input port index": 3
-                    },
-                    {
-                        "GID": 275,
-                        "parent node index": 4,
-                        "output port index": 1,
-                        "connected node": 6,
-                        "connected input port index": 0
-                    },
-                    {
-                        "GID": 276,
-                        "parent node index": 4,
-                        "output port index": 1,
-                        "connected node": 7,
-                        "connected input port index": 0
-                    },
-                    {
-                        "GID": 278,
-                        "parent node index": 6,
-                        "output port index": 0,
-                        "connected node": 5,
-                        "connected input port index": 0
-                    },
-                    {
-                        "GID": 277,
-                        "parent node index": 7,
-                        "output port index": 0,
-                        "connected node": 5,
-                        "connected input port index": 1
-                    }
-                ],
-                "GID": 86
-            },
-            "GID": 80
-        },
-        {
-            "title": "parameter_study",
-            "variables": {},
-            "flow": {
-                "algorithm mode": "data",
-                "nodes": [
                     {
                         "identifier": "Project_Node",
                         "version": null,
@@ -1247,27 +1110,214 @@
                             {
                                 "type": "data",
                                 "label": "name",
-                                "GID": 176,
-                                "val": "gASVBQAAAAAAAACMAS6ULg==",
+                                "GID": 262,
+                                "val": "gASVCwAAAAAAAACMB2V4YW1wbGWULg==",
                                 "dtype": "DType.String",
                                 "dtype state": "gASVigAAAAAAAAB9lCiMB2RlZmF1bHSUjAEulIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwDc3RylJOUjAVudW1weZSMBHN0cl+Uk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
+                            },
+                            {
+                                "type": "exec",
+                                "label": "remove",
+                                "GID": 263,
+                                "val": "gAROLg==",
+                                "dtype": "DType.Untyped",
+                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "enable_remove",
+                                "GID": 264,
+                                "val": "gASJLg==",
+                                "dtype": "DType.Boolean",
+                                "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "remove_name",
+                                "GID": 265,
+                                "val": "gASVBAAAAAAAAACMAJQu",
+                                "dtype": "DType.String",
+                                "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUjACUjAN2YWyUaAKMA2RvY5RoAowGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA3N0cpSTlIwFbnVtcHmUjARzdHJflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "remove_all",
+                                "GID": 266,
+                                "val": "gASJLg==",
+                                "dtype": "DType.Boolean",
+                                "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "recursive",
+                                "GID": 267,
+                                "val": "gASILg==",
+                                "dtype": "DType.Boolean",
+                                "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiIwDdmFslIiMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
                             }
                         ],
                         "outputs": [
                             {
                                 "type": "data",
                                 "label": "project",
-                                "GID": 177,
+                                "GID": 268,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjBlweWlyb25fYXRvbWlzdGljcy5wcm9qZWN0lIwHUHJvamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg==",
                                 "otype_namespace": "atomistics",
                                 "otype_name": "project_output_atomistics_project"
                             }
                         ],
-                        "GID": 175,
-                        "pos x": 36.642795760527065,
-                        "pos y": 42.51648351648352
+                        "GID": 261,
+                        "pos x": 22.446290461185907,
+                        "pos y": 19.78021978021978
                     },
+                    {
+                        "identifier": "CalcStatic_Node",
+                        "version": null,
+                        "state data": "gAR9lC4=",
+                        "additional data": {},
+                        "inputs": [
+                            {
+                                "type": "exec",
+                                "label": "run",
+                                "GID": 270,
+                                "val": "gAROLg==",
+                                "dtype": "DType.Untyped",
+                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
+                            },
+                            {
+                                "type": "exec",
+                                "label": "reset",
+                                "GID": 271,
+                                "val": "gAROLg==",
+                                "dtype": "DType.Untyped",
+                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "name",
+                                "GID": 272,
+                                "val": "gASVDwAAAAAAAACMC2NhbGNfc3RhdGljlC4=",
+                                "dtype": "DType.String",
+                                "dtype state": "gASVjQAAAAAAAAB9lCiMB2RlZmF1bHSUjARjYWxjlIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwDc3RylJOUjAVudW1weZSMBHN0cl+Uk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
+                            },
+                            {
+                                "type": "data",
+                                "label": "job",
+                                "GID": 273,
+                                "dtype": "DType.Data",
+                                "dtype state": "gASVjgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjB9weWlyb25fYXRvbWlzdGljcy5sYW1tcHMubGFtbXBzlIwGTGFtbXBzlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIiMBHNpemWUjAFtlHUu",
+                                "otype_namespace": "atomistics",
+                                "otype_name": "atomistic_taker_job"
+                            }
+                        ],
+                        "outputs": [
+                            {
+                                "type": "exec",
+                                "label": "ran",
+                                "GID": 274,
+                                "dtype": "DType.Untyped",
+                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "job",
+                                "GID": 275,
+                                "dtype": "DType.Data",
+                                "dtype state": "gASVjgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjB9weWlyb25fYXRvbWlzdGljcy5sYW1tcHMubGFtbXBzlIwGTGFtbXBzlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIiMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "energy_pot",
+                                "GID": 276,
+                                "dtype": "DType.Float",
+                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURwAAAAAAAAAAjAN2YWyURwAAAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiIwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu",
+                                "otype_namespace": "atomistics",
+                                "otype_name": "atomistic_taker_output_energy_pot"
+                            },
+                            {
+                                "type": "data",
+                                "label": "forces",
+                                "GID": 277,
+                                "dtype": "DType.List",
+                                "dtype state": "gASVgQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSIdS4=",
+                                "otype_namespace": "atomistics",
+                                "otype_name": "atomistic_taker_output_forces"
+                            }
+                        ],
+                        "GID": 269,
+                        "pos x": 867.2242910340876,
+                        "pos y": 32.967032967032964
+                    }
+                ],
+                "connections": [
+                    {
+                        "GID": 151,
+                        "parent node index": 0,
+                        "output port index": 0,
+                        "connected node": 1,
+                        "connected input port index": 2
+                    },
+                    {
+                        "GID": 152,
+                        "parent node index": 1,
+                        "output port index": 0,
+                        "connected node": 2,
+                        "connected input port index": 1
+                    },
+                    {
+                        "GID": 279,
+                        "parent node index": 2,
+                        "output port index": 0,
+                        "connected node": 7,
+                        "connected input port index": 3
+                    },
+                    {
+                        "GID": 156,
+                        "parent node index": 4,
+                        "output port index": 0,
+                        "connected node": 3,
+                        "connected input port index": 0
+                    },
+                    {
+                        "GID": 157,
+                        "parent node index": 5,
+                        "output port index": 0,
+                        "connected node": 3,
+                        "connected input port index": 1
+                    },
+                    {
+                        "GID": 278,
+                        "parent node index": 6,
+                        "output port index": 0,
+                        "connected node": 2,
+                        "connected input port index": 0
+                    },
+                    {
+                        "GID": 280,
+                        "parent node index": 7,
+                        "output port index": 1,
+                        "connected node": 4,
+                        "connected input port index": 0
+                    },
+                    {
+                        "GID": 281,
+                        "parent node index": 7,
+                        "output port index": 1,
+                        "connected node": 5,
+                        "connected input port index": 0
+                    }
+                ],
+                "GID": 90
+            },
+            "GID": 84
+        },
+        {
+            "title": "parameter_study",
+            "variables": {},
+            "flow": {
+                "algorithm mode": "data",
+                "nodes": [
                     {
                         "identifier": "BulkStructure_Node",
                         "version": null,
@@ -1277,7 +1327,7 @@
                             {
                                 "type": "data",
                                 "label": "element",
-                                "GID": 179,
+                                "GID": 169,
                                 "val": "gASVBgAAAAAAAACMAkZllC4=",
                                 "dtype": "DType.String",
                                 "dtype state": "gASViwAAAAAAAAB9lCiMB2RlZmF1bHSUjAJGZZSMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA3N0cpSTlIwFbnVtcHmUjARzdHJflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu",
@@ -1287,7 +1337,7 @@
                             {
                                 "type": "data",
                                 "label": "crystal_structure",
-                                "GID": 180,
+                                "GID": 170,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Choice",
                                 "dtype state": "gASVwgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiYwFaXRlbXOUXZQoTowCc2OUjANmY2OUjANiY2OUjANoY3CUjAdkaWFtb25klIwKemluY2JsZW5kZZSMCHJvY2tzYWx0lIwOY2VzaXVtY2hsb3JpZGWUjAhmbHVvcml0ZZSMCHd1cnR6aXRllGV1Lg=="
@@ -1295,7 +1345,7 @@
                             {
                                 "type": "data",
                                 "label": "a",
-                                "GID": 181,
+                                "GID": 171,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVmQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZSMCGRlY2ltYWxzlEsKdS4="
@@ -1303,7 +1353,7 @@
                             {
                                 "type": "data",
                                 "label": "c",
-                                "GID": 182,
+                                "GID": 172,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVmQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZSMCGRlY2ltYWxzlEsKdS4="
@@ -1311,7 +1361,7 @@
                             {
                                 "type": "data",
                                 "label": "c_over_a",
-                                "GID": 183,
+                                "GID": 173,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVmQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZSMCGRlY2ltYWxzlEsKdS4="
@@ -1319,7 +1369,7 @@
                             {
                                 "type": "data",
                                 "label": "u",
-                                "GID": 184,
+                                "GID": 174,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVmQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZSMCGRlY2ltYWxzlEsKdS4="
@@ -1327,7 +1377,7 @@
                             {
                                 "type": "data",
                                 "label": "orthorhombic",
-                                "GID": 185,
+                                "GID": 175,
                                 "val": "gASJLg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -1335,7 +1385,7 @@
                             {
                                 "type": "data",
                                 "label": "cubic",
-                                "GID": 186,
+                                "GID": 176,
                                 "val": "gASJLg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -1345,14 +1395,14 @@
                             {
                                 "type": "data",
                                 "label": "structure",
-                                "GID": 187,
+                                "GID": 177,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVmgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCxweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLnN0cnVjdHVyZS5hdG9tc5SMBUF0b21zlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu",
                                 "otype_namespace": "atomistics",
                                 "otype_name": "bulk_structure_output_structure"
                             }
                         ],
-                        "GID": 178,
+                        "GID": 168,
                         "pos x": 46.64566026926382,
                         "pos y": 268.13186813186815
                     },
@@ -1365,7 +1415,7 @@
                             {
                                 "type": "data",
                                 "label": "structure",
-                                "GID": 189,
+                                "GID": 179,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVmgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCxweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLnN0cnVjdHVyZS5hdG9tc5SMBUF0b21zlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
                             }
@@ -1374,12 +1424,12 @@
                             {
                                 "type": "data",
                                 "label": "potentials",
-                                "GID": 190,
+                                "GID": 180,
                                 "dtype": "DType.List",
                                 "dtype state": "gASVaQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAhidWlsdGluc5SMA3N0cpSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJdS4="
                             }
                         ],
-                        "GID": 188,
+                        "GID": 178,
                         "pos x": 318.23546261816097,
                         "pos y": 268.8901098901099
                     },
@@ -1392,14 +1442,14 @@
                             {
                                 "type": "data",
                                 "label": "array",
-                                "GID": 192,
+                                "GID": 182,
                                 "dtype": "DType.List",
                                 "dtype state": "gASVbAAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAhidWlsdGluc5SMBm9iamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJdS4="
                             },
                             {
                                 "type": "data",
                                 "label": "i",
-                                "GID": 193,
+                                "GID": 183,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Integer",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANpbnSUk5SMBW51bXB5lIwHaW50ZWdlcpSTlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
@@ -1407,7 +1457,7 @@
                             {
                                 "type": "data",
                                 "label": "j",
-                                "GID": 194,
+                                "GID": 184,
                                 "val": "gARLFC4=",
                                 "dtype": "DType.Integer",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANpbnSUk5SMBW51bXB5lIwHaW50ZWdlcpSTlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
@@ -1417,12 +1467,12 @@
                             {
                                 "type": "data",
                                 "label": "sliced",
-                                "GID": 195,
+                                "GID": 185,
                                 "dtype": "DType.List",
                                 "dtype state": "gASVbAAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAhidWlsdGluc5SMBm9iamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJdS4="
                             }
                         ],
-                        "GID": 191,
+                        "GID": 181,
                         "pos x": 598.8312804354053,
                         "pos y": 276.9230769230769
                     },
@@ -1435,7 +1485,7 @@
                             {
                                 "type": "data",
                                 "label": "project",
-                                "GID": 197,
+                                "GID": 187,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjBlweWlyb25fYXRvbWlzdGljcy5wcm9qZWN0lIwHUHJvamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg==",
                                 "otype_namespace": "atomistics",
@@ -1444,7 +1494,7 @@
                             {
                                 "type": "data",
                                 "label": "structure",
-                                "GID": 198,
+                                "GID": 188,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVmgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCxweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLnN0cnVjdHVyZS5hdG9tc5SMBUF0b21zlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu",
                                 "otype_namespace": "atomistics",
@@ -1453,7 +1503,7 @@
                             {
                                 "type": "data",
                                 "label": "potential",
-                                "GID": 199,
+                                "GID": 189,
                                 "dtype": "DType.Choice",
                                 "dtype state": "gASVLxkAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAhidWlsdGluc5SMA3N0cpSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSIjAVpdGVtc5RdlCiMIzE5OTctLUFja2xhbmQtRy1KLS1GZS0tTEFNTVBTLS1pcHIxlIwfMTk5OC0tTWV5ZXItUi0tRmUtLUxBTU1QUy0taXByMZSMHzIwMDEtLUxlZS1CLUotLUZlLS1MQU1NUFMtLWlwcjGUjCIyMDAxLS1MZWUtQi1KLS1GZS1Dci0tTEFNTVBTLS1pcHIxlIwmMjAwMy0tTWVuZGVsZXYtTS1JLS1GZS0yLS1MQU1NUFMtLWlwcjOUjCYyMDAzLS1NZW5kZWxldi1NLUktLUZlLTUtLUxBTU1QUy0taXByMZSMJTIwMDQtLUFja2xhbmQtRy1KLS1GZS1QLS1MQU1NUFMtLWlwcjGUjCAyMDA0LS1aaG91LVgtVy0tRmUtLUxBTU1QUy0taXByMpSMIjIwMDUtLUxlZS1CLUotLUZlLUN1LS1MQU1NUFMtLWlwcjGUjCcyMDA1LS1NZW5kZWxldi1NLUktLUFsLUZlLS1MQU1NUFMtLWlwcjGUjCEyMDA2LS1DaGFtYXRpLUgtLUZlLS1MQU1NUFMtLWlwcjGUjCAyMDA2LS1LaW0tSi0tRmUtUHQtLUxBTU1QUy0taXByMZSMITIwMDYtLUxlZS1CLUotLUZlLUMtLUxBTU1QUy0taXByMZSMITIwMDYtLUxlZS1CLUotLUZlLU4tLUxBTU1QUy0taXByMZSMITIwMDctLUxlZS1CLUotLUZlLUgtLUxBTU1QUy0taXByMZSMJjIwMDctLU1lbmRlbGV2LU0tSS0tVi1GZS0tTEFNTVBTLS1pcHIxlIwlMjAwOC0tSGVwYnVybi1ELUotLUZlLUMtLUxBTU1QUy0taXByMZSMHzIwMDgtLVNhLUktLUZlLU5iLS1MQU1NUFMtLWlwcjGUjB8yMDA4LS1TYS1JLS1GZS1UaS0tTEFNTVBTLS1pcHIxlIwlMjAwOS0tQm9ubnktRy0tRmUtQ3UtTmktLUxBTU1QUy0taXByMZSMIjIwMDktLUJvbm55LUctLUZlLU5pLS1MQU1NUFMtLWlwcjGUjCQyMDA5LS1LaW0tSC1LLS1GZS1UaS1DLS1MQU1NUFMtLWlwcjKUjCIyMDA5LS1LaW0tWS1NLS1GZS1Nbi0tTEFNTVBTLS1pcHIxlIwkMjAwOS0tT2xzc29uLVAtQS1ULS1GZS0tTEFNTVBTLS1pcHIxlIwmMjAwOS0tU3R1a293c2tpLUEtLUZlLUNyLS1MQU1NUFMtLWlwcjGUjCQyMDEwLS1LaW0tSC1LLS1GZS1OYi1DLS1MQU1NUFMtLWlwcjGUjCAyMDEwLS1MZWUtRS0tRmUtQWwtLUxBTU1QUy0taXByMZSMITIwMTAtLU1hbGVyYmEtTC0tRmUtLUxBTU1QUy0taXByMZSMIjIwMTEtLUJvbm55LUctLUZlLUNyLS1MQU1NUFMtLWlwcjKUjCIyMDExLS1Cb25ueS1HLS1GZS1Dci0tTEFNTVBTLS1pcHIzlIwlMjAxMS0tQm9ubnktRy0tRmUtTmktQ3ItLUxBTU1QUy0taXByMZSMJTIwMTEtLUJvbm55LUctLUZlLU5pLUNyLS1MQU1NUFMtLWlwcjKUjCMyMDExLS1DaGllc2EtUy0tRmUtMzMtLUxBTU1QUy0taXByMZSMLTIwMTItLUplbGluZWstQi0tQWwtU2ktTWctQ3UtRmUtLUxBTU1QUy0taXByMpSMIDIwMTItLUtvLVctUy0tRmUtUC0tTEFNTVBTLS1pcHIxlIwiMjAxMi0tUHJvdmlsbGUtTC0tRmUtLUxBTU1QUy0taXByMZSMJDIwMTMtLUJvbm55LUctLUZlLUNyLVctLUxBTU1QUy0taXByMpSMJDIwMTMtLUJvbm55LUctLUZlLUNyLVctLUxBTU1QUy0taXByM5SMJTIwMTMtLUJvbm55LUctLUZlLU5pLUNyLS1MQU1NUFMtLWlwcjGUjCEyMDEzLS1Cb25ueS1HLS1GZS1XLS1MQU1NUFMtLWlwcjGUjCoyMDEzLS1IZW5yaWtzc29uLUstTy1FLS1GZS1DLS1MQU1NUFMtLWlwcjGUjCgyMDE0LS1MaXlhbmFnZS1MLVMtSS0tRmUtQy0tTEFNTVBTLS1pcHIylIwfMjAxNS0tQXNhZGktRS0tRmUtLUxBTU1QUy0taXByMZSMIzIwMTUtLUVpY2gtUy1NLS1GZS1Dci0tTEFNTVBTLS1pcHIxlIwoMjAxNy0tQmVsYW5kLUwtSy0tRmUtTmktQ3ItLUxBTU1QUy0taXByMZSMIzIwMTctLUNob2ktVy1NLS1Dby1GZS0tTEFNTVBTLS1pcHIxlIwiMjAxNy0tV3UtQy0tTmktQ3ItRmUtLUxBTU1QUy0taXByMZSMHzIwMTctLVd1LUMtLU5pLUZlLS1MQU1NUFMtLWlwcjGUjCwyMDE4LS1DaG9pLVctTS0tQ28tTmktQ3ItRmUtTW4tLUxBTU1QUy0taXByMZSMIzIwMTgtLUV0ZXNhbWktUy1BLS1GZS0tTEFNTVBTLS1pcHIxlIwsMjAxOC0tRmFya2FzLUQtLUZlLU5pLUNyLUNvLUN1LS1MQU1NUFMtLWlwcjKUjCQyMDE4LS1KZW9uZy1HLVUtLVBkLUZlLS1MQU1NUFMtLWlwcjGUjCYyMDE4LS1aaG91LVgtVy0tRmUtTmktQ3ItLUxBTU1QUy0taXByMZSMJjIwMTgtLVpob3UtWC1XLS1GZS1OaS1Dci0tTEFNTVBTLS1pcHIylIwnMjAxOS0tQXNsYW0tSS0tRmUtTW4tU2ktQy0tTEFNTVBTLS1pcHIxlIwmMjAxOS0tQnlnZ21hc3Rhci1KLS1GZS1PLS1MQU1NUFMtLWlwcjGUjCoyMDE5LS1NZW5kZWxldi1NLUktLUZlLU5pLUNyLS1MQU1NUFMtLWlwcjGUjCQyMDIwLS1CeWdnbWFzdGFyLUotLUZlLS1MQU1NUFMtLWlwcjGUjCwyMDIwLS1GYXJrYXMtRC0tRmUtTmktQ3ItQ28tQWwtLUxBTU1QUy0taXByMZSMLDIwMjAtLUdyb2dlci1SLS1Dby1Dci1GZS1Nbi1OaS0tTEFNTVBTLS1pcHIxlIweMjAyMC0tTW9yaS1ILS1GZS0tTEFNTVBTLS1pcHIxlIwvMjAyMS0tRGVsdWlnaS1PLVItLUZlLU5pLUNyLUNvLUN1LS1MQU1NUFMtLWlwcjGUjCIyMDIxLS1TdGFyaWtvdi1TLS1GZS0tTEFNTVBTLS1pcHIxlIwiMjAyMS0tU3Rhcmlrb3YtUy0tRmUtLUxBTU1QUy0taXByMpSMHzIwMjEtLVdlbi1NLS1GZS1ILS1MQU1NUFMtLWlwcjGUjCMyMDIyLS1NYWhhdGEtQS0tQWwtRmUtLUxBTU1QUy0taXByMZSMJzIwMjItLVN0YXJpa292LVMtLUZlLUNyLUgtLUxBTU1QUy0taXByMZSMHTIwMjItLVN1bi1ZLS1GZS0tTEFNTVBTLS1pcHIxlIw6RUFNX0R5bmFtb19BY2tsYW5kQmFjb25DYWxkZXJfMTk5N19GZV9fTU9fMTQyNzk5NzE3NTE2XzAwNZSMQUVBTV9EeW5hbW9fQWNrbGFuZE1lbmRlbGV2U3JvbG92aXR6XzIwMDRfRmVQX19NT184ODQzNDMxNDYzMTBfMDA1lIw7RUFNX0R5bmFtb19Cb25ueUNhc3RpbkJ1bGxlbnNfMjAxM19GZVdfX01PXzczNzU2NzI0MjYzMV8wMDCUjEBFQU1fRHluYW1vX0Jvbm55Q2FzdGluVGVyZW50eWV2XzIwMTNfRmVOaUNyX19NT183NjMxOTc5NDEwMzlfMDAwlIw/RUFNX0R5bmFtb19Cb25ueVBhc2lhbm90Q2FzdGluXzIwMDlfRmVDdU5pX19NT180NjkzNDM5NzMxNzFfMDA1lIw+RUFNX0R5bmFtb19Cb25ueVBhc2lhbm90TWFsZXJiYV8yMDA5X0ZlTmlfX01PXzI2NzcyMTQwODkzNF8wMDWUjEFFQU1fRHluYW1vX0NoYW1hdGlQYXBhbmljb2xhb3VNaXNoaW5fMjAwNl9GZV9fTU9fOTYwNjk5NTEzNDI0XzAwMJSMN0VBTV9EeW5hbW9fSGVwYnVybkFja2xhbmRfMjAwOF9GZUNfX01PXzE0Mzk3NzE1MjcyOF8wMDWUjDBFQU1fRHluYW1vX01hcmluaWNhXzIwMDdfRmVfX01PXzQ2NjgwODg3NzEzMF8wMDCUjDBFQU1fRHluYW1vX01hcmluaWNhXzIwMTFfRmVfX01PXzI1NTMxNTQwNzkxMF8wMDCUjD1FQU1fRHluYW1vX01lbmRlbGV2Qm9yb3Zpa292XzIwMjBfRmVOaUNyX19NT185MjIzNjMzNDA1NzBfMDAwlIw3RUFNX0R5bmFtb19NZW5kZWxldkhhblNvbl8yMDA3X1ZGZV9fTU9fMjQ5NzA2ODEwNTI3XzAwNZSMRkVBTV9EeW5hbW9fTWVuZGVsZXZIYW5Tcm9sb3ZpdHpfMjAwM1BvdGVudGlhbDJfRmVfX01PXzc2OTU4MjM2MzQzOV8wMDWUjEZFQU1fRHluYW1vX01lbmRlbGV2SGFuU3JvbG92aXR6XzIwMDNQb3RlbnRpYWw1X0ZlX19NT185NDI0MjA3MDY4NThfMDA1lIw8RUFNX0R5bmFtb19NZW5kZWxldkhhblNyb2xvdml0el8yMDAzX0ZlX19NT184MDc5OTc4MjY0NDlfMDAwlIxCRUFNX0R5bmFtb19NZW5kZWxldlNyb2xvdml0ekFja2xhbmRfMjAwNV9BbEZlX19NT181Nzc0NTM4OTE5NDFfMDA1lIwwRUFNX0R5bmFtb19NZW5kZWxldl8yMDAzX0ZlX19NT181NDY2NzM1NDkwODVfMDAwlIxJRUFNX0R5bmFtb19aaG91Sm9obnNvbldhZGxleV8yMDA0TklTVHJldGFidWxhdGlvbl9GZV9fTU9fNjgxMDg4Mjk4MjA4XzAwMJSMOUVBTV9EeW5hbW9fWmhvdUpvaG5zb25XYWRsZXlfMjAwNF9GZV9fTU9fNjUwMjc5OTA1MjMwXzAwNZSMRkVBTV9NYWduZXRpYzJHUXVpbnRpY19DaGllc2FEZXJsZXREdWRhcmV2XzIwMTFfRmVfX01PXzE0MDQ0NDMyMTYwN18wMDKUjDxFQU1fTWFnbmV0aWNDdWJpY19EdWRhcmV2RGVybGV0XzIwMDVfRmVfX01PXzEzNTAzNDIyOTI4Ml8wMDKUjENFQU1fTWFnbmV0aWNDdWJpY19NZW5kZWxldkhhblNyb2xvdml0el8yMDAzX0ZlX19NT184NTYyOTU5NTI0MjVfMDAylIw8TUVBTV9MQU1NUFNfQXNhZGlaYWVlbU5vdXJhbmlhbl8yMDE1X0ZlX19NT180OTIzMTA4OTg3NzlfMDAwlIw7TUVBTV9MQU1NUFNfQ2hvaUpvU29obl8yMDE4X0NvTmlDckZlTW5fX01PXzExNTQ1NDc0NzUwM18wMDCUjDZNRUFNX0xBTU1QU19DaG9pS2ltU2VvbF8yMDE3X0NvRmVfX01PXzE3OTE1ODI1NzE4MF8wMDCUjDVNRUFNX0xBTU1QU19FdGVzYW1pQXNhZGlfMjAxOF9GZV9fTU9fNTQ5OTAwMjg3NDIxXzAwMJSMR01FQU1fTEFNTVBTX0plbGluZWtHcm9oSG9yc3RlbWV5ZXJfMjAxMl9BbFNpTWdDdUZlX19NT18yNjI1MTk1MjA2NzhfMDAwlIw2TUVBTV9MQU1NUFNfSmVvbmdQYXJrRG9fMjAxOF9QZEZlX19NT185MjQ3MzY2MjIyMDNfMDAwlIw2TUVBTV9MQU1NUFNfS2ltSnVuZ0xlZV8yMDA5X0ZlVGlDX19NT18xMTAxMTkyMDQ3MjNfMDAwlIw2TUVBTV9MQU1NUFNfS2ltSnVuZ0xlZV8yMDEwX0ZlTmJDX19NT18wNzI2ODk3MTg2MTZfMDAwlIwxTUVBTV9MQU1NUFNfS2ltTGVlXzIwMDZfUHRGZV9fTU9fMzQzMTY4MTAxNDkwXzAwMJSMNU1FQU1fTEFNTVBTX0tpbVNoaW5MZWVfMjAwOV9GZU1uX19NT18wNTg3MzU0MDA0NjJfMDAwlIwyTUVBTV9MQU1NUFNfS29KaW1MZWVfMjAxMl9GZVBfX01PXzE3OTQyMDM2Mzk0NF8wMDCUjDFNRUFNX0xBTU1QU19MZWVKYW5nXzIwMDdfRmVIX19NT18wOTU2MTA5NTE5NTdfMDAwlIwzTUVBTV9MQU1NUFNfTGVlTGVlS2ltXzIwMDZfRmVOX19NT180MzI4NjE3NjY3MzhfMDAwlIwxTUVBTV9MQU1NUFNfTGVlTGVlXzIwMTBfRmVBbF9fTU9fMzMyMjExNTIyMDUwXzAwMJSMN01FQU1fTEFNTVBTX0xlZVdpcnRoU2hpbV8yMDA1X0ZlQ3VfX01PXzA2MzYyNjA2NTQzN18wMDCUjC1NRUFNX0xBTU1QU19MZWVfMjAwNl9GZUNfX01PXzg1Njk1NjE3ODY2OV8wMDCUjDpNRUFNX0xBTU1QU19MaXlhbmFnZUtpbUhvdXplXzIwMTRfRmVDX19NT18wNzUyNzk4MDAxOTVfMDAwlIwwTUVBTV9MQU1NUFNfU2FMZWVfMjAwOF9GZVRpX19NT18yNjA1NDY5Njc3OTNfMDAwlIwwTUVBTV9MQU1NUFNfU2FMZWVfMjAwOF9OYkZlX19NT18xNjIwMzYxNDEyNjFfMDAwlIw0TUVBTV9MQU1NUFNfV3VMZWVTdV8yMDE3X05pQ3JGZV9fTU9fOTEyNjM2MTA3MTA4XzAwMJSMMk1FQU1fTEFNTVBTX1d1TGVlU3VfMjAxN19OaUZlX19NT18zMjEyMzMxNzY0OThfMDAwlIwxTUpfTW9ycmlzQWdhTGV2YXNob3ZfMjAwOF9GZV9fTU9fODU3MjgyNzU0MzA3XzAwM5SMRE1vcnNlX1NoaWZ0ZWRfR2lyaWZhbGNvV2VpemVyXzE5NTlIaWdoQ3V0b2ZmX0ZlX19NT18xNDc2MDMxMjg0MzdfMDA0lIxDTW9yc2VfU2hpZnRlZF9HaXJpZmFsY29XZWl6ZXJfMTk1OUxvd0N1dG9mZl9GZV9fTU9fMzMxMjg1NDk1NjE3XzAwNJSMQ01vcnNlX1NoaWZ0ZWRfR2lyaWZhbGNvV2VpemVyXzE5NTlNZWRDdXRvZmZfRmVfX01PXzk4NDM1ODM0NDE5Nl8wMDSUjD1UZXJzb2ZmX0xBTU1QU19NdWVsbGVyRXJoYXJ0QWxiZV8yMDA3X0ZlX19NT18xMzc5NjQzMTA3MDJfMDAzlIxFU2ltX0xBTU1QU19FQU1DRF9TdHVrb3dza2lTYWRpZ2hFcmhhcnRfMjAwOV9GZUNyX19TTV83NzU1NjQ0OTk1MTNfMDAwlIxBU2ltX0xBTU1QU19FQU1fQm9ubnlDYXN0aW5CdWxsZW5zXzIwMTNfRmVDcldfX1NNXzY5OTI1NzM1MDcwNF8wMDCUjERTaW1fTEFNTVBTX0VBTV9Cb25ueVBhc2lhbm90VGVyZW50eWV2XzIwMTFfRmVDcl9fU01fMjM3MDg5Mjk4NDYzXzAwMJSMQFNpbV9MQU1NUFNfTUVBTV9Bc2FkaVphZWVtTm91cmFuaWFuXzIwMTVfRmVfX1NNXzA0MjYzMDY4MDk5M18wMDCUjDlTaW1fTEFNTVBTX01FQU1fRXRlc2FtaUFzYWRpXzIwMThfRmVfX1NNXzI2NzAxNjYwODc1NV8wMDCUjEtTaW1fTEFNTVBTX01FQU1fSmVsaW5la0dyb2hIb3JzdGVtZXllcl8yMDEyX0FsU2lNZ0N1RmVfX1NNXzY1NjUxNzM1MjQ4NV8wMDCUjDpTaW1fTEFNTVBTX01FQU1fS2ltSnVuZ0xlZV8yMDA5X0ZlVGlDX19TTV81MzEwMzgyNzQ0NzFfMDAwlIw+U2ltX0xBTU1QU19NRUFNX0xpeWFuYWdlS2ltSG91emVfMjAxNF9GZUNfX1NNXzY1MjQyNTc3NzgwOF8wMDCUjEhTaW1fTEFNTVBTX1JlYXhGRl9BcnlhbnBvdXJWYW5EdWluS3ViaWNraV8yMDEwX0ZlSE9fX1NNXzIyMjk2NDIxNjAwMV8wMDGUjEVTaW1fTEFNTVBTX1RlcnNvZmZaQkxfQnlnZ21hc3RhckdyYW5iZXJnXzIwMjBfRmVfX1NNXzk1ODg2Mzg5NTIzNF8wMDCUjE1TaW1fTEFNTVBTX1RlcnNvZmZaQkxfSGVucmlrc3NvbkJqb3JrYXNOb3JkbHVuZF8yMDEzX0ZlQ19fU01fNDczNDYzNDk4MjY5XzAwMJRldS4="
                             }
@@ -1462,140 +1512,15 @@
                             {
                                 "type": "data",
                                 "label": "engine",
-                                "GID": 200,
+                                "GID": 190,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVjgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjB9weWlyb25fYXRvbWlzdGljcy5sYW1tcHMubGFtbXBzlIwGTGFtbXBzlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIiMBHNpemWUjAFtlHUu",
                                 "otype_namespace": "atomistics",
                                 "otype_name": "lammps_output_job"
                             }
                         ],
-                        "GID": 196,
+                        "GID": 186,
                         "pos x": 937.6224577484961,
-                        "pos y": 48.35164835164835
-                    },
-                    {
-                        "identifier": "CalcMinimize_Node",
-                        "version": null,
-                        "state data": "gAR9lC4=",
-                        "additional data": {},
-                        "inputs": [
-                            {
-                                "type": "exec",
-                                "label": "run",
-                                "GID": 202,
-                                "val": "gAROLg==",
-                                "dtype": "DType.Untyped",
-                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
-                            },
-                            {
-                                "type": "exec",
-                                "label": "remove",
-                                "GID": 203,
-                                "val": "gAROLg==",
-                                "dtype": "DType.Untyped",
-                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "name",
-                                "GID": 204,
-                                "val": "gASVDAAAAAAAAACMCGNhbGNfbWlulC4=",
-                                "dtype": "DType.String",
-                                "dtype state": "gASVjQAAAAAAAAB9lCiMB2RlZmF1bHSUjARjYWxjlIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwDc3RylJOUjAVudW1weZSMBHN0cl+Uk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
-                            },
-                            {
-                                "type": "data",
-                                "label": "job",
-                                "GID": 205,
-                                "dtype": "DType.Data",
-                                "dtype state": "gASVjgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjB9weWlyb25fYXRvbWlzdGljcy5sYW1tcHMubGFtbXBzlIwGTGFtbXBzlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIiMBHNpemWUjAFtlHUu",
-                                "otype_namespace": "atomistics",
-                                "otype_name": "atomistic_taker_job"
-                            },
-                            {
-                                "type": "data",
-                                "label": "ionic_energy_tolerance",
-                                "GID": 206,
-                                "val": "gASVCgAAAAAAAABHAAAAAAAAAAAu",
-                                "dtype": "DType.Float",
-                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURwAAAAAAAAAAjAN2YWyURwAAAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "ionic_force_tolerance",
-                                "GID": 207,
-                                "val": "gASVCgAAAAAAAABHPxo24uscQy0u",
-                                "dtype": "DType.Float",
-                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURz8aNuLrHEMtjAN2YWyURz8aNuLrHEMtjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "max_iter",
-                                "GID": 208,
-                                "val": "gASVBgAAAAAAAABKoIYBAC4=",
-                                "dtype": "DType.Integer",
-                                "dtype state": "gASVkQAAAAAAAAB9lCiMB2RlZmF1bHSUSqCGAQCMA3ZhbJRKoIYBAIwDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA2ludJSTlIwFbnVtcHmUjAdpbnRlZ2VylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "pressure",
-                                "GID": 209,
-                                "dtype": "DType.Data",
-                                "dtype state": "gASVlgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlGgIjARsaXN0lJOUjAVudW1weZSMB25kYXJyYXmUk5RljAphbGxvd19ub25llIiMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
-                            },
-                            {
-                                "type": "data",
-                                "label": "n_print",
-                                "GID": 210,
-                                "val": "gARLZC4=",
-                                "dtype": "DType.Integer",
-                                "dtype state": "gASViwAAAAAAAAB9lCiMB2RlZmF1bHSUS2SMA3ZhbJRLZIwDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA2ludJSTlIwFbnVtcHmUjAdpbnRlZ2VylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "style",
-                                "GID": 211,
-                                "val": "gASVBgAAAAAAAACMAmNnlC4=",
-                                "dtype": "DType.Choice",
-                                "dtype state": "gASVZwAAAAAAAAB9lCiMB2RlZmF1bHSUjAJjZ5SMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZSMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjAVpdGVtc5RdlGgCYXUu"
-                            }
-                        ],
-                        "outputs": [
-                            {
-                                "type": "exec",
-                                "label": "ran",
-                                "GID": 212,
-                                "dtype": "DType.Untyped",
-                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "job",
-                                "GID": 213,
-                                "dtype": "DType.Data",
-                                "dtype state": "gASVjgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjB9weWlyb25fYXRvbWlzdGljcy5sYW1tcHMubGFtbXBzlIwGTGFtbXBzlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIiMBHNpemWUjAFtlHUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "energy_pot",
-                                "GID": 214,
-                                "dtype": "DType.Float",
-                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURwAAAAAAAAAAjAN2YWyURwAAAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiIwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu",
-                                "otype_namespace": "atomistics",
-                                "otype_name": "atomistic_taker_output_energy_pot"
-                            },
-                            {
-                                "type": "data",
-                                "label": "forces",
-                                "GID": 215,
-                                "dtype": "DType.List",
-                                "dtype state": "gASVgQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSIdS4=",
-                                "otype_namespace": "atomistics",
-                                "otype_name": "atomistic_taker_output_forces"
-                            }
-                        ],
-                        "GID": 201,
-                        "pos x": 1230.2148381552563,
                         "pos y": 48.35164835164835
                     },
                     {
@@ -1607,14 +1532,14 @@
                             {
                                 "type": "data",
                                 "label": "x",
-                                "GID": 228,
+                                "GID": 207,
                                 "dtype": "DType.Untyped",
                                 "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
                             },
                             {
                                 "type": "data",
                                 "label": "y",
-                                "GID": 229,
+                                "GID": 208,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Untyped",
                                 "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
@@ -1622,7 +1547,7 @@
                             {
                                 "type": "data",
                                 "label": "type",
-                                "GID": 230,
+                                "GID": 209,
                                 "val": "gASVCAAAAAAAAACMBGhpc3SULg==",
                                 "dtype": "DType.Choice",
                                 "dtype state": "gASVfAAAAAAAAAB9lCiMB2RlZmF1bHSUjAdzY2F0dGVylIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlIwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlF2UKGgCjARoaXN0lIwFam9pbnSUZXUu"
@@ -1632,12 +1557,12 @@
                             {
                                 "type": "data",
                                 "label": "plot",
-                                "GID": 231,
+                                "GID": 210,
                                 "dtype": "DType.Untyped",
                                 "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
                             }
                         ],
-                        "GID": 227,
+                        "GID": 206,
                         "pos x": 1516.2073904325407,
                         "pos y": 542.8571428571429
                     },
@@ -1650,7 +1575,7 @@
                             {
                                 "type": "data",
                                 "label": "scl",
-                                "GID": 233,
+                                "GID": 212,
                                 "val": "gARLAC4=",
                                 "dtype": "DType.Integer",
                                 "dtype state": "gASViwAAAAAAAAB9lCiMB2RlZmF1bHSUSwGMA3ZhbJRLAYwDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA2ludJSTlIwFbnVtcHmUjAdpbnRlZ2VylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -1658,7 +1583,7 @@
                             {
                                 "type": "data",
                                 "label": "round",
-                                "GID": 234,
+                                "GID": 213,
                                 "val": "gASJLg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -1668,12 +1593,12 @@
                             {
                                 "type": "data",
                                 "label": "",
-                                "GID": 235,
+                                "GID": 214,
                                 "dtype": "DType.Untyped",
                                 "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
                             }
                         ],
-                        "GID": 232,
+                        "GID": 211,
                         "pos x": 943.0191922085362,
                         "pos y": 255.8901098901099
                     },
@@ -1686,22 +1611,22 @@
                             {
                                 "type": "data",
                                 "label": "job",
-                                "GID": 280,
+                                "GID": 216,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVpgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCpweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLmpvYi5hdG9taXN0aWOUjBNBdG9taXN0aWNHZW5lcmljSm9ilJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIiMBHNpemWUjAFtlHUu"
                             },
                             {
                                 "type": "data",
                                 "label": "field",
-                                "GID": 281,
+                                "GID": 217,
                                 "val": "gASVCgAAAAAAAACMBnZvbHVtZZQu",
                                 "dtype": "DType.Choice",
-                                "dtype state": "gASVUgEAAAAAAAB9lCiMB2RlZmF1bHSUjAVzdGVwc5SMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZSMCGJ1aWx0aW5zlIwDc3RylJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlI+UKIwGZm9yY2VzlIwHaW5kaWNlc5SMEGNvbXB1dGF0aW9uX3RpbWWUjAlmb3JjZV9tYXiUjAplbmVyZ3lfcG90lIwTdG90YWxfZGlzcGxhY2VtZW50c5RoAowJcHJlc3N1cmVzlIwTdW53cmFwcGVkX3Bvc2l0aW9uc5SMDWRpc3BsYWNlbWVudHOUjAt0ZW1wZXJhdHVyZZSMCXBvc2l0aW9uc5SMEWdldF9kaXNwbGFjZW1lbnRzlIwKZW5lcmd5X3RvdJSMBnZvbHVtZZSMBWNlbGxzlJB1Lg=="
+                                "dtype state": "gASVUgEAAAAAAAB9lCiMB2RlZmF1bHSUjAVzdGVwc5SMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZSMCGJ1aWx0aW5zlIwDc3RylJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlI+UKIwKZW5lcmd5X3BvdJSMC3RlbXBlcmF0dXJllIwKZW5lcmd5X3RvdJRoAowQY29tcHV0YXRpb25fdGltZZSME3RvdGFsX2Rpc3BsYWNlbWVudHOUjAlwb3NpdGlvbnOUjAdpbmRpY2VzlIwFY2VsbHOUjA1kaXNwbGFjZW1lbnRzlIwGZm9yY2VzlIwJcHJlc3N1cmVzlIwGdm9sdW1llIwTdW53cmFwcGVkX3Bvc2l0aW9uc5SMCWZvcmNlX21heJSMEWdldF9kaXNwbGFjZW1lbnRzlJB1Lg=="
                             },
                             {
                                 "type": "data",
                                 "label": "transpose",
-                                "GID": 282,
+                                "GID": 218,
                                 "val": "gASILg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -1709,7 +1634,7 @@
                             {
                                 "type": "data",
                                 "label": "index",
-                                "GID": 283,
+                                "GID": 219,
                                 "val": "gASVBgAAAAAAAABK/////y4=",
                                 "dtype": "DType.Integer",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANpbnSUk5SMBW51bXB5lIwHaW50ZWdlcpSTlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
@@ -1719,84 +1644,279 @@
                             {
                                 "type": "data",
                                 "label": "output",
-                                "GID": 284,
+                                "GID": 220,
                                 "dtype": "DType.List",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANpbnSUk5RoCIwFZmxvYXSUk5SMBW51bXB5lIwGbnVtYmVylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIh1Lg=="
                             }
                         ],
-                        "GID": 279,
+                        "GID": 215,
                         "pos x": 1533.806932111143,
+                        "pos y": 81.31868131868131
+                    },
+                    {
+                        "identifier": "Project_Node",
+                        "version": null,
+                        "state data": "gAR9lC4=",
+                        "additional data": {},
+                        "inputs": [
+                            {
+                                "type": "data",
+                                "label": "name",
+                                "GID": 283,
+                                "val": "gASVCwAAAAAAAACMB2V4YW1wbGWULg==",
+                                "dtype": "DType.String",
+                                "dtype state": "gASVigAAAAAAAAB9lCiMB2RlZmF1bHSUjAEulIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwDc3RylJOUjAVudW1weZSMBHN0cl+Uk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
+                            },
+                            {
+                                "type": "exec",
+                                "label": "remove",
+                                "GID": 284,
+                                "val": "gAROLg==",
+                                "dtype": "DType.Untyped",
+                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "enable_remove",
+                                "GID": 285,
+                                "val": "gASJLg==",
+                                "dtype": "DType.Boolean",
+                                "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "remove_name",
+                                "GID": 286,
+                                "val": "gASVBAAAAAAAAACMAJQu",
+                                "dtype": "DType.String",
+                                "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUjACUjAN2YWyUaAKMA2RvY5RoAowGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA3N0cpSTlIwFbnVtcHmUjARzdHJflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "remove_all",
+                                "GID": 287,
+                                "val": "gASJLg==",
+                                "dtype": "DType.Boolean",
+                                "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "recursive",
+                                "GID": 288,
+                                "val": "gASILg==",
+                                "dtype": "DType.Boolean",
+                                "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiIwDdmFslIiMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            }
+                        ],
+                        "outputs": [
+                            {
+                                "type": "data",
+                                "label": "project",
+                                "GID": 289,
+                                "dtype": "DType.Data",
+                                "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjBlweWlyb25fYXRvbWlzdGljcy5wcm9qZWN0lIwHUHJvamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg==",
+                                "otype_namespace": "atomistics",
+                                "otype_name": "project_output_atomistics_project"
+                            }
+                        ],
+                        "GID": 282,
+                        "pos x": 51.04554568891435,
+                        "pos y": 28.571428571428573
+                    },
+                    {
+                        "identifier": "CalcMinimize_Node",
+                        "version": null,
+                        "state data": "gAR9lC4=",
+                        "additional data": {},
+                        "inputs": [
+                            {
+                                "type": "exec",
+                                "label": "run",
+                                "GID": 291,
+                                "val": "gAROLg==",
+                                "dtype": "DType.Untyped",
+                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
+                            },
+                            {
+                                "type": "exec",
+                                "label": "reset",
+                                "GID": 292,
+                                "val": "gAROLg==",
+                                "dtype": "DType.Untyped",
+                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "name",
+                                "GID": 293,
+                                "val": "gASVDAAAAAAAAACMCGNhbGNfbWlulC4=",
+                                "dtype": "DType.String",
+                                "dtype state": "gASVjQAAAAAAAAB9lCiMB2RlZmF1bHSUjARjYWxjlIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwDc3RylJOUjAVudW1weZSMBHN0cl+Uk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
+                            },
+                            {
+                                "type": "data",
+                                "label": "job",
+                                "GID": 294,
+                                "dtype": "DType.Data",
+                                "dtype state": "gASVjgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjB9weWlyb25fYXRvbWlzdGljcy5sYW1tcHMubGFtbXBzlIwGTGFtbXBzlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIiMBHNpemWUjAFtlHUu",
+                                "otype_namespace": "atomistics",
+                                "otype_name": "atomistic_taker_job"
+                            },
+                            {
+                                "type": "data",
+                                "label": "ionic_energy_tolerance",
+                                "GID": 295,
+                                "val": "gASVCgAAAAAAAABHAAAAAAAAAAAu",
+                                "dtype": "DType.Float",
+                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURwAAAAAAAAAAjAN2YWyURwAAAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "ionic_force_tolerance",
+                                "GID": 296,
+                                "val": "gASVCgAAAAAAAABHPxo24uscQy0u",
+                                "dtype": "DType.Float",
+                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURz8aNuLrHEMtjAN2YWyURz8aNuLrHEMtjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "max_iter",
+                                "GID": 297,
+                                "val": "gASVBgAAAAAAAABKoIYBAC4=",
+                                "dtype": "DType.Integer",
+                                "dtype state": "gASVkQAAAAAAAAB9lCiMB2RlZmF1bHSUSqCGAQCMA3ZhbJRKoIYBAIwDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA2ludJSTlIwFbnVtcHmUjAdpbnRlZ2VylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "pressure",
+                                "GID": 298,
+                                "dtype": "DType.Data",
+                                "dtype state": "gASVlgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlGgIjARsaXN0lJOUjAVudW1weZSMB25kYXJyYXmUk5RljAphbGxvd19ub25llIiMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
+                            },
+                            {
+                                "type": "data",
+                                "label": "n_print",
+                                "GID": 299,
+                                "val": "gARLZC4=",
+                                "dtype": "DType.Integer",
+                                "dtype state": "gASViwAAAAAAAAB9lCiMB2RlZmF1bHSUS2SMA3ZhbJRLZIwDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA2ludJSTlIwFbnVtcHmUjAdpbnRlZ2VylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "style",
+                                "GID": 300,
+                                "val": "gASVBgAAAAAAAACMAmNnlC4=",
+                                "dtype": "DType.Choice",
+                                "dtype state": "gASVZwAAAAAAAAB9lCiMB2RlZmF1bHSUjAJjZ5SMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZSMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjAVpdGVtc5RdlGgCYXUu"
+                            }
+                        ],
+                        "outputs": [
+                            {
+                                "type": "exec",
+                                "label": "ran",
+                                "GID": 301,
+                                "dtype": "DType.Untyped",
+                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "job",
+                                "GID": 302,
+                                "dtype": "DType.Data",
+                                "dtype state": "gASVjgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjB9weWlyb25fYXRvbWlzdGljcy5sYW1tcHMubGFtbXBzlIwGTGFtbXBzlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIiMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "energy_pot",
+                                "GID": 303,
+                                "dtype": "DType.Float",
+                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURwAAAAAAAAAAjAN2YWyURwAAAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiIwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu",
+                                "otype_namespace": "atomistics",
+                                "otype_name": "atomistic_taker_output_energy_pot"
+                            },
+                            {
+                                "type": "data",
+                                "label": "forces",
+                                "GID": 304,
+                                "dtype": "DType.List",
+                                "dtype state": "gASVgQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSIdS4=",
+                                "otype_namespace": "atomistics",
+                                "otype_name": "atomistic_taker_output_forces"
+                            }
+                        ],
+                        "GID": 290,
+                        "pos x": 1234.614723574907,
                         "pos y": 81.31868131868131
                     }
                 ],
                 "connections": [
                     {
-                        "GID": 236,
+                        "GID": 222,
                         "parent node index": 0,
                         "output port index": 0,
-                        "connected node": 4,
+                        "connected node": 1,
                         "connected input port index": 0
                     },
                     {
-                        "GID": 237,
+                        "GID": 223,
+                        "parent node index": 0,
+                        "output port index": 0,
+                        "connected node": 3,
+                        "connected input port index": 1
+                    },
+                    {
+                        "GID": 224,
                         "parent node index": 1,
                         "output port index": 0,
                         "connected node": 2,
                         "connected input port index": 0
                     },
                     {
-                        "GID": 238,
-                        "parent node index": 1,
+                        "GID": 225,
+                        "parent node index": 2,
                         "output port index": 0,
-                        "connected node": 4,
-                        "connected input port index": 1
+                        "connected node": 3,
+                        "connected input port index": 2
                     },
                     {
-                        "GID": 239,
-                        "parent node index": 2,
+                        "GID": 306,
+                        "parent node index": 3,
+                        "output port index": 0,
+                        "connected node": 8,
+                        "connected input port index": 3
+                    },
+                    {
+                        "GID": 305,
+                        "parent node index": 5,
+                        "output port index": 0,
+                        "connected node": 8,
+                        "connected input port index": 7
+                    },
+                    {
+                        "GID": 229,
+                        "parent node index": 6,
+                        "output port index": 0,
+                        "connected node": 4,
+                        "connected input port index": 0
+                    },
+                    {
+                        "GID": 307,
+                        "parent node index": 7,
                         "output port index": 0,
                         "connected node": 3,
                         "connected input port index": 0
                     },
                     {
-                        "GID": 240,
-                        "parent node index": 3,
-                        "output port index": 0,
-                        "connected node": 4,
-                        "connected input port index": 2
-                    },
-                    {
-                        "GID": 241,
-                        "parent node index": 4,
-                        "output port index": 0,
-                        "connected node": 5,
-                        "connected input port index": 3
-                    },
-                    {
-                        "GID": 285,
-                        "parent node index": 5,
-                        "output port index": 1,
-                        "connected node": 8,
-                        "connected input port index": 0
-                    },
-                    {
-                        "GID": 246,
-                        "parent node index": 7,
-                        "output port index": 0,
-                        "connected node": 5,
-                        "connected input port index": 7
-                    },
-                    {
-                        "GID": 286,
+                        "GID": 308,
                         "parent node index": 8,
-                        "output port index": 0,
+                        "output port index": 1,
                         "connected node": 6,
                         "connected input port index": 0
                     }
                 ],
-                "GID": 174
+                "GID": 164
             },
-            "GID": 168
+            "GID": 158
         }
     ]
 }

--- a/notebooks/premade_bulk_modulus.json
+++ b/notebooks/premade_bulk_modulus.json
@@ -44,183 +44,6 @@
                         "pos y": 282.14285714285717
                     },
                     {
-                        "identifier": "CalcMurnaghan_Node",
-                        "version": null,
-                        "state data": "gAR9lC4=",
-                        "additional data": {},
-                        "inputs": [
-                            {
-                                "type": "exec",
-                                "label": "run",
-                                "GID": 13,
-                                "val": "gAROLg==",
-                                "dtype": "DType.Untyped",
-                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
-                            },
-                            {
-                                "type": "exec",
-                                "label": "remove",
-                                "GID": 14,
-                                "val": "gAROLg==",
-                                "dtype": "DType.Untyped",
-                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "name",
-                                "GID": 15,
-                                "val": "gASVCAAAAAAAAACMBGNhbGOULg==",
-                                "dtype": "DType.String",
-                                "dtype state": "gASVjQAAAAAAAAB9lCiMB2RlZmF1bHSUjARjYWxjlIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwDc3RylJOUjAVudW1weZSMBHN0cl+Uk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
-                            },
-                            {
-                                "type": "data",
-                                "label": "project",
-                                "GID": 16,
-                                "dtype": "DType.Data",
-                                "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjBlweWlyb25fYXRvbWlzdGljcy5wcm9qZWN0lIwHUHJvamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg==",
-                                "otype_namespace": "atomistics",
-                                "otype_name": "murnaghan_input_project"
-                            },
-                            {
-                                "type": "data",
-                                "label": "engine",
-                                "GID": 17,
-                                "dtype": "DType.Data",
-                                "dtype state": "gASVpgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCpweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLmpvYi5hdG9taXN0aWOUjBNBdG9taXN0aWNHZW5lcmljSm9ilJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu",
-                                "otype_namespace": "atomistics",
-                                "otype_name": "murnaghan_input_job"
-                            },
-                            {
-                                "type": "data",
-                                "label": "num_points",
-                                "GID": 18,
-                                "val": "gARLCy4=",
-                                "dtype": "DType.Integer",
-                                "dtype state": "gASViwAAAAAAAAB9lCiMB2RlZmF1bHSUSwuMA3ZhbJRLC4wDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA2ludJSTlIwFbnVtcHmUjAdpbnRlZ2VylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "fit_type",
-                                "GID": 19,
-                                "val": "gASVDgAAAAAAAACMCnBvbHlub21pYWyULg==",
-                                "dtype": "DType.Choice",
-                                "dtype state": "gASVsAAAAAAAAAB9lCiMB2RlZmF1bHSUjApwb2x5bm9taWFslIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlIwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlF2UKGgCjAViaXJjaJSMDmJpcmNobXVybmFnaGFulIwJbXVybmFnaGFulIwQcG91cmllcnRhcmFudG9sYZSMBXZpbmV0lGV1Lg=="
-                            },
-                            {
-                                "type": "data",
-                                "label": "fit_order",
-                                "GID": 20,
-                                "val": "gARLAy4=",
-                                "dtype": "DType.Integer",
-                                "dtype state": "gASViwAAAAAAAAB9lCiMB2RlZmF1bHSUSwOMA3ZhbJRLA4wDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA2ludJSTlIwFbnVtcHmUjAdpbnRlZ2VylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "vol_range_fraction",
-                                "GID": 21,
-                                "val": "gASVCgAAAAAAAABHP7mZmZmZmZou",
-                                "dtype": "DType.Float",
-                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURz+5mZmZmZmajAN2YWyURz+5mZmZmZmajANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
-                            }
-                        ],
-                        "outputs": [
-                            {
-                                "type": "exec",
-                                "label": "ran",
-                                "GID": 22,
-                                "dtype": "DType.Untyped",
-                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "job",
-                                "GID": 23,
-                                "dtype": "DType.Data",
-                                "dtype state": "gASVnwAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjC1weWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLm1hc3Rlci5tdXJuYWdoYW6UjAlNdXJuYWdoYW6Uk5RhjAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
-                            },
-                            {
-                                "type": "data",
-                                "label": "eq_energy",
-                                "GID": 24,
-                                "dtype": "DType.Float",
-                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURwAAAAAAAAAAjAN2YWyURwAAAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "eq_volume",
-                                "GID": 25,
-                                "dtype": "DType.Float",
-                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURwAAAAAAAAAAjAN2YWyURwAAAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "eq_bulk_modulus",
-                                "GID": 26,
-                                "dtype": "DType.Float",
-                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURwAAAAAAAAAAjAN2YWyURwAAAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu",
-                                "otype_namespace": "atomistics",
-                                "otype_name": "murnaghan_output_bulk_modulus"
-                            },
-                            {
-                                "type": "data",
-                                "label": "eq_b_prime",
-                                "GID": 27,
-                                "dtype": "DType.Float",
-                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURwAAAAAAAAAAjAN2YWyURwAAAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu",
-                                "otype_namespace": "atomistics",
-                                "otype_name": "murnaghan_output_b_prime"
-                            },
-                            {
-                                "type": "data",
-                                "label": "volumes",
-                                "GID": 28,
-                                "dtype": "DType.List",
-                                "dtype state": "gASVawAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAhidWlsdGluc5SMBWZsb2F0lJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIl1Lg=="
-                            },
-                            {
-                                "type": "data",
-                                "label": "energies",
-                                "GID": 29,
-                                "dtype": "DType.List",
-                                "dtype state": "gASVawAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAhidWlsdGluc5SMBWZsb2F0lJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIl1Lg=="
-                            }
-                        ],
-                        "GID": 12,
-                        "pos x": 1059.3830481314028,
-                        "pos y": 194.23076923076928
-                    },
-                    {
-                        "identifier": "Project_Node",
-                        "version": null,
-                        "state data": "gAR9lC4=",
-                        "additional data": {},
-                        "inputs": [
-                            {
-                                "type": "data",
-                                "label": "name",
-                                "GID": 31,
-                                "val": "gASVGAAAAAAAAACMFHByZW1hZGVfYnVsa19tb2R1bHVzlC4=",
-                                "dtype": "DType.String",
-                                "dtype state": "gASVigAAAAAAAAB9lCiMB2RlZmF1bHSUjAEulIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwDc3RylJOUjAVudW1weZSMBHN0cl+Uk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
-                            }
-                        ],
-                        "outputs": [
-                            {
-                                "type": "data",
-                                "label": "project",
-                                "GID": 32,
-                                "dtype": "DType.Data",
-                                "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjBlweWlyb25fYXRvbWlzdGljcy5wcm9qZWN0lIwHUHJvamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg==",
-                                "otype_namespace": "atomistics",
-                                "otype_name": "project_output_atomistics_project"
-                            }
-                        ],
-                        "GID": 30,
-                        "pos x": 255.0334802266354,
-                        "pos y": 88.73626373626378
-                    },
-                    {
                         "identifier": "Lammps_Node",
                         "version": "v0.2",
                         "state data": "gAR9lC4=",
@@ -230,6 +53,7 @@
                                 "type": "data",
                                 "label": "project",
                                 "GID": 34,
+                                "val": "gASVGwwAAAAAAACMGXB5aXJvbl9hdG9taXN0aWNzLnByb2plY3SUjAdQcm9qZWN0lJOUKYGUfZQojApfcm9vdF9wYXRolE6MDV9wcm9qZWN0X3BhdGiUjEEvVXNlcnMvaHViZXIvd29yay9weWlyb24vaXJvbmZsb3cvbm90ZWJvb2tzL3ByZW1hZGVfYnVsa19tb2R1bHVzL5SMCF9oaXN0b3J5lF2UjAR1c2VylE6MCXNxbF9xdWVyeZROjAdfZmlsdGVylF2UKIwGZ3JvdXBzlIwFbm9kZXOUjAdvYmplY3RzlGWMDV9pbnNwZWN0X21vZGWUiYwFX2RhdGGUTowIX2NyZWF0b3KUaACMB0NyZWF0b3KUk5QpgZR9lCiMDF9qb2JfZmFjdG9yeZSMHHB5aXJvbl9iYXNlLmpvYnMuam9iLmpvYnR5cGWUjApKb2JGYWN0b3J5lJOUKYGUfZQojA9fam9iX2NsYXNzX2RpY3SUfZQojA5GbGV4aWJsZU1hc3RlcpSMIHB5aXJvbl9iYXNlLmpvYnMubWFzdGVyLmZsZXhpYmxllIwJU2NyaXB0Sm9ilIwXcHlpcm9uX2Jhc2Uuam9icy5zY3JpcHSUjBBTZXJpYWxNYXN0ZXJCYXNllIwecHlpcm9uX2Jhc2Uuam9icy5tYXN0ZXIuc2VyaWFslIwIVGFibGVKb2KUjCJweWlyb25fYXRvbWlzdGljcy50YWJsZS5kYXRhbWluaW5nlIwJV29ya2VySm9ilIwXcHlpcm9uX2Jhc2Uuam9icy53b3JrZXKUjANBUlSUjD1weWlyb25fYXRvbWlzdGljcy5pbnRlcmFjdGl2ZS5hY3RpdmF0aW9uX3JlbGF4YXRpb25fdGVjaG5pcXVllIwTQXRvbWlzdGljRXhhbXBsZUpvYpSMKXB5aXJvbl9hdG9taXN0aWNzLnRlc3RpbmcucmFuZG9tYXRvbWlzdGljlIwGQ2FscGh5lIwccHlpcm9uX2F0b21pc3RpY3MuY2FscGh5LmpvYpSMEUNvbnZFbmN1dFBhcmFsbGVslIw3cHlpcm9uX2F0b21pc3RpY3MuZGZ0Lm1hc3Rlci5jb252ZXJnZW5jZV9lbmN1dF9wYXJhbGxlbJSMD0NvbnZFbmN1dFNlcmlhbJSMNXB5aXJvbl9hdG9taXN0aWNzLmRmdC5tYXN0ZXIuY29udmVyZ2VuY2VfZW5jdXRfc2VyaWFslIwRQ29udmVyZ2VuY2VWb2x1bWWUjDZweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLm1hc3Rlci5jb252ZXJnZW5jZV92b2x1bWWUjBJDb252S3BvaW50UGFyYWxsZWyUjDhweWlyb25fYXRvbWlzdGljcy5kZnQubWFzdGVyLmNvbnZlcmdlbmNlX2twb2ludF9wYXJhbGxlbJSMDUVsYXN0aWNUZW5zb3KUjCtweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLm1hc3Rlci5lbGFzdGljlIwKRXhhbXBsZUpvYpRoLYwIR2F1c3NpYW6UjCNweWlyb25fYXRvbWlzdGljcy5nYXVzc2lhbi5nYXVzc2lhbpSMBEdwYXeUjBtweWlyb25fYXRvbWlzdGljcy5ncGF3LmdwYXeUjApIZXNzaWFuSm9ilIwocHlpcm9uX2F0b21pc3RpY3MudGhlcm1vZHluYW1pY3MuaGVzc2lhbpSMBkxhbW1wc5SMH3B5aXJvbl9hdG9taXN0aWNzLmxhbW1wcy5sYW1tcHOUjAlNYXBNYXN0ZXKUjCxweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLm1hc3Rlci5wYXJhbGxlbJSMCU11cm5hZ2hhbpSMLXB5aXJvbl9hdG9taXN0aWNzLmF0b21pc3RpY3MubWFzdGVyLm11cm5hZ2hhbpSMDE11cm5hZ2hhbkRGVJSMKnB5aXJvbl9hdG9taXN0aWNzLmRmdC5tYXN0ZXIubXVybmFnaGFuX2RmdJSMClBob25vcHlKb2KUjCtweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLm1hc3Rlci5waG9ub3B5lIwQUXVhc2lIYXJtb25pY0pvYpSMKXB5aXJvbl9hdG9taXN0aWNzLmF0b21pc3RpY3MubWFzdGVyLnF1YXNplIwLUXVhc2lOZXd0b26UjCpweWlyb25fYXRvbWlzdGljcy5pbnRlcmFjdGl2ZS5xdWFzaV9uZXd0b26UjA5TY2lweU1pbmltaXplcpSMLXB5aXJvbl9hdG9taXN0aWNzLmludGVyYWN0aXZlLnNjaXB5X21pbmltaXplcpSMDFNlcmlhbE1hc3RlcpSMKnB5aXJvbl9hdG9taXN0aWNzLmF0b21pc3RpY3MubWFzdGVyLnNlcmlhbJSMBlNwaGlueJSMH3B5aXJvbl9hdG9taXN0aWNzLnNwaGlueC5zcGhpbniUjBJTdHJ1Y3R1cmVDb250YWluZXKUjDNweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLmpvYi5zdHJ1Y3R1cmVjb250YWluZXKUjBNTdHJ1Y3R1cmVMaXN0TWFzdGVylIwtcHlpcm9uX2F0b21pc3RpY3MuYXRvbWlzdGljcy5tYXN0ZXIuc3RydWN0dXJllIwGU1FTSm9ilIwkcHlpcm9uX2F0b21pc3RpY3MuYXRvbWlzdGljcy5qb2Iuc3FzlIwJU1FTTWFzdGVylIwtcHlpcm9uX2F0b21pc3RpY3MuYXRvbWlzdGljcy5tYXN0ZXIuc3FzbWFzdGVylIwIU3hEeW5NYXSUjCpweWlyb25fYXRvbWlzdGljcy50aGVybW9keW5hbWljcy5zeHBob25vbnOUjBNTeEV4dE9wdEludGVyYWN0aXZllIwpcHlpcm9uX2F0b21pc3RpY3MuaW50ZXJhY3RpdmUuc3hleHRvcHRpbnSUjAxTeEhhcm1Qb3RUc3SUaF6MCVN4UGhvbm9uc5RoXowLU3hVbmlxRGlzcGyUaF6MBFZhc3CUjBtweWlyb25fYXRvbWlzdGljcy52YXNwLnZhc3CUjAtWYXNwTWV0YWR5bpSMHnB5aXJvbl9hdG9taXN0aWNzLnZhc3AubWV0YWR5bpSMB1Zhc3BTb2yUjB5weWlyb25fYXRvbWlzdGljcy52YXNwLnZhc3Bzb2yUdYwNX2pvYl9keW5fZGljdJR9lIwIX3Byb2plY3SUaAN1YmhsaAOMCl9zdHJ1Y3R1cmWUjC5weWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLnN0cnVjdHVyZS5mYWN0b3J5lIwQU3RydWN0dXJlRmFjdG9yeZSTlCmBlH2UKIwEX2FzZZSMNHB5aXJvbl9hdG9taXN0aWNzLmF0b21pc3RpY3Muc3RydWN0dXJlLmZhY3Rvcmllcy5hc2WUjApBc2VGYWN0b3J5lJOUKYGUjAdfYWltc2dilIw3cHlpcm9uX2F0b21pc3RpY3MuYXRvbWlzdGljcy5zdHJ1Y3R1cmUuZmFjdG9yaWVzLmFpbXNnYpSMDUFpbXNnYkZhY3RvcnmUk5QpgZSMEV9tYXRlcmlhbHNwcm9qZWN0lIxBcHlpcm9uX2F0b21pc3RpY3MuYXRvbWlzdGljcy5zdHJ1Y3R1cmUuZmFjdG9yaWVzLm1hdGVyaWFsc3Byb2plY3SUjBdNYXRlcmlhbHNQcm9qZWN0RmFjdG9yeZSTlCmBlIwJX2NvbXBvdW5klIw5cHlpcm9uX2F0b21pc3RpY3MuYXRvbWlzdGljcy5zdHJ1Y3R1cmUuZmFjdG9yaWVzLmNvbXBvdW5klIwPQ29tcG91bmRGYWN0b3J5lJOUKYGUdWJ1YowIam9iX3R5cGWUaBmMDUpvYlR5cGVDaG9pY2WUk5QpgZR9lGgeaB9zYowMX21haW50ZW5hbmNllE6MC29iamVjdF90eXBllIwwcHlpcm9uX2F0b21pc3RpY3MuYXRvbWlzdGljcy5nZW5lcmljLm9iamVjdF90eXBllIwQT2JqZWN0VHlwZUNob2ljZZSTlCmBlH2UjApUaGVybW9CdWxrlGiTc2J1Yi4=",
                                 "dtype": "DType.Data",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjBlweWlyb25fYXRvbWlzdGljcy5wcm9qZWN0lIwHUHJvamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg==",
                                 "otype_namespace": "atomistics",
@@ -355,42 +179,252 @@
                         "GID": 38,
                         "pos x": 250.6381273965547,
                         "pos y": 260.1648351648352
+                    },
+                    {
+                        "identifier": "Project_Node",
+                        "version": null,
+                        "state data": "gAR9lC4=",
+                        "additional data": {},
+                        "inputs": [
+                            {
+                                "type": "data",
+                                "label": "name",
+                                "GID": 54,
+                                "val": "gASVGAAAAAAAAACMFHByZW1hZGVfYnVsa19tb2R1bHVzlC4=",
+                                "dtype": "DType.String",
+                                "dtype state": "gASVigAAAAAAAAB9lCiMB2RlZmF1bHSUjAEulIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwDc3RylJOUjAVudW1weZSMBHN0cl+Uk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
+                            },
+                            {
+                                "type": "exec",
+                                "label": "remove",
+                                "GID": 55,
+                                "val": "gAROLg==",
+                                "dtype": "DType.Untyped",
+                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "enable_remove",
+                                "GID": 56,
+                                "val": "gASJLg==",
+                                "dtype": "DType.Boolean",
+                                "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "remove_name",
+                                "GID": 57,
+                                "val": "gASVBAAAAAAAAACMAJQu",
+                                "dtype": "DType.String",
+                                "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUjACUjAN2YWyUaAKMA2RvY5RoAowGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA3N0cpSTlIwFbnVtcHmUjARzdHJflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "remove_all",
+                                "GID": 58,
+                                "val": "gASJLg==",
+                                "dtype": "DType.Boolean",
+                                "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "recursive",
+                                "GID": 59,
+                                "val": "gASILg==",
+                                "dtype": "DType.Boolean",
+                                "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiIwDdmFslIiMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            }
+                        ],
+                        "outputs": [
+                            {
+                                "type": "data",
+                                "label": "project",
+                                "GID": 60,
+                                "dtype": "DType.Data",
+                                "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjBlweWlyb25fYXRvbWlzdGljcy5wcm9qZWN0lIwHUHJvamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg==",
+                                "otype_namespace": "atomistics",
+                                "otype_name": "project_output_atomistics_project"
+                            }
+                        ],
+                        "GID": 53,
+                        "pos x": 266.6399312517903,
+                        "pos y": 16.208791208791208
+                    },
+                    {
+                        "identifier": "CalcMurnaghan_Node",
+                        "version": null,
+                        "state data": "gAR9lC4=",
+                        "additional data": {},
+                        "inputs": [
+                            {
+                                "type": "exec",
+                                "label": "run",
+                                "GID": 62,
+                                "val": "gAROLg==",
+                                "dtype": "DType.Untyped",
+                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
+                            },
+                            {
+                                "type": "exec",
+                                "label": "reset",
+                                "GID": 63,
+                                "val": "gAROLg==",
+                                "dtype": "DType.Untyped",
+                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "name",
+                                "GID": 64,
+                                "val": "gASVCAAAAAAAAACMBGNhbGOULg==",
+                                "dtype": "DType.String",
+                                "dtype state": "gASVjQAAAAAAAAB9lCiMB2RlZmF1bHSUjARjYWxjlIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwDc3RylJOUjAVudW1weZSMBHN0cl+Uk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
+                            },
+                            {
+                                "type": "data",
+                                "label": "project",
+                                "GID": 65,
+                                "dtype": "DType.Data",
+                                "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjBlweWlyb25fYXRvbWlzdGljcy5wcm9qZWN0lIwHUHJvamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg==",
+                                "otype_namespace": "atomistics",
+                                "otype_name": "murnaghan_input_project"
+                            },
+                            {
+                                "type": "data",
+                                "label": "engine",
+                                "GID": 66,
+                                "dtype": "DType.Data",
+                                "dtype state": "gASVpgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCpweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLmpvYi5hdG9taXN0aWOUjBNBdG9taXN0aWNHZW5lcmljSm9ilJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu",
+                                "otype_namespace": "atomistics",
+                                "otype_name": "murnaghan_input_job"
+                            },
+                            {
+                                "type": "data",
+                                "label": "num_points",
+                                "GID": 67,
+                                "val": "gARLCy4=",
+                                "dtype": "DType.Integer",
+                                "dtype state": "gASViwAAAAAAAAB9lCiMB2RlZmF1bHSUSwuMA3ZhbJRLC4wDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA2ludJSTlIwFbnVtcHmUjAdpbnRlZ2VylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "fit_type",
+                                "GID": 68,
+                                "val": "gASVDgAAAAAAAACMCnBvbHlub21pYWyULg==",
+                                "dtype": "DType.Choice",
+                                "dtype state": "gASVsAAAAAAAAAB9lCiMB2RlZmF1bHSUjApwb2x5bm9taWFslIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlIwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlF2UKGgCjAViaXJjaJSMDmJpcmNobXVybmFnaGFulIwJbXVybmFnaGFulIwQcG91cmllcnRhcmFudG9sYZSMBXZpbmV0lGV1Lg=="
+                            },
+                            {
+                                "type": "data",
+                                "label": "fit_order",
+                                "GID": 69,
+                                "val": "gARLAy4=",
+                                "dtype": "DType.Integer",
+                                "dtype state": "gASViwAAAAAAAAB9lCiMB2RlZmF1bHSUSwOMA3ZhbJRLA4wDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA2ludJSTlIwFbnVtcHmUjAdpbnRlZ2VylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "vol_range_fraction",
+                                "GID": 70,
+                                "val": "gASVCgAAAAAAAABHP7mZmZmZmZou",
+                                "dtype": "DType.Float",
+                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURz+5mZmZmZmajAN2YWyURz+5mZmZmZmajANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
+                            }
+                        ],
+                        "outputs": [
+                            {
+                                "type": "exec",
+                                "label": "ran",
+                                "GID": 71,
+                                "dtype": "DType.Untyped",
+                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "job",
+                                "GID": 72,
+                                "dtype": "DType.Data",
+                                "dtype state": "gASVnwAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjC1weWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLm1hc3Rlci5tdXJuYWdoYW6UjAlNdXJuYWdoYW6Uk5RhjAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
+                            },
+                            {
+                                "type": "data",
+                                "label": "eq_energy",
+                                "GID": 73,
+                                "dtype": "DType.Float",
+                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURwAAAAAAAAAAjAN2YWyURwAAAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "eq_volume",
+                                "GID": 74,
+                                "dtype": "DType.Float",
+                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURwAAAAAAAAAAjAN2YWyURwAAAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "eq_bulk_modulus",
+                                "GID": 75,
+                                "dtype": "DType.Float",
+                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURwAAAAAAAAAAjAN2YWyURwAAAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu",
+                                "otype_namespace": "atomistics",
+                                "otype_name": "murnaghan_output_bulk_modulus"
+                            },
+                            {
+                                "type": "data",
+                                "label": "eq_b_prime",
+                                "GID": 76,
+                                "dtype": "DType.Float",
+                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURwAAAAAAAAAAjAN2YWyURwAAAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu",
+                                "otype_namespace": "atomistics",
+                                "otype_name": "murnaghan_output_b_prime"
+                            },
+                            {
+                                "type": "data",
+                                "label": "volumes",
+                                "GID": 77,
+                                "dtype": "DType.List",
+                                "dtype state": "gASVawAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAhidWlsdGluc5SMBWZsb2F0lJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIl1Lg=="
+                            },
+                            {
+                                "type": "data",
+                                "label": "energies",
+                                "GID": 78,
+                                "dtype": "DType.List",
+                                "dtype state": "gASVawAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAhidWlsdGluc5SMBWZsb2F0lJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIl1Lg=="
+                            }
+                        ],
+                        "GID": 61,
+                        "pos x": 1066.2159839587512,
+                        "pos y": 175.90109890109892
                     }
                 ],
                 "connections": [
                     {
-                        "GID": 48,
+                        "GID": 80,
                         "parent node index": 1,
-                        "output port index": 4,
-                        "connected node": 0,
-                        "connected input port index": 1
-                    },
-                    {
-                        "GID": 49,
-                        "parent node index": 2,
                         "output port index": 0,
-                        "connected node": 1,
-                        "connected input port index": 3
-                    },
-                    {
-                        "GID": 50,
-                        "parent node index": 2,
-                        "output port index": 0,
-                        "connected node": 3,
-                        "connected input port index": 0
-                    },
-                    {
-                        "GID": 51,
-                        "parent node index": 3,
-                        "output port index": 0,
-                        "connected node": 1,
+                        "connected node": 4,
                         "connected input port index": 4
                     },
                     {
                         "GID": 52,
-                        "parent node index": 4,
+                        "parent node index": 2,
                         "output port index": 0,
-                        "connected node": 3,
+                        "connected node": 1,
+                        "connected input port index": 1
+                    },
+                    {
+                        "GID": 81,
+                        "parent node index": 3,
+                        "output port index": 0,
+                        "connected node": 4,
+                        "connected input port index": 3
+                    },
+                    {
+                        "GID": 79,
+                        "parent node index": 4,
+                        "output port index": 4,
+                        "connected node": 0,
                         "connected input port index": 1
                     }
                 ],

--- a/notebooks/premade_bulk_modulus.json
+++ b/notebooks/premade_bulk_modulus.json
@@ -18,7 +18,7 @@
                                 "GID": 9,
                                 "val": "gASVDwAAAAAAAACMC0J1bGtNb2R1bHVzlC4=",
                                 "dtype": "DType.Choice",
-                                "dtype state": "gASVsQAAAAAAAAB9lCiMB2RlZmF1bHSUjBBNYXRlcmlhbFByb3BlcnR5lIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlIwIYnVpbHRpbnOUjANzdHKUk5RhjAphbGxvd19ub25llImMB2JhdGNoZWSUiYwFaXRlbXOUXZQoaAKMDVN1cmZhY2VFbmVyZ3mUjAtCdWxrTW9kdWx1c5SMBkJQcmltZZRldS4="
+                                "dtype state": "gASVsQAAAAAAAAB9lCiMB2RlZmF1bHSUjBBNYXRlcmlhbFByb3BlcnR5lIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlIwIYnVpbHRpbnOUjANzdHKUk5RhjAphbGxvd19ub25llImMB2JhdGNoZWSUiYwFaXRlbXOUXZQojAtCdWxrTW9kdWx1c5SMBkJQcmltZZRoAowNU3VyZmFjZUVuZXJneZRldS4="
                             },
                             {
                                 "type": "data",
@@ -36,219 +36,14 @@
                                 "label": "value",
                                 "GID": 11,
                                 "dtype": "DType.Float",
-                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURwAAAAAAAAAAjAN2YWyURwAAAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
+                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURwAAAAAAAAAAjAN2YWyURwAAAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu",
+                                "otype_namespace": "atomistics",
+                                "otype_name": "bulkmodulus3"
                             }
                         ],
                         "GID": 8,
-                        "pos x": 1404.4182452927373,
-                        "pos y": 282.14285714285717
-                    },
-                    {
-                        "identifier": "Lammps_Node",
-                        "version": "v0.2",
-                        "state data": "gAR9lC4=",
-                        "additional data": {},
-                        "inputs": [
-                            {
-                                "type": "data",
-                                "label": "project",
-                                "GID": 34,
-                                "val": "gASVGwwAAAAAAACMGXB5aXJvbl9hdG9taXN0aWNzLnByb2plY3SUjAdQcm9qZWN0lJOUKYGUfZQojApfcm9vdF9wYXRolE6MDV9wcm9qZWN0X3BhdGiUjEEvVXNlcnMvaHViZXIvd29yay9weWlyb24vaXJvbmZsb3cvbm90ZWJvb2tzL3ByZW1hZGVfYnVsa19tb2R1bHVzL5SMCF9oaXN0b3J5lF2UjAR1c2VylE6MCXNxbF9xdWVyeZROjAdfZmlsdGVylF2UKIwGZ3JvdXBzlIwFbm9kZXOUjAdvYmplY3RzlGWMDV9pbnNwZWN0X21vZGWUiYwFX2RhdGGUTowIX2NyZWF0b3KUaACMB0NyZWF0b3KUk5QpgZR9lCiMDF9qb2JfZmFjdG9yeZSMHHB5aXJvbl9iYXNlLmpvYnMuam9iLmpvYnR5cGWUjApKb2JGYWN0b3J5lJOUKYGUfZQojA9fam9iX2NsYXNzX2RpY3SUfZQojA5GbGV4aWJsZU1hc3RlcpSMIHB5aXJvbl9iYXNlLmpvYnMubWFzdGVyLmZsZXhpYmxllIwJU2NyaXB0Sm9ilIwXcHlpcm9uX2Jhc2Uuam9icy5zY3JpcHSUjBBTZXJpYWxNYXN0ZXJCYXNllIwecHlpcm9uX2Jhc2Uuam9icy5tYXN0ZXIuc2VyaWFslIwIVGFibGVKb2KUjCJweWlyb25fYXRvbWlzdGljcy50YWJsZS5kYXRhbWluaW5nlIwJV29ya2VySm9ilIwXcHlpcm9uX2Jhc2Uuam9icy53b3JrZXKUjANBUlSUjD1weWlyb25fYXRvbWlzdGljcy5pbnRlcmFjdGl2ZS5hY3RpdmF0aW9uX3JlbGF4YXRpb25fdGVjaG5pcXVllIwTQXRvbWlzdGljRXhhbXBsZUpvYpSMKXB5aXJvbl9hdG9taXN0aWNzLnRlc3RpbmcucmFuZG9tYXRvbWlzdGljlIwGQ2FscGh5lIwccHlpcm9uX2F0b21pc3RpY3MuY2FscGh5LmpvYpSMEUNvbnZFbmN1dFBhcmFsbGVslIw3cHlpcm9uX2F0b21pc3RpY3MuZGZ0Lm1hc3Rlci5jb252ZXJnZW5jZV9lbmN1dF9wYXJhbGxlbJSMD0NvbnZFbmN1dFNlcmlhbJSMNXB5aXJvbl9hdG9taXN0aWNzLmRmdC5tYXN0ZXIuY29udmVyZ2VuY2VfZW5jdXRfc2VyaWFslIwRQ29udmVyZ2VuY2VWb2x1bWWUjDZweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLm1hc3Rlci5jb252ZXJnZW5jZV92b2x1bWWUjBJDb252S3BvaW50UGFyYWxsZWyUjDhweWlyb25fYXRvbWlzdGljcy5kZnQubWFzdGVyLmNvbnZlcmdlbmNlX2twb2ludF9wYXJhbGxlbJSMDUVsYXN0aWNUZW5zb3KUjCtweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLm1hc3Rlci5lbGFzdGljlIwKRXhhbXBsZUpvYpRoLYwIR2F1c3NpYW6UjCNweWlyb25fYXRvbWlzdGljcy5nYXVzc2lhbi5nYXVzc2lhbpSMBEdwYXeUjBtweWlyb25fYXRvbWlzdGljcy5ncGF3LmdwYXeUjApIZXNzaWFuSm9ilIwocHlpcm9uX2F0b21pc3RpY3MudGhlcm1vZHluYW1pY3MuaGVzc2lhbpSMBkxhbW1wc5SMH3B5aXJvbl9hdG9taXN0aWNzLmxhbW1wcy5sYW1tcHOUjAlNYXBNYXN0ZXKUjCxweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLm1hc3Rlci5wYXJhbGxlbJSMCU11cm5hZ2hhbpSMLXB5aXJvbl9hdG9taXN0aWNzLmF0b21pc3RpY3MubWFzdGVyLm11cm5hZ2hhbpSMDE11cm5hZ2hhbkRGVJSMKnB5aXJvbl9hdG9taXN0aWNzLmRmdC5tYXN0ZXIubXVybmFnaGFuX2RmdJSMClBob25vcHlKb2KUjCtweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLm1hc3Rlci5waG9ub3B5lIwQUXVhc2lIYXJtb25pY0pvYpSMKXB5aXJvbl9hdG9taXN0aWNzLmF0b21pc3RpY3MubWFzdGVyLnF1YXNplIwLUXVhc2lOZXd0b26UjCpweWlyb25fYXRvbWlzdGljcy5pbnRlcmFjdGl2ZS5xdWFzaV9uZXd0b26UjA5TY2lweU1pbmltaXplcpSMLXB5aXJvbl9hdG9taXN0aWNzLmludGVyYWN0aXZlLnNjaXB5X21pbmltaXplcpSMDFNlcmlhbE1hc3RlcpSMKnB5aXJvbl9hdG9taXN0aWNzLmF0b21pc3RpY3MubWFzdGVyLnNlcmlhbJSMBlNwaGlueJSMH3B5aXJvbl9hdG9taXN0aWNzLnNwaGlueC5zcGhpbniUjBJTdHJ1Y3R1cmVDb250YWluZXKUjDNweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLmpvYi5zdHJ1Y3R1cmVjb250YWluZXKUjBNTdHJ1Y3R1cmVMaXN0TWFzdGVylIwtcHlpcm9uX2F0b21pc3RpY3MuYXRvbWlzdGljcy5tYXN0ZXIuc3RydWN0dXJllIwGU1FTSm9ilIwkcHlpcm9uX2F0b21pc3RpY3MuYXRvbWlzdGljcy5qb2Iuc3FzlIwJU1FTTWFzdGVylIwtcHlpcm9uX2F0b21pc3RpY3MuYXRvbWlzdGljcy5tYXN0ZXIuc3FzbWFzdGVylIwIU3hEeW5NYXSUjCpweWlyb25fYXRvbWlzdGljcy50aGVybW9keW5hbWljcy5zeHBob25vbnOUjBNTeEV4dE9wdEludGVyYWN0aXZllIwpcHlpcm9uX2F0b21pc3RpY3MuaW50ZXJhY3RpdmUuc3hleHRvcHRpbnSUjAxTeEhhcm1Qb3RUc3SUaF6MCVN4UGhvbm9uc5RoXowLU3hVbmlxRGlzcGyUaF6MBFZhc3CUjBtweWlyb25fYXRvbWlzdGljcy52YXNwLnZhc3CUjAtWYXNwTWV0YWR5bpSMHnB5aXJvbl9hdG9taXN0aWNzLnZhc3AubWV0YWR5bpSMB1Zhc3BTb2yUjB5weWlyb25fYXRvbWlzdGljcy52YXNwLnZhc3Bzb2yUdYwNX2pvYl9keW5fZGljdJR9lIwIX3Byb2plY3SUaAN1YmhsaAOMCl9zdHJ1Y3R1cmWUjC5weWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLnN0cnVjdHVyZS5mYWN0b3J5lIwQU3RydWN0dXJlRmFjdG9yeZSTlCmBlH2UKIwEX2FzZZSMNHB5aXJvbl9hdG9taXN0aWNzLmF0b21pc3RpY3Muc3RydWN0dXJlLmZhY3Rvcmllcy5hc2WUjApBc2VGYWN0b3J5lJOUKYGUjAdfYWltc2dilIw3cHlpcm9uX2F0b21pc3RpY3MuYXRvbWlzdGljcy5zdHJ1Y3R1cmUuZmFjdG9yaWVzLmFpbXNnYpSMDUFpbXNnYkZhY3RvcnmUk5QpgZSMEV9tYXRlcmlhbHNwcm9qZWN0lIxBcHlpcm9uX2F0b21pc3RpY3MuYXRvbWlzdGljcy5zdHJ1Y3R1cmUuZmFjdG9yaWVzLm1hdGVyaWFsc3Byb2plY3SUjBdNYXRlcmlhbHNQcm9qZWN0RmFjdG9yeZSTlCmBlIwJX2NvbXBvdW5klIw5cHlpcm9uX2F0b21pc3RpY3MuYXRvbWlzdGljcy5zdHJ1Y3R1cmUuZmFjdG9yaWVzLmNvbXBvdW5klIwPQ29tcG91bmRGYWN0b3J5lJOUKYGUdWJ1YowIam9iX3R5cGWUaBmMDUpvYlR5cGVDaG9pY2WUk5QpgZR9lGgeaB9zYowMX21haW50ZW5hbmNllE6MC29iamVjdF90eXBllIwwcHlpcm9uX2F0b21pc3RpY3MuYXRvbWlzdGljcy5nZW5lcmljLm9iamVjdF90eXBllIwQT2JqZWN0VHlwZUNob2ljZZSTlCmBlH2UjApUaGVybW9CdWxrlGiTc2J1Yi4=",
-                                "dtype": "DType.Data",
-                                "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjBlweWlyb25fYXRvbWlzdGljcy5wcm9qZWN0lIwHUHJvamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg==",
-                                "otype_namespace": "atomistics",
-                                "otype_name": "lammps_input_project"
-                            },
-                            {
-                                "type": "data",
-                                "label": "structure",
-                                "GID": 35,
-                                "dtype": "DType.Data",
-                                "dtype state": "gASVmgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCxweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLnN0cnVjdHVyZS5hdG9tc5SMBUF0b21zlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu",
-                                "otype_namespace": "atomistics",
-                                "otype_name": "lammps_input_structure"
-                            },
-                            {
-                                "type": "data",
-                                "label": "potential",
-                                "GID": 36,
-                                "val": "gASVJwAAAAAAAACMIzE5OTctLUFja2xhbmQtRy1KLS1GZS0tTEFNTVBTLS1pcHIxlC4=",
-                                "dtype": "DType.Choice",
-                                "dtype state": "gASVLxkAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAhidWlsdGluc5SMA3N0cpSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjAVpdGVtc5RdlCiMIzE5OTctLUFja2xhbmQtRy1KLS1GZS0tTEFNTVBTLS1pcHIxlIwfMTk5OC0tTWV5ZXItUi0tRmUtLUxBTU1QUy0taXByMZSMHzIwMDEtLUxlZS1CLUotLUZlLS1MQU1NUFMtLWlwcjGUjCIyMDAxLS1MZWUtQi1KLS1GZS1Dci0tTEFNTVBTLS1pcHIxlIwmMjAwMy0tTWVuZGVsZXYtTS1JLS1GZS0yLS1MQU1NUFMtLWlwcjOUjCYyMDAzLS1NZW5kZWxldi1NLUktLUZlLTUtLUxBTU1QUy0taXByMZSMJTIwMDQtLUFja2xhbmQtRy1KLS1GZS1QLS1MQU1NUFMtLWlwcjGUjCAyMDA0LS1aaG91LVgtVy0tRmUtLUxBTU1QUy0taXByMpSMIjIwMDUtLUxlZS1CLUotLUZlLUN1LS1MQU1NUFMtLWlwcjGUjCcyMDA1LS1NZW5kZWxldi1NLUktLUFsLUZlLS1MQU1NUFMtLWlwcjGUjCEyMDA2LS1DaGFtYXRpLUgtLUZlLS1MQU1NUFMtLWlwcjGUjCAyMDA2LS1LaW0tSi0tRmUtUHQtLUxBTU1QUy0taXByMZSMITIwMDYtLUxlZS1CLUotLUZlLUMtLUxBTU1QUy0taXByMZSMITIwMDYtLUxlZS1CLUotLUZlLU4tLUxBTU1QUy0taXByMZSMITIwMDctLUxlZS1CLUotLUZlLUgtLUxBTU1QUy0taXByMZSMJjIwMDctLU1lbmRlbGV2LU0tSS0tVi1GZS0tTEFNTVBTLS1pcHIxlIwlMjAwOC0tSGVwYnVybi1ELUotLUZlLUMtLUxBTU1QUy0taXByMZSMHzIwMDgtLVNhLUktLUZlLU5iLS1MQU1NUFMtLWlwcjGUjB8yMDA4LS1TYS1JLS1GZS1UaS0tTEFNTVBTLS1pcHIxlIwlMjAwOS0tQm9ubnktRy0tRmUtQ3UtTmktLUxBTU1QUy0taXByMZSMIjIwMDktLUJvbm55LUctLUZlLU5pLS1MQU1NUFMtLWlwcjGUjCQyMDA5LS1LaW0tSC1LLS1GZS1UaS1DLS1MQU1NUFMtLWlwcjKUjCIyMDA5LS1LaW0tWS1NLS1GZS1Nbi0tTEFNTVBTLS1pcHIxlIwkMjAwOS0tT2xzc29uLVAtQS1ULS1GZS0tTEFNTVBTLS1pcHIxlIwmMjAwOS0tU3R1a293c2tpLUEtLUZlLUNyLS1MQU1NUFMtLWlwcjGUjCQyMDEwLS1LaW0tSC1LLS1GZS1OYi1DLS1MQU1NUFMtLWlwcjGUjCAyMDEwLS1MZWUtRS0tRmUtQWwtLUxBTU1QUy0taXByMZSMITIwMTAtLU1hbGVyYmEtTC0tRmUtLUxBTU1QUy0taXByMZSMIjIwMTEtLUJvbm55LUctLUZlLUNyLS1MQU1NUFMtLWlwcjKUjCIyMDExLS1Cb25ueS1HLS1GZS1Dci0tTEFNTVBTLS1pcHIzlIwlMjAxMS0tQm9ubnktRy0tRmUtTmktQ3ItLUxBTU1QUy0taXByMZSMJTIwMTEtLUJvbm55LUctLUZlLU5pLUNyLS1MQU1NUFMtLWlwcjKUjCMyMDExLS1DaGllc2EtUy0tRmUtMzMtLUxBTU1QUy0taXByMZSMLTIwMTItLUplbGluZWstQi0tQWwtU2ktTWctQ3UtRmUtLUxBTU1QUy0taXByMpSMIDIwMTItLUtvLVctUy0tRmUtUC0tTEFNTVBTLS1pcHIxlIwiMjAxMi0tUHJvdmlsbGUtTC0tRmUtLUxBTU1QUy0taXByMZSMJDIwMTMtLUJvbm55LUctLUZlLUNyLVctLUxBTU1QUy0taXByMpSMJDIwMTMtLUJvbm55LUctLUZlLUNyLVctLUxBTU1QUy0taXByM5SMJTIwMTMtLUJvbm55LUctLUZlLU5pLUNyLS1MQU1NUFMtLWlwcjGUjCEyMDEzLS1Cb25ueS1HLS1GZS1XLS1MQU1NUFMtLWlwcjGUjCoyMDEzLS1IZW5yaWtzc29uLUstTy1FLS1GZS1DLS1MQU1NUFMtLWlwcjGUjCgyMDE0LS1MaXlhbmFnZS1MLVMtSS0tRmUtQy0tTEFNTVBTLS1pcHIylIwfMjAxNS0tQXNhZGktRS0tRmUtLUxBTU1QUy0taXByMZSMIzIwMTUtLUVpY2gtUy1NLS1GZS1Dci0tTEFNTVBTLS1pcHIxlIwoMjAxNy0tQmVsYW5kLUwtSy0tRmUtTmktQ3ItLUxBTU1QUy0taXByMZSMIzIwMTctLUNob2ktVy1NLS1Dby1GZS0tTEFNTVBTLS1pcHIxlIwiMjAxNy0tV3UtQy0tTmktQ3ItRmUtLUxBTU1QUy0taXByMZSMHzIwMTctLVd1LUMtLU5pLUZlLS1MQU1NUFMtLWlwcjGUjCwyMDE4LS1DaG9pLVctTS0tQ28tTmktQ3ItRmUtTW4tLUxBTU1QUy0taXByMZSMIzIwMTgtLUV0ZXNhbWktUy1BLS1GZS0tTEFNTVBTLS1pcHIxlIwsMjAxOC0tRmFya2FzLUQtLUZlLU5pLUNyLUNvLUN1LS1MQU1NUFMtLWlwcjKUjCQyMDE4LS1KZW9uZy1HLVUtLVBkLUZlLS1MQU1NUFMtLWlwcjGUjCYyMDE4LS1aaG91LVgtVy0tRmUtTmktQ3ItLUxBTU1QUy0taXByMZSMJjIwMTgtLVpob3UtWC1XLS1GZS1OaS1Dci0tTEFNTVBTLS1pcHIylIwnMjAxOS0tQXNsYW0tSS0tRmUtTW4tU2ktQy0tTEFNTVBTLS1pcHIxlIwmMjAxOS0tQnlnZ21hc3Rhci1KLS1GZS1PLS1MQU1NUFMtLWlwcjGUjCoyMDE5LS1NZW5kZWxldi1NLUktLUZlLU5pLUNyLS1MQU1NUFMtLWlwcjGUjCQyMDIwLS1CeWdnbWFzdGFyLUotLUZlLS1MQU1NUFMtLWlwcjGUjCwyMDIwLS1GYXJrYXMtRC0tRmUtTmktQ3ItQ28tQWwtLUxBTU1QUy0taXByMZSMLDIwMjAtLUdyb2dlci1SLS1Dby1Dci1GZS1Nbi1OaS0tTEFNTVBTLS1pcHIxlIweMjAyMC0tTW9yaS1ILS1GZS0tTEFNTVBTLS1pcHIxlIwvMjAyMS0tRGVsdWlnaS1PLVItLUZlLU5pLUNyLUNvLUN1LS1MQU1NUFMtLWlwcjGUjCIyMDIxLS1TdGFyaWtvdi1TLS1GZS0tTEFNTVBTLS1pcHIxlIwiMjAyMS0tU3Rhcmlrb3YtUy0tRmUtLUxBTU1QUy0taXByMpSMHzIwMjEtLVdlbi1NLS1GZS1ILS1MQU1NUFMtLWlwcjGUjCMyMDIyLS1NYWhhdGEtQS0tQWwtRmUtLUxBTU1QUy0taXByMZSMJzIwMjItLVN0YXJpa292LVMtLUZlLUNyLUgtLUxBTU1QUy0taXByMZSMHTIwMjItLVN1bi1ZLS1GZS0tTEFNTVBTLS1pcHIxlIw6RUFNX0R5bmFtb19BY2tsYW5kQmFjb25DYWxkZXJfMTk5N19GZV9fTU9fMTQyNzk5NzE3NTE2XzAwNZSMQUVBTV9EeW5hbW9fQWNrbGFuZE1lbmRlbGV2U3JvbG92aXR6XzIwMDRfRmVQX19NT184ODQzNDMxNDYzMTBfMDA1lIw7RUFNX0R5bmFtb19Cb25ueUNhc3RpbkJ1bGxlbnNfMjAxM19GZVdfX01PXzczNzU2NzI0MjYzMV8wMDCUjEBFQU1fRHluYW1vX0Jvbm55Q2FzdGluVGVyZW50eWV2XzIwMTNfRmVOaUNyX19NT183NjMxOTc5NDEwMzlfMDAwlIw/RUFNX0R5bmFtb19Cb25ueVBhc2lhbm90Q2FzdGluXzIwMDlfRmVDdU5pX19NT180NjkzNDM5NzMxNzFfMDA1lIw+RUFNX0R5bmFtb19Cb25ueVBhc2lhbm90TWFsZXJiYV8yMDA5X0ZlTmlfX01PXzI2NzcyMTQwODkzNF8wMDWUjEFFQU1fRHluYW1vX0NoYW1hdGlQYXBhbmljb2xhb3VNaXNoaW5fMjAwNl9GZV9fTU9fOTYwNjk5NTEzNDI0XzAwMJSMN0VBTV9EeW5hbW9fSGVwYnVybkFja2xhbmRfMjAwOF9GZUNfX01PXzE0Mzk3NzE1MjcyOF8wMDWUjDBFQU1fRHluYW1vX01hcmluaWNhXzIwMDdfRmVfX01PXzQ2NjgwODg3NzEzMF8wMDCUjDBFQU1fRHluYW1vX01hcmluaWNhXzIwMTFfRmVfX01PXzI1NTMxNTQwNzkxMF8wMDCUjD1FQU1fRHluYW1vX01lbmRlbGV2Qm9yb3Zpa292XzIwMjBfRmVOaUNyX19NT185MjIzNjMzNDA1NzBfMDAwlIw3RUFNX0R5bmFtb19NZW5kZWxldkhhblNvbl8yMDA3X1ZGZV9fTU9fMjQ5NzA2ODEwNTI3XzAwNZSMRkVBTV9EeW5hbW9fTWVuZGVsZXZIYW5Tcm9sb3ZpdHpfMjAwM1BvdGVudGlhbDJfRmVfX01PXzc2OTU4MjM2MzQzOV8wMDWUjEZFQU1fRHluYW1vX01lbmRlbGV2SGFuU3JvbG92aXR6XzIwMDNQb3RlbnRpYWw1X0ZlX19NT185NDI0MjA3MDY4NThfMDA1lIw8RUFNX0R5bmFtb19NZW5kZWxldkhhblNyb2xvdml0el8yMDAzX0ZlX19NT184MDc5OTc4MjY0NDlfMDAwlIxCRUFNX0R5bmFtb19NZW5kZWxldlNyb2xvdml0ekFja2xhbmRfMjAwNV9BbEZlX19NT181Nzc0NTM4OTE5NDFfMDA1lIwwRUFNX0R5bmFtb19NZW5kZWxldl8yMDAzX0ZlX19NT181NDY2NzM1NDkwODVfMDAwlIxJRUFNX0R5bmFtb19aaG91Sm9obnNvbldhZGxleV8yMDA0TklTVHJldGFidWxhdGlvbl9GZV9fTU9fNjgxMDg4Mjk4MjA4XzAwMJSMOUVBTV9EeW5hbW9fWmhvdUpvaG5zb25XYWRsZXlfMjAwNF9GZV9fTU9fNjUwMjc5OTA1MjMwXzAwNZSMRkVBTV9NYWduZXRpYzJHUXVpbnRpY19DaGllc2FEZXJsZXREdWRhcmV2XzIwMTFfRmVfX01PXzE0MDQ0NDMyMTYwN18wMDKUjDxFQU1fTWFnbmV0aWNDdWJpY19EdWRhcmV2RGVybGV0XzIwMDVfRmVfX01PXzEzNTAzNDIyOTI4Ml8wMDKUjENFQU1fTWFnbmV0aWNDdWJpY19NZW5kZWxldkhhblNyb2xvdml0el8yMDAzX0ZlX19NT184NTYyOTU5NTI0MjVfMDAylIw8TUVBTV9MQU1NUFNfQXNhZGlaYWVlbU5vdXJhbmlhbl8yMDE1X0ZlX19NT180OTIzMTA4OTg3NzlfMDAwlIw7TUVBTV9MQU1NUFNfQ2hvaUpvU29obl8yMDE4X0NvTmlDckZlTW5fX01PXzExNTQ1NDc0NzUwM18wMDCUjDZNRUFNX0xBTU1QU19DaG9pS2ltU2VvbF8yMDE3X0NvRmVfX01PXzE3OTE1ODI1NzE4MF8wMDCUjDVNRUFNX0xBTU1QU19FdGVzYW1pQXNhZGlfMjAxOF9GZV9fTU9fNTQ5OTAwMjg3NDIxXzAwMJSMR01FQU1fTEFNTVBTX0plbGluZWtHcm9oSG9yc3RlbWV5ZXJfMjAxMl9BbFNpTWdDdUZlX19NT18yNjI1MTk1MjA2NzhfMDAwlIw2TUVBTV9MQU1NUFNfSmVvbmdQYXJrRG9fMjAxOF9QZEZlX19NT185MjQ3MzY2MjIyMDNfMDAwlIw2TUVBTV9MQU1NUFNfS2ltSnVuZ0xlZV8yMDA5X0ZlVGlDX19NT18xMTAxMTkyMDQ3MjNfMDAwlIw2TUVBTV9MQU1NUFNfS2ltSnVuZ0xlZV8yMDEwX0ZlTmJDX19NT18wNzI2ODk3MTg2MTZfMDAwlIwxTUVBTV9MQU1NUFNfS2ltTGVlXzIwMDZfUHRGZV9fTU9fMzQzMTY4MTAxNDkwXzAwMJSMNU1FQU1fTEFNTVBTX0tpbVNoaW5MZWVfMjAwOV9GZU1uX19NT18wNTg3MzU0MDA0NjJfMDAwlIwyTUVBTV9MQU1NUFNfS29KaW1MZWVfMjAxMl9GZVBfX01PXzE3OTQyMDM2Mzk0NF8wMDCUjDFNRUFNX0xBTU1QU19MZWVKYW5nXzIwMDdfRmVIX19NT18wOTU2MTA5NTE5NTdfMDAwlIwzTUVBTV9MQU1NUFNfTGVlTGVlS2ltXzIwMDZfRmVOX19NT180MzI4NjE3NjY3MzhfMDAwlIwxTUVBTV9MQU1NUFNfTGVlTGVlXzIwMTBfRmVBbF9fTU9fMzMyMjExNTIyMDUwXzAwMJSMN01FQU1fTEFNTVBTX0xlZVdpcnRoU2hpbV8yMDA1X0ZlQ3VfX01PXzA2MzYyNjA2NTQzN18wMDCUjC1NRUFNX0xBTU1QU19MZWVfMjAwNl9GZUNfX01PXzg1Njk1NjE3ODY2OV8wMDCUjDpNRUFNX0xBTU1QU19MaXlhbmFnZUtpbUhvdXplXzIwMTRfRmVDX19NT18wNzUyNzk4MDAxOTVfMDAwlIwwTUVBTV9MQU1NUFNfU2FMZWVfMjAwOF9GZVRpX19NT18yNjA1NDY5Njc3OTNfMDAwlIwwTUVBTV9MQU1NUFNfU2FMZWVfMjAwOF9OYkZlX19NT18xNjIwMzYxNDEyNjFfMDAwlIw0TUVBTV9MQU1NUFNfV3VMZWVTdV8yMDE3X05pQ3JGZV9fTU9fOTEyNjM2MTA3MTA4XzAwMJSMMk1FQU1fTEFNTVBTX1d1TGVlU3VfMjAxN19OaUZlX19NT18zMjEyMzMxNzY0OThfMDAwlIwxTUpfTW9ycmlzQWdhTGV2YXNob3ZfMjAwOF9GZV9fTU9fODU3MjgyNzU0MzA3XzAwM5SMRE1vcnNlX1NoaWZ0ZWRfR2lyaWZhbGNvV2VpemVyXzE5NTlIaWdoQ3V0b2ZmX0ZlX19NT18xNDc2MDMxMjg0MzdfMDA0lIxDTW9yc2VfU2hpZnRlZF9HaXJpZmFsY29XZWl6ZXJfMTk1OUxvd0N1dG9mZl9GZV9fTU9fMzMxMjg1NDk1NjE3XzAwNJSMQ01vcnNlX1NoaWZ0ZWRfR2lyaWZhbGNvV2VpemVyXzE5NTlNZWRDdXRvZmZfRmVfX01PXzk4NDM1ODM0NDE5Nl8wMDSUjD1UZXJzb2ZmX0xBTU1QU19NdWVsbGVyRXJoYXJ0QWxiZV8yMDA3X0ZlX19NT18xMzc5NjQzMTA3MDJfMDAzlIxFU2ltX0xBTU1QU19FQU1DRF9TdHVrb3dza2lTYWRpZ2hFcmhhcnRfMjAwOV9GZUNyX19TTV83NzU1NjQ0OTk1MTNfMDAwlIxBU2ltX0xBTU1QU19FQU1fQm9ubnlDYXN0aW5CdWxsZW5zXzIwMTNfRmVDcldfX1NNXzY5OTI1NzM1MDcwNF8wMDCUjERTaW1fTEFNTVBTX0VBTV9Cb25ueVBhc2lhbm90VGVyZW50eWV2XzIwMTFfRmVDcl9fU01fMjM3MDg5Mjk4NDYzXzAwMJSMQFNpbV9MQU1NUFNfTUVBTV9Bc2FkaVphZWVtTm91cmFuaWFuXzIwMTVfRmVfX1NNXzA0MjYzMDY4MDk5M18wMDCUjDlTaW1fTEFNTVBTX01FQU1fRXRlc2FtaUFzYWRpXzIwMThfRmVfX1NNXzI2NzAxNjYwODc1NV8wMDCUjEtTaW1fTEFNTVBTX01FQU1fSmVsaW5la0dyb2hIb3JzdGVtZXllcl8yMDEyX0FsU2lNZ0N1RmVfX1NNXzY1NjUxNzM1MjQ4NV8wMDCUjDpTaW1fTEFNTVBTX01FQU1fS2ltSnVuZ0xlZV8yMDA5X0ZlVGlDX19TTV81MzEwMzgyNzQ0NzFfMDAwlIw+U2ltX0xBTU1QU19NRUFNX0xpeWFuYWdlS2ltSG91emVfMjAxNF9GZUNfX1NNXzY1MjQyNTc3NzgwOF8wMDCUjEhTaW1fTEFNTVBTX1JlYXhGRl9BcnlhbnBvdXJWYW5EdWluS3ViaWNraV8yMDEwX0ZlSE9fX1NNXzIyMjk2NDIxNjAwMV8wMDGUjEVTaW1fTEFNTVBTX1RlcnNvZmZaQkxfQnlnZ21hc3RhckdyYW5iZXJnXzIwMjBfRmVfX1NNXzk1ODg2Mzg5NTIzNF8wMDCUjE1TaW1fTEFNTVBTX1RlcnNvZmZaQkxfSGVucmlrc3NvbkJqb3JrYXNOb3JkbHVuZF8yMDEzX0ZlQ19fU01fNDczNDYzNDk4MjY5XzAwMJRldS4="
-                            }
-                        ],
-                        "outputs": [
-                            {
-                                "type": "data",
-                                "label": "engine",
-                                "GID": 37,
-                                "dtype": "DType.Data",
-                                "dtype state": "gASVjgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjB9weWlyb25fYXRvbWlzdGljcy5sYW1tcHMubGFtbXBzlIwGTGFtbXBzlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu",
-                                "otype_namespace": "atomistics",
-                                "otype_name": "lammps_output_job"
-                            }
-                        ],
-                        "GID": 33,
-                        "pos x": 648.4175585188576,
-                        "pos y": 315.10989010989016
-                    },
-                    {
-                        "identifier": "BulkStructure_Node",
-                        "version": null,
-                        "state data": "gAR9lC4=",
-                        "additional data": {},
-                        "inputs": [
-                            {
-                                "type": "data",
-                                "label": "element",
-                                "GID": 39,
-                                "val": "gASVBgAAAAAAAACMAkZllC4=",
-                                "dtype": "DType.String",
-                                "dtype state": "gASViwAAAAAAAAB9lCiMB2RlZmF1bHSUjAJGZZSMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA3N0cpSTlIwFbnVtcHmUjARzdHJflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu",
-                                "otype_namespace": "atomistics",
-                                "otype_name": "bulk_structure_input_element"
-                            },
-                            {
-                                "type": "data",
-                                "label": "crystal_structure",
-                                "GID": 40,
-                                "val": "gAROLg==",
-                                "dtype": "DType.Choice",
-                                "dtype state": "gASVwgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiYwFaXRlbXOUXZQoTowCc2OUjANmY2OUjANiY2OUjANoY3CUjAdkaWFtb25klIwKemluY2JsZW5kZZSMCHJvY2tzYWx0lIwOY2VzaXVtY2hsb3JpZGWUjAhmbHVvcml0ZZSMCHd1cnR6aXRllGV1Lg=="
-                            },
-                            {
-                                "type": "data",
-                                "label": "a",
-                                "GID": 41,
-                                "val": "gAROLg==",
-                                "dtype": "DType.Float",
-                                "dtype state": "gASVmQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZSMCGRlY2ltYWxzlEsKdS4="
-                            },
-                            {
-                                "type": "data",
-                                "label": "c",
-                                "GID": 42,
-                                "val": "gAROLg==",
-                                "dtype": "DType.Float",
-                                "dtype state": "gASVmQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZSMCGRlY2ltYWxzlEsKdS4="
-                            },
-                            {
-                                "type": "data",
-                                "label": "c_over_a",
-                                "GID": 43,
-                                "val": "gAROLg==",
-                                "dtype": "DType.Float",
-                                "dtype state": "gASVmQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZSMCGRlY2ltYWxzlEsKdS4="
-                            },
-                            {
-                                "type": "data",
-                                "label": "u",
-                                "GID": 44,
-                                "val": "gAROLg==",
-                                "dtype": "DType.Float",
-                                "dtype state": "gASVmQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZSMCGRlY2ltYWxzlEsKdS4="
-                            },
-                            {
-                                "type": "data",
-                                "label": "orthorhombic",
-                                "GID": 45,
-                                "val": "gASJLg==",
-                                "dtype": "DType.Boolean",
-                                "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "cubic",
-                                "GID": 46,
-                                "val": "gASJLg==",
-                                "dtype": "DType.Boolean",
-                                "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
-                            }
-                        ],
-                        "outputs": [
-                            {
-                                "type": "data",
-                                "label": "structure",
-                                "GID": 47,
-                                "dtype": "DType.Data",
-                                "dtype state": "gASVmgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCxweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLnN0cnVjdHVyZS5hdG9tc5SMBUF0b21zlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu",
-                                "otype_namespace": "atomistics",
-                                "otype_name": "bulk_structure_output_structure"
-                            }
-                        ],
-                        "GID": 38,
-                        "pos x": 250.6381273965547,
-                        "pos y": 260.1648351648352
-                    },
-                    {
-                        "identifier": "Project_Node",
-                        "version": null,
-                        "state data": "gAR9lC4=",
-                        "additional data": {},
-                        "inputs": [
-                            {
-                                "type": "data",
-                                "label": "name",
-                                "GID": 54,
-                                "val": "gASVGAAAAAAAAACMFHByZW1hZGVfYnVsa19tb2R1bHVzlC4=",
-                                "dtype": "DType.String",
-                                "dtype state": "gASVigAAAAAAAAB9lCiMB2RlZmF1bHSUjAEulIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwDc3RylJOUjAVudW1weZSMBHN0cl+Uk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
-                            },
-                            {
-                                "type": "exec",
-                                "label": "remove",
-                                "GID": 55,
-                                "val": "gAROLg==",
-                                "dtype": "DType.Untyped",
-                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "enable_remove",
-                                "GID": 56,
-                                "val": "gASJLg==",
-                                "dtype": "DType.Boolean",
-                                "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "remove_name",
-                                "GID": 57,
-                                "val": "gASVBAAAAAAAAACMAJQu",
-                                "dtype": "DType.String",
-                                "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUjACUjAN2YWyUaAKMA2RvY5RoAowGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA3N0cpSTlIwFbnVtcHmUjARzdHJflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "remove_all",
-                                "GID": 58,
-                                "val": "gASJLg==",
-                                "dtype": "DType.Boolean",
-                                "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "recursive",
-                                "GID": 59,
-                                "val": "gASILg==",
-                                "dtype": "DType.Boolean",
-                                "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiIwDdmFslIiMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
-                            }
-                        ],
-                        "outputs": [
-                            {
-                                "type": "data",
-                                "label": "project",
-                                "GID": 60,
-                                "dtype": "DType.Data",
-                                "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjBlweWlyb25fYXRvbWlzdGljcy5wcm9qZWN0lIwHUHJvamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg==",
-                                "otype_namespace": "atomistics",
-                                "otype_name": "project_output_atomistics_project"
-                            }
-                        ],
-                        "GID": 53,
-                        "pos x": 266.6399312517903,
-                        "pos y": 16.208791208791208
+                        "pos x": 1288.4101976511029,
+                        "pos y": 181.98901098901098
                     },
                     {
                         "identifier": "CalcMurnaghan_Node",
@@ -259,7 +54,7 @@
                             {
                                 "type": "exec",
                                 "label": "run",
-                                "GID": 62,
+                                "GID": 13,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Untyped",
                                 "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
@@ -267,7 +62,7 @@
                             {
                                 "type": "exec",
                                 "label": "reset",
-                                "GID": 63,
+                                "GID": 14,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Untyped",
                                 "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
@@ -275,7 +70,7 @@
                             {
                                 "type": "data",
                                 "label": "name",
-                                "GID": 64,
+                                "GID": 15,
                                 "val": "gASVCAAAAAAAAACMBGNhbGOULg==",
                                 "dtype": "DType.String",
                                 "dtype state": "gASVjQAAAAAAAAB9lCiMB2RlZmF1bHSUjARjYWxjlIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwDc3RylJOUjAVudW1weZSMBHN0cl+Uk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
@@ -283,7 +78,7 @@
                             {
                                 "type": "data",
                                 "label": "project",
-                                "GID": 65,
+                                "GID": 16,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjBlweWlyb25fYXRvbWlzdGljcy5wcm9qZWN0lIwHUHJvamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg==",
                                 "otype_namespace": "atomistics",
@@ -292,7 +87,7 @@
                             {
                                 "type": "data",
                                 "label": "engine",
-                                "GID": 66,
+                                "GID": 17,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVpgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCpweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLmpvYi5hdG9taXN0aWOUjBNBdG9taXN0aWNHZW5lcmljSm9ilJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu",
                                 "otype_namespace": "atomistics",
@@ -301,7 +96,7 @@
                             {
                                 "type": "data",
                                 "label": "num_points",
-                                "GID": 67,
+                                "GID": 18,
                                 "val": "gARLCy4=",
                                 "dtype": "DType.Integer",
                                 "dtype state": "gASViwAAAAAAAAB9lCiMB2RlZmF1bHSUSwuMA3ZhbJRLC4wDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA2ludJSTlIwFbnVtcHmUjAdpbnRlZ2VylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -309,7 +104,7 @@
                             {
                                 "type": "data",
                                 "label": "fit_type",
-                                "GID": 68,
+                                "GID": 19,
                                 "val": "gASVDgAAAAAAAACMCnBvbHlub21pYWyULg==",
                                 "dtype": "DType.Choice",
                                 "dtype state": "gASVsAAAAAAAAAB9lCiMB2RlZmF1bHSUjApwb2x5bm9taWFslIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlIwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlF2UKGgCjAViaXJjaJSMDmJpcmNobXVybmFnaGFulIwJbXVybmFnaGFulIwQcG91cmllcnRhcmFudG9sYZSMBXZpbmV0lGV1Lg=="
@@ -317,7 +112,7 @@
                             {
                                 "type": "data",
                                 "label": "fit_order",
-                                "GID": 69,
+                                "GID": 20,
                                 "val": "gARLAy4=",
                                 "dtype": "DType.Integer",
                                 "dtype state": "gASViwAAAAAAAAB9lCiMB2RlZmF1bHSUSwOMA3ZhbJRLA4wDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA2ludJSTlIwFbnVtcHmUjAdpbnRlZ2VylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -325,7 +120,7 @@
                             {
                                 "type": "data",
                                 "label": "vol_range_fraction",
-                                "GID": 70,
+                                "GID": 21,
                                 "val": "gASVCgAAAAAAAABHP7mZmZmZmZou",
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURz+5mZmZmZmajAN2YWyURz+5mZmZmZmajANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
@@ -335,35 +130,35 @@
                             {
                                 "type": "exec",
                                 "label": "ran",
-                                "GID": 71,
+                                "GID": 22,
                                 "dtype": "DType.Untyped",
                                 "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
                             },
                             {
                                 "type": "data",
                                 "label": "job",
-                                "GID": 72,
+                                "GID": 23,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVnwAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjC1weWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLm1hc3Rlci5tdXJuYWdoYW6UjAlNdXJuYWdoYW6Uk5RhjAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
                             },
                             {
                                 "type": "data",
                                 "label": "eq_energy",
-                                "GID": 73,
+                                "GID": 24,
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURwAAAAAAAAAAjAN2YWyURwAAAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
                             },
                             {
                                 "type": "data",
                                 "label": "eq_volume",
-                                "GID": 74,
+                                "GID": 25,
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURwAAAAAAAAAAjAN2YWyURwAAAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
                             },
                             {
                                 "type": "data",
                                 "label": "eq_bulk_modulus",
-                                "GID": 75,
+                                "GID": 26,
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURwAAAAAAAAAAjAN2YWyURwAAAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu",
                                 "otype_namespace": "atomistics",
@@ -372,7 +167,7 @@
                             {
                                 "type": "data",
                                 "label": "eq_b_prime",
-                                "GID": 76,
+                                "GID": 27,
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURwAAAAAAAAAAjAN2YWyURwAAAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu",
                                 "otype_namespace": "atomistics",
@@ -381,50 +176,263 @@
                             {
                                 "type": "data",
                                 "label": "volumes",
-                                "GID": 77,
+                                "GID": 28,
                                 "dtype": "DType.List",
                                 "dtype state": "gASVawAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAhidWlsdGluc5SMBWZsb2F0lJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIl1Lg=="
                             },
                             {
                                 "type": "data",
                                 "label": "energies",
-                                "GID": 78,
+                                "GID": 29,
                                 "dtype": "DType.List",
                                 "dtype state": "gASVawAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAhidWlsdGluc5SMBWZsb2F0lJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIl1Lg=="
                             }
                         ],
-                        "GID": 61,
-                        "pos x": 1066.2159839587512,
-                        "pos y": 175.90109890109892
+                        "GID": 12,
+                        "pos x": 903.4202234316815,
+                        "pos y": 87.98901098901098
+                    },
+                    {
+                        "identifier": "Project_Node",
+                        "version": null,
+                        "state data": "gAR9lC4=",
+                        "additional data": {},
+                        "inputs": [
+                            {
+                                "type": "data",
+                                "label": "name",
+                                "GID": 31,
+                                "val": "gASVGAAAAAAAAACMFHByZW1hZGVfYnVsa19tb2R1bHVzlC4=",
+                                "dtype": "DType.String",
+                                "dtype state": "gASVigAAAAAAAAB9lCiMB2RlZmF1bHSUjAEulIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwDc3RylJOUjAVudW1weZSMBHN0cl+Uk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
+                            },
+                            {
+                                "type": "exec",
+                                "label": "remove",
+                                "GID": 32,
+                                "val": "gAROLg==",
+                                "dtype": "DType.Untyped",
+                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "enable_remove",
+                                "GID": 33,
+                                "val": "gASJLg==",
+                                "dtype": "DType.Boolean",
+                                "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "remove_name",
+                                "GID": 34,
+                                "val": "gASVBAAAAAAAAACMAJQu",
+                                "dtype": "DType.String",
+                                "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUjACUjAN2YWyUaAKMA2RvY5RoAowGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA3N0cpSTlIwFbnVtcHmUjARzdHJflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "remove_all",
+                                "GID": 35,
+                                "val": "gASJLg==",
+                                "dtype": "DType.Boolean",
+                                "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "recursive",
+                                "GID": 36,
+                                "val": "gASILg==",
+                                "dtype": "DType.Boolean",
+                                "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiIwDdmFslIiMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            }
+                        ],
+                        "outputs": [
+                            {
+                                "type": "data",
+                                "label": "project",
+                                "GID": 37,
+                                "dtype": "DType.Data",
+                                "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjBlweWlyb25fYXRvbWlzdGljcy5wcm9qZWN0lIwHUHJvamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg==",
+                                "otype_namespace": "atomistics",
+                                "otype_name": "project_output_atomistics_project"
+                            }
+                        ],
+                        "GID": 30,
+                        "pos x": 191.8418791177313,
+                        "pos y": 62.362637362637365
+                    },
+                    {
+                        "identifier": "Lammps_Node",
+                        "version": "v0.2",
+                        "state data": "gAR9lC4=",
+                        "additional data": {},
+                        "inputs": [
+                            {
+                                "type": "data",
+                                "label": "project",
+                                "GID": 39,
+                                "dtype": "DType.Data",
+                                "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjBlweWlyb25fYXRvbWlzdGljcy5wcm9qZWN0lIwHUHJvamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg==",
+                                "otype_namespace": "atomistics",
+                                "otype_name": "lammps_input_project"
+                            },
+                            {
+                                "type": "data",
+                                "label": "structure",
+                                "GID": 40,
+                                "dtype": "DType.Data",
+                                "dtype state": "gASVmgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCxweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLnN0cnVjdHVyZS5hdG9tc5SMBUF0b21zlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu",
+                                "otype_namespace": "atomistics",
+                                "otype_name": "lammps_input_structure"
+                            },
+                            {
+                                "type": "data",
+                                "label": "potential",
+                                "GID": 41,
+                                "val": "gASVJwAAAAAAAACMIzE5OTctLUFja2xhbmQtRy1KLS1GZS0tTEFNTVBTLS1pcHIxlC4=",
+                                "dtype": "DType.Choice",
+                                "dtype state": "gASVLxkAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAhidWlsdGluc5SMA3N0cpSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjAVpdGVtc5RdlCiMIzE5OTctLUFja2xhbmQtRy1KLS1GZS0tTEFNTVBTLS1pcHIxlIwfMTk5OC0tTWV5ZXItUi0tRmUtLUxBTU1QUy0taXByMZSMHzIwMDEtLUxlZS1CLUotLUZlLS1MQU1NUFMtLWlwcjGUjCIyMDAxLS1MZWUtQi1KLS1GZS1Dci0tTEFNTVBTLS1pcHIxlIwmMjAwMy0tTWVuZGVsZXYtTS1JLS1GZS0yLS1MQU1NUFMtLWlwcjOUjCYyMDAzLS1NZW5kZWxldi1NLUktLUZlLTUtLUxBTU1QUy0taXByMZSMJTIwMDQtLUFja2xhbmQtRy1KLS1GZS1QLS1MQU1NUFMtLWlwcjGUjCAyMDA0LS1aaG91LVgtVy0tRmUtLUxBTU1QUy0taXByMpSMIjIwMDUtLUxlZS1CLUotLUZlLUN1LS1MQU1NUFMtLWlwcjGUjCcyMDA1LS1NZW5kZWxldi1NLUktLUFsLUZlLS1MQU1NUFMtLWlwcjGUjCEyMDA2LS1DaGFtYXRpLUgtLUZlLS1MQU1NUFMtLWlwcjGUjCAyMDA2LS1LaW0tSi0tRmUtUHQtLUxBTU1QUy0taXByMZSMITIwMDYtLUxlZS1CLUotLUZlLUMtLUxBTU1QUy0taXByMZSMITIwMDYtLUxlZS1CLUotLUZlLU4tLUxBTU1QUy0taXByMZSMITIwMDctLUxlZS1CLUotLUZlLUgtLUxBTU1QUy0taXByMZSMJjIwMDctLU1lbmRlbGV2LU0tSS0tVi1GZS0tTEFNTVBTLS1pcHIxlIwlMjAwOC0tSGVwYnVybi1ELUotLUZlLUMtLUxBTU1QUy0taXByMZSMHzIwMDgtLVNhLUktLUZlLU5iLS1MQU1NUFMtLWlwcjGUjB8yMDA4LS1TYS1JLS1GZS1UaS0tTEFNTVBTLS1pcHIxlIwlMjAwOS0tQm9ubnktRy0tRmUtQ3UtTmktLUxBTU1QUy0taXByMZSMIjIwMDktLUJvbm55LUctLUZlLU5pLS1MQU1NUFMtLWlwcjGUjCQyMDA5LS1LaW0tSC1LLS1GZS1UaS1DLS1MQU1NUFMtLWlwcjKUjCIyMDA5LS1LaW0tWS1NLS1GZS1Nbi0tTEFNTVBTLS1pcHIxlIwkMjAwOS0tT2xzc29uLVAtQS1ULS1GZS0tTEFNTVBTLS1pcHIxlIwmMjAwOS0tU3R1a293c2tpLUEtLUZlLUNyLS1MQU1NUFMtLWlwcjGUjCQyMDEwLS1LaW0tSC1LLS1GZS1OYi1DLS1MQU1NUFMtLWlwcjGUjCAyMDEwLS1MZWUtRS0tRmUtQWwtLUxBTU1QUy0taXByMZSMITIwMTAtLU1hbGVyYmEtTC0tRmUtLUxBTU1QUy0taXByMZSMIjIwMTEtLUJvbm55LUctLUZlLUNyLS1MQU1NUFMtLWlwcjKUjCIyMDExLS1Cb25ueS1HLS1GZS1Dci0tTEFNTVBTLS1pcHIzlIwlMjAxMS0tQm9ubnktRy0tRmUtTmktQ3ItLUxBTU1QUy0taXByMZSMJTIwMTEtLUJvbm55LUctLUZlLU5pLUNyLS1MQU1NUFMtLWlwcjKUjCMyMDExLS1DaGllc2EtUy0tRmUtMzMtLUxBTU1QUy0taXByMZSMLTIwMTItLUplbGluZWstQi0tQWwtU2ktTWctQ3UtRmUtLUxBTU1QUy0taXByMpSMIDIwMTItLUtvLVctUy0tRmUtUC0tTEFNTVBTLS1pcHIxlIwiMjAxMi0tUHJvdmlsbGUtTC0tRmUtLUxBTU1QUy0taXByMZSMJDIwMTMtLUJvbm55LUctLUZlLUNyLVctLUxBTU1QUy0taXByMpSMJDIwMTMtLUJvbm55LUctLUZlLUNyLVctLUxBTU1QUy0taXByM5SMJTIwMTMtLUJvbm55LUctLUZlLU5pLUNyLS1MQU1NUFMtLWlwcjGUjCEyMDEzLS1Cb25ueS1HLS1GZS1XLS1MQU1NUFMtLWlwcjGUjCoyMDEzLS1IZW5yaWtzc29uLUstTy1FLS1GZS1DLS1MQU1NUFMtLWlwcjGUjCgyMDE0LS1MaXlhbmFnZS1MLVMtSS0tRmUtQy0tTEFNTVBTLS1pcHIylIwfMjAxNS0tQXNhZGktRS0tRmUtLUxBTU1QUy0taXByMZSMIzIwMTUtLUVpY2gtUy1NLS1GZS1Dci0tTEFNTVBTLS1pcHIxlIwoMjAxNy0tQmVsYW5kLUwtSy0tRmUtTmktQ3ItLUxBTU1QUy0taXByMZSMIzIwMTctLUNob2ktVy1NLS1Dby1GZS0tTEFNTVBTLS1pcHIxlIwiMjAxNy0tV3UtQy0tTmktQ3ItRmUtLUxBTU1QUy0taXByMZSMHzIwMTctLVd1LUMtLU5pLUZlLS1MQU1NUFMtLWlwcjGUjCwyMDE4LS1DaG9pLVctTS0tQ28tTmktQ3ItRmUtTW4tLUxBTU1QUy0taXByMZSMIzIwMTgtLUV0ZXNhbWktUy1BLS1GZS0tTEFNTVBTLS1pcHIxlIwsMjAxOC0tRmFya2FzLUQtLUZlLU5pLUNyLUNvLUN1LS1MQU1NUFMtLWlwcjKUjCQyMDE4LS1KZW9uZy1HLVUtLVBkLUZlLS1MQU1NUFMtLWlwcjGUjCYyMDE4LS1aaG91LVgtVy0tRmUtTmktQ3ItLUxBTU1QUy0taXByMZSMJjIwMTgtLVpob3UtWC1XLS1GZS1OaS1Dci0tTEFNTVBTLS1pcHIylIwnMjAxOS0tQXNsYW0tSS0tRmUtTW4tU2ktQy0tTEFNTVBTLS1pcHIxlIwmMjAxOS0tQnlnZ21hc3Rhci1KLS1GZS1PLS1MQU1NUFMtLWlwcjGUjCoyMDE5LS1NZW5kZWxldi1NLUktLUZlLU5pLUNyLS1MQU1NUFMtLWlwcjGUjCQyMDIwLS1CeWdnbWFzdGFyLUotLUZlLS1MQU1NUFMtLWlwcjGUjCwyMDIwLS1GYXJrYXMtRC0tRmUtTmktQ3ItQ28tQWwtLUxBTU1QUy0taXByMZSMLDIwMjAtLUdyb2dlci1SLS1Dby1Dci1GZS1Nbi1OaS0tTEFNTVBTLS1pcHIxlIweMjAyMC0tTW9yaS1ILS1GZS0tTEFNTVBTLS1pcHIxlIwvMjAyMS0tRGVsdWlnaS1PLVItLUZlLU5pLUNyLUNvLUN1LS1MQU1NUFMtLWlwcjGUjCIyMDIxLS1TdGFyaWtvdi1TLS1GZS0tTEFNTVBTLS1pcHIxlIwiMjAyMS0tU3Rhcmlrb3YtUy0tRmUtLUxBTU1QUy0taXByMpSMHzIwMjEtLVdlbi1NLS1GZS1ILS1MQU1NUFMtLWlwcjGUjCMyMDIyLS1NYWhhdGEtQS0tQWwtRmUtLUxBTU1QUy0taXByMZSMJzIwMjItLVN0YXJpa292LVMtLUZlLUNyLUgtLUxBTU1QUy0taXByMZSMHTIwMjItLVN1bi1ZLS1GZS0tTEFNTVBTLS1pcHIxlIw6RUFNX0R5bmFtb19BY2tsYW5kQmFjb25DYWxkZXJfMTk5N19GZV9fTU9fMTQyNzk5NzE3NTE2XzAwNZSMQUVBTV9EeW5hbW9fQWNrbGFuZE1lbmRlbGV2U3JvbG92aXR6XzIwMDRfRmVQX19NT184ODQzNDMxNDYzMTBfMDA1lIw7RUFNX0R5bmFtb19Cb25ueUNhc3RpbkJ1bGxlbnNfMjAxM19GZVdfX01PXzczNzU2NzI0MjYzMV8wMDCUjEBFQU1fRHluYW1vX0Jvbm55Q2FzdGluVGVyZW50eWV2XzIwMTNfRmVOaUNyX19NT183NjMxOTc5NDEwMzlfMDAwlIw/RUFNX0R5bmFtb19Cb25ueVBhc2lhbm90Q2FzdGluXzIwMDlfRmVDdU5pX19NT180NjkzNDM5NzMxNzFfMDA1lIw+RUFNX0R5bmFtb19Cb25ueVBhc2lhbm90TWFsZXJiYV8yMDA5X0ZlTmlfX01PXzI2NzcyMTQwODkzNF8wMDWUjEFFQU1fRHluYW1vX0NoYW1hdGlQYXBhbmljb2xhb3VNaXNoaW5fMjAwNl9GZV9fTU9fOTYwNjk5NTEzNDI0XzAwMJSMN0VBTV9EeW5hbW9fSGVwYnVybkFja2xhbmRfMjAwOF9GZUNfX01PXzE0Mzk3NzE1MjcyOF8wMDWUjDBFQU1fRHluYW1vX01hcmluaWNhXzIwMDdfRmVfX01PXzQ2NjgwODg3NzEzMF8wMDCUjDBFQU1fRHluYW1vX01hcmluaWNhXzIwMTFfRmVfX01PXzI1NTMxNTQwNzkxMF8wMDCUjD1FQU1fRHluYW1vX01lbmRlbGV2Qm9yb3Zpa292XzIwMjBfRmVOaUNyX19NT185MjIzNjMzNDA1NzBfMDAwlIw3RUFNX0R5bmFtb19NZW5kZWxldkhhblNvbl8yMDA3X1ZGZV9fTU9fMjQ5NzA2ODEwNTI3XzAwNZSMRkVBTV9EeW5hbW9fTWVuZGVsZXZIYW5Tcm9sb3ZpdHpfMjAwM1BvdGVudGlhbDJfRmVfX01PXzc2OTU4MjM2MzQzOV8wMDWUjEZFQU1fRHluYW1vX01lbmRlbGV2SGFuU3JvbG92aXR6XzIwMDNQb3RlbnRpYWw1X0ZlX19NT185NDI0MjA3MDY4NThfMDA1lIw8RUFNX0R5bmFtb19NZW5kZWxldkhhblNyb2xvdml0el8yMDAzX0ZlX19NT184MDc5OTc4MjY0NDlfMDAwlIxCRUFNX0R5bmFtb19NZW5kZWxldlNyb2xvdml0ekFja2xhbmRfMjAwNV9BbEZlX19NT181Nzc0NTM4OTE5NDFfMDA1lIwwRUFNX0R5bmFtb19NZW5kZWxldl8yMDAzX0ZlX19NT181NDY2NzM1NDkwODVfMDAwlIxJRUFNX0R5bmFtb19aaG91Sm9obnNvbldhZGxleV8yMDA0TklTVHJldGFidWxhdGlvbl9GZV9fTU9fNjgxMDg4Mjk4MjA4XzAwMJSMOUVBTV9EeW5hbW9fWmhvdUpvaG5zb25XYWRsZXlfMjAwNF9GZV9fTU9fNjUwMjc5OTA1MjMwXzAwNZSMRkVBTV9NYWduZXRpYzJHUXVpbnRpY19DaGllc2FEZXJsZXREdWRhcmV2XzIwMTFfRmVfX01PXzE0MDQ0NDMyMTYwN18wMDKUjDxFQU1fTWFnbmV0aWNDdWJpY19EdWRhcmV2RGVybGV0XzIwMDVfRmVfX01PXzEzNTAzNDIyOTI4Ml8wMDKUjENFQU1fTWFnbmV0aWNDdWJpY19NZW5kZWxldkhhblNyb2xvdml0el8yMDAzX0ZlX19NT184NTYyOTU5NTI0MjVfMDAylIw8TUVBTV9MQU1NUFNfQXNhZGlaYWVlbU5vdXJhbmlhbl8yMDE1X0ZlX19NT180OTIzMTA4OTg3NzlfMDAwlIw7TUVBTV9MQU1NUFNfQ2hvaUpvU29obl8yMDE4X0NvTmlDckZlTW5fX01PXzExNTQ1NDc0NzUwM18wMDCUjDZNRUFNX0xBTU1QU19DaG9pS2ltU2VvbF8yMDE3X0NvRmVfX01PXzE3OTE1ODI1NzE4MF8wMDCUjDVNRUFNX0xBTU1QU19FdGVzYW1pQXNhZGlfMjAxOF9GZV9fTU9fNTQ5OTAwMjg3NDIxXzAwMJSMR01FQU1fTEFNTVBTX0plbGluZWtHcm9oSG9yc3RlbWV5ZXJfMjAxMl9BbFNpTWdDdUZlX19NT18yNjI1MTk1MjA2NzhfMDAwlIw2TUVBTV9MQU1NUFNfSmVvbmdQYXJrRG9fMjAxOF9QZEZlX19NT185MjQ3MzY2MjIyMDNfMDAwlIw2TUVBTV9MQU1NUFNfS2ltSnVuZ0xlZV8yMDA5X0ZlVGlDX19NT18xMTAxMTkyMDQ3MjNfMDAwlIw2TUVBTV9MQU1NUFNfS2ltSnVuZ0xlZV8yMDEwX0ZlTmJDX19NT18wNzI2ODk3MTg2MTZfMDAwlIwxTUVBTV9MQU1NUFNfS2ltTGVlXzIwMDZfUHRGZV9fTU9fMzQzMTY4MTAxNDkwXzAwMJSMNU1FQU1fTEFNTVBTX0tpbVNoaW5MZWVfMjAwOV9GZU1uX19NT18wNTg3MzU0MDA0NjJfMDAwlIwyTUVBTV9MQU1NUFNfS29KaW1MZWVfMjAxMl9GZVBfX01PXzE3OTQyMDM2Mzk0NF8wMDCUjDFNRUFNX0xBTU1QU19MZWVKYW5nXzIwMDdfRmVIX19NT18wOTU2MTA5NTE5NTdfMDAwlIwzTUVBTV9MQU1NUFNfTGVlTGVlS2ltXzIwMDZfRmVOX19NT180MzI4NjE3NjY3MzhfMDAwlIwxTUVBTV9MQU1NUFNfTGVlTGVlXzIwMTBfRmVBbF9fTU9fMzMyMjExNTIyMDUwXzAwMJSMN01FQU1fTEFNTVBTX0xlZVdpcnRoU2hpbV8yMDA1X0ZlQ3VfX01PXzA2MzYyNjA2NTQzN18wMDCUjC1NRUFNX0xBTU1QU19MZWVfMjAwNl9GZUNfX01PXzg1Njk1NjE3ODY2OV8wMDCUjDpNRUFNX0xBTU1QU19MaXlhbmFnZUtpbUhvdXplXzIwMTRfRmVDX19NT18wNzUyNzk4MDAxOTVfMDAwlIwwTUVBTV9MQU1NUFNfU2FMZWVfMjAwOF9GZVRpX19NT18yNjA1NDY5Njc3OTNfMDAwlIwwTUVBTV9MQU1NUFNfU2FMZWVfMjAwOF9OYkZlX19NT18xNjIwMzYxNDEyNjFfMDAwlIw0TUVBTV9MQU1NUFNfV3VMZWVTdV8yMDE3X05pQ3JGZV9fTU9fOTEyNjM2MTA3MTA4XzAwMJSMMk1FQU1fTEFNTVBTX1d1TGVlU3VfMjAxN19OaUZlX19NT18zMjEyMzMxNzY0OThfMDAwlIwxTUpfTW9ycmlzQWdhTGV2YXNob3ZfMjAwOF9GZV9fTU9fODU3MjgyNzU0MzA3XzAwM5SMRE1vcnNlX1NoaWZ0ZWRfR2lyaWZhbGNvV2VpemVyXzE5NTlIaWdoQ3V0b2ZmX0ZlX19NT18xNDc2MDMxMjg0MzdfMDA0lIxDTW9yc2VfU2hpZnRlZF9HaXJpZmFsY29XZWl6ZXJfMTk1OUxvd0N1dG9mZl9GZV9fTU9fMzMxMjg1NDk1NjE3XzAwNJSMQ01vcnNlX1NoaWZ0ZWRfR2lyaWZhbGNvV2VpemVyXzE5NTlNZWRDdXRvZmZfRmVfX01PXzk4NDM1ODM0NDE5Nl8wMDSUjD1UZXJzb2ZmX0xBTU1QU19NdWVsbGVyRXJoYXJ0QWxiZV8yMDA3X0ZlX19NT18xMzc5NjQzMTA3MDJfMDAzlIxFU2ltX0xBTU1QU19FQU1DRF9TdHVrb3dza2lTYWRpZ2hFcmhhcnRfMjAwOV9GZUNyX19TTV83NzU1NjQ0OTk1MTNfMDAwlIxBU2ltX0xBTU1QU19FQU1fQm9ubnlDYXN0aW5CdWxsZW5zXzIwMTNfRmVDcldfX1NNXzY5OTI1NzM1MDcwNF8wMDCUjERTaW1fTEFNTVBTX0VBTV9Cb25ueVBhc2lhbm90VGVyZW50eWV2XzIwMTFfRmVDcl9fU01fMjM3MDg5Mjk4NDYzXzAwMJSMQFNpbV9MQU1NUFNfTUVBTV9Bc2FkaVphZWVtTm91cmFuaWFuXzIwMTVfRmVfX1NNXzA0MjYzMDY4MDk5M18wMDCUjDlTaW1fTEFNTVBTX01FQU1fRXRlc2FtaUFzYWRpXzIwMThfRmVfX1NNXzI2NzAxNjYwODc1NV8wMDCUjEtTaW1fTEFNTVBTX01FQU1fSmVsaW5la0dyb2hIb3JzdGVtZXllcl8yMDEyX0FsU2lNZ0N1RmVfX1NNXzY1NjUxNzM1MjQ4NV8wMDCUjDpTaW1fTEFNTVBTX01FQU1fS2ltSnVuZ0xlZV8yMDA5X0ZlVGlDX19TTV81MzEwMzgyNzQ0NzFfMDAwlIw+U2ltX0xBTU1QU19NRUFNX0xpeWFuYWdlS2ltSG91emVfMjAxNF9GZUNfX1NNXzY1MjQyNTc3NzgwOF8wMDCUjEhTaW1fTEFNTVBTX1JlYXhGRl9BcnlhbnBvdXJWYW5EdWluS3ViaWNraV8yMDEwX0ZlSE9fX1NNXzIyMjk2NDIxNjAwMV8wMDGUjEVTaW1fTEFNTVBTX1RlcnNvZmZaQkxfQnlnZ21hc3RhckdyYW5iZXJnXzIwMjBfRmVfX1NNXzk1ODg2Mzg5NTIzNF8wMDCUjE1TaW1fTEFNTVBTX1RlcnNvZmZaQkxfSGVucmlrc3NvbkJqb3JrYXNOb3JkbHVuZF8yMDEzX0ZlQ19fU01fNDczNDYzNDk4MjY5XzAwMJRldS4="
+                            }
+                        ],
+                        "outputs": [
+                            {
+                                "type": "data",
+                                "label": "engine",
+                                "GID": 42,
+                                "dtype": "DType.Data",
+                                "dtype state": "gASVjgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjB9weWlyb25fYXRvbWlzdGljcy5sYW1tcHMubGFtbXBzlIwGTGFtbXBzlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu",
+                                "otype_namespace": "atomistics",
+                                "otype_name": "lammps_output_job"
+                            }
+                        ],
+                        "GID": 38,
+                        "pos x": 549.2294471498138,
+                        "pos y": 247.1098901098901
+                    },
+                    {
+                        "identifier": "BulkStructure_Node",
+                        "version": null,
+                        "state data": "gAR9lC4=",
+                        "additional data": {},
+                        "inputs": [
+                            {
+                                "type": "data",
+                                "label": "element",
+                                "GID": 44,
+                                "val": "gASVBgAAAAAAAACMAkZllC4=",
+                                "dtype": "DType.String",
+                                "dtype state": "gASViwAAAAAAAAB9lCiMB2RlZmF1bHSUjAJGZZSMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA3N0cpSTlIwFbnVtcHmUjARzdHJflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu",
+                                "otype_namespace": "atomistics",
+                                "otype_name": "bulk_structure_input_element"
+                            },
+                            {
+                                "type": "data",
+                                "label": "crystal_structure",
+                                "GID": 45,
+                                "val": "gAROLg==",
+                                "dtype": "DType.Choice",
+                                "dtype state": "gASVwgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiYwFaXRlbXOUXZQoTowCc2OUjANmY2OUjANiY2OUjANoY3CUjAdkaWFtb25klIwKemluY2JsZW5kZZSMCHJvY2tzYWx0lIwOY2VzaXVtY2hsb3JpZGWUjAhmbHVvcml0ZZSMCHd1cnR6aXRllGV1Lg=="
+                            },
+                            {
+                                "type": "data",
+                                "label": "a",
+                                "GID": 46,
+                                "val": "gAROLg==",
+                                "dtype": "DType.Float",
+                                "dtype state": "gASVmQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZSMCGRlY2ltYWxzlEsKdS4="
+                            },
+                            {
+                                "type": "data",
+                                "label": "c",
+                                "GID": 47,
+                                "val": "gAROLg==",
+                                "dtype": "DType.Float",
+                                "dtype state": "gASVmQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZSMCGRlY2ltYWxzlEsKdS4="
+                            },
+                            {
+                                "type": "data",
+                                "label": "c_over_a",
+                                "GID": 48,
+                                "val": "gAROLg==",
+                                "dtype": "DType.Float",
+                                "dtype state": "gASVmQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZSMCGRlY2ltYWxzlEsKdS4="
+                            },
+                            {
+                                "type": "data",
+                                "label": "u",
+                                "GID": 49,
+                                "val": "gAROLg==",
+                                "dtype": "DType.Float",
+                                "dtype state": "gASVmQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZSMCGRlY2ltYWxzlEsKdS4="
+                            },
+                            {
+                                "type": "data",
+                                "label": "orthorhombic",
+                                "GID": 50,
+                                "val": "gASJLg==",
+                                "dtype": "DType.Boolean",
+                                "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "cubic",
+                                "GID": 51,
+                                "val": "gASJLg==",
+                                "dtype": "DType.Boolean",
+                                "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            }
+                        ],
+                        "outputs": [
+                            {
+                                "type": "data",
+                                "label": "structure",
+                                "GID": 52,
+                                "dtype": "DType.Data",
+                                "dtype state": "gASVmgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCxweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLnN0cnVjdHVyZS5hdG9tc5SMBUF0b21zlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu",
+                                "otype_namespace": "atomistics",
+                                "otype_name": "bulk_structure_output_structure"
+                            }
+                        ],
+                        "GID": 43,
+                        "pos x": 195.03867086794617,
+                        "pos y": 352.53846153846155
                     }
                 ],
                 "connections": [
                     {
-                        "GID": 80,
+                        "GID": 57,
                         "parent node index": 1,
-                        "output port index": 0,
-                        "connected node": 4,
-                        "connected input port index": 4
-                    },
-                    {
-                        "GID": 52,
-                        "parent node index": 2,
-                        "output port index": 0,
-                        "connected node": 1,
+                        "output port index": 4,
+                        "connected node": 0,
                         "connected input port index": 1
                     },
                     {
-                        "GID": 81,
-                        "parent node index": 3,
+                        "GID": 53,
+                        "parent node index": 2,
                         "output port index": 0,
-                        "connected node": 4,
+                        "connected node": 3,
+                        "connected input port index": 0
+                    },
+                    {
+                        "GID": 54,
+                        "parent node index": 2,
+                        "output port index": 0,
+                        "connected node": 1,
                         "connected input port index": 3
                     },
                     {
-                        "GID": 79,
+                        "GID": 56,
+                        "parent node index": 3,
+                        "output port index": 0,
+                        "connected node": 1,
+                        "connected input port index": 4
+                    },
+                    {
+                        "GID": 55,
                         "parent node index": 4,
-                        "output port index": 4,
-                        "connected node": 0,
+                        "output port index": 0,
+                        "connected node": 3,
                         "connected input port index": 1
                     }
                 ],

--- a/notebooks/premade_surface_energy.json
+++ b/notebooks/premade_surface_energy.json
@@ -36,9 +36,7 @@
                                 "label": "value",
                                 "GID": 11,
                                 "dtype": "DType.Float",
-                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURwAAAAAAAAAAjAN2YWyURwAAAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu",
-                                "otype_namespace": "atomistics",
-                                "otype_name": "surfaceenergy3"
+                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURwAAAAAAAAAAjAN2YWyURwAAAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
                             }
                         ],
                         "GID": 8,
@@ -104,258 +102,6 @@
                         "pos y": 281.31868131868134
                     },
                     {
-                        "identifier": "CalcMinimize_Node",
-                        "version": null,
-                        "state data": "gAR9lC4=",
-                        "additional data": {},
-                        "inputs": [
-                            {
-                                "type": "exec",
-                                "label": "run",
-                                "GID": 19,
-                                "val": "gAROLg==",
-                                "dtype": "DType.Untyped",
-                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
-                            },
-                            {
-                                "type": "exec",
-                                "label": "remove",
-                                "GID": 20,
-                                "val": "gAROLg==",
-                                "dtype": "DType.Untyped",
-                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "name",
-                                "GID": 21,
-                                "val": "gASVCAAAAAAAAACMBGJ1bGuULg==",
-                                "dtype": "DType.String",
-                                "dtype state": "gASVjQAAAAAAAAB9lCiMB2RlZmF1bHSUjARjYWxjlIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwDc3RylJOUjAVudW1weZSMBHN0cl+Uk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
-                            },
-                            {
-                                "type": "data",
-                                "label": "job",
-                                "GID": 22,
-                                "dtype": "DType.Data",
-                                "dtype state": "gASVjgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjB9weWlyb25fYXRvbWlzdGljcy5sYW1tcHMubGFtbXBzlIwGTGFtbXBzlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu",
-                                "otype_namespace": "atomistics",
-                                "otype_name": "atomistic_taker_job"
-                            },
-                            {
-                                "type": "data",
-                                "label": "ionic_energy_tolerance",
-                                "GID": 23,
-                                "val": "gASVCgAAAAAAAABHAAAAAAAAAAAu",
-                                "dtype": "DType.Float",
-                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURwAAAAAAAAAAjAN2YWyURwAAAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "ionic_force_tolerance",
-                                "GID": 24,
-                                "val": "gASVCgAAAAAAAABHPxo24uscQy0u",
-                                "dtype": "DType.Float",
-                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURz8aNuLrHEMtjAN2YWyURz8aNuLrHEMtjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "max_iter",
-                                "GID": 25,
-                                "val": "gASVBgAAAAAAAABKoIYBAC4=",
-                                "dtype": "DType.Integer",
-                                "dtype state": "gASVkQAAAAAAAAB9lCiMB2RlZmF1bHSUSqCGAQCMA3ZhbJRKoIYBAIwDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA2ludJSTlIwFbnVtcHmUjAdpbnRlZ2VylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "pressure",
-                                "GID": 26,
-                                "val": "gAROLg==",
-                                "dtype": "DType.Data",
-                                "dtype state": "gASVlgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlGgIjARsaXN0lJOUjAVudW1weZSMB25kYXJyYXmUk5RljAphbGxvd19ub25llIiMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
-                            },
-                            {
-                                "type": "data",
-                                "label": "n_print",
-                                "GID": 27,
-                                "val": "gARLZC4=",
-                                "dtype": "DType.Integer",
-                                "dtype state": "gASViwAAAAAAAAB9lCiMB2RlZmF1bHSUS2SMA3ZhbJRLZIwDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA2ludJSTlIwFbnVtcHmUjAdpbnRlZ2VylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "style",
-                                "GID": 28,
-                                "val": "gASVBgAAAAAAAACMAmNnlC4=",
-                                "dtype": "DType.Choice",
-                                "dtype state": "gASVZwAAAAAAAAB9lCiMB2RlZmF1bHSUjAJjZ5SMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZSMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjAVpdGVtc5RdlGgCYXUu"
-                            }
-                        ],
-                        "outputs": [
-                            {
-                                "type": "exec",
-                                "label": "ran",
-                                "GID": 29,
-                                "dtype": "DType.Untyped",
-                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "job",
-                                "GID": 30,
-                                "dtype": "DType.Data",
-                                "dtype state": "gASVjgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjB9weWlyb25fYXRvbWlzdGljcy5sYW1tcHMubGFtbXBzlIwGTGFtbXBzlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "energy_pot",
-                                "GID": 31,
-                                "dtype": "DType.Float",
-                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURwAAAAAAAAAAjAN2YWyURwAAAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu",
-                                "otype_namespace": "atomistics",
-                                "otype_name": "atomistic_taker_output_energy_pot"
-                            },
-                            {
-                                "type": "data",
-                                "label": "forces",
-                                "GID": 32,
-                                "dtype": "DType.List",
-                                "dtype state": "gASVgQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJdS4=",
-                                "otype_namespace": "atomistics",
-                                "otype_name": "atomistic_taker_output_forces"
-                            }
-                        ],
-                        "GID": 18,
-                        "pos x": 742.9176443655927,
-                        "pos y": 92.3076923076923
-                    },
-                    {
-                        "identifier": "CalcMinimize_Node",
-                        "version": null,
-                        "state data": "gAR9lC4=",
-                        "additional data": {},
-                        "inputs": [
-                            {
-                                "type": "exec",
-                                "label": "run",
-                                "GID": 35,
-                                "val": "gAROLg==",
-                                "dtype": "DType.Untyped",
-                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
-                            },
-                            {
-                                "type": "exec",
-                                "label": "remove",
-                                "GID": 36,
-                                "val": "gAROLg==",
-                                "dtype": "DType.Untyped",
-                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "name",
-                                "GID": 37,
-                                "val": "gASVCAAAAAAAAACMBHN1cmaULg==",
-                                "dtype": "DType.String",
-                                "dtype state": "gASVjQAAAAAAAAB9lCiMB2RlZmF1bHSUjARjYWxjlIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwDc3RylJOUjAVudW1weZSMBHN0cl+Uk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
-                            },
-                            {
-                                "type": "data",
-                                "label": "job",
-                                "GID": 38,
-                                "dtype": "DType.Data",
-                                "dtype state": "gASVjgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjB9weWlyb25fYXRvbWlzdGljcy5sYW1tcHMubGFtbXBzlIwGTGFtbXBzlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu",
-                                "otype_namespace": "atomistics",
-                                "otype_name": "atomistic_taker_job"
-                            },
-                            {
-                                "type": "data",
-                                "label": "ionic_energy_tolerance",
-                                "GID": 39,
-                                "val": "gASVCgAAAAAAAABHAAAAAAAAAAAu",
-                                "dtype": "DType.Float",
-                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURwAAAAAAAAAAjAN2YWyURwAAAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "ionic_force_tolerance",
-                                "GID": 40,
-                                "val": "gASVCgAAAAAAAABHPxo24uscQy0u",
-                                "dtype": "DType.Float",
-                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURz8aNuLrHEMtjAN2YWyURz8aNuLrHEMtjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "max_iter",
-                                "GID": 41,
-                                "val": "gASVBgAAAAAAAABKoIYBAC4=",
-                                "dtype": "DType.Integer",
-                                "dtype state": "gASVkQAAAAAAAAB9lCiMB2RlZmF1bHSUSqCGAQCMA3ZhbJRKoIYBAIwDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA2ludJSTlIwFbnVtcHmUjAdpbnRlZ2VylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "pressure",
-                                "GID": 42,
-                                "val": "gAROLg==",
-                                "dtype": "DType.Data",
-                                "dtype state": "gASVlgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlGgIjARsaXN0lJOUjAVudW1weZSMB25kYXJyYXmUk5RljAphbGxvd19ub25llIiMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
-                            },
-                            {
-                                "type": "data",
-                                "label": "n_print",
-                                "GID": 43,
-                                "val": "gARLZC4=",
-                                "dtype": "DType.Integer",
-                                "dtype state": "gASViwAAAAAAAAB9lCiMB2RlZmF1bHSUS2SMA3ZhbJRLZIwDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA2ludJSTlIwFbnVtcHmUjAdpbnRlZ2VylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "style",
-                                "GID": 44,
-                                "val": "gASVBgAAAAAAAACMAmNnlC4=",
-                                "dtype": "DType.Choice",
-                                "dtype state": "gASVZwAAAAAAAAB9lCiMB2RlZmF1bHSUjAJjZ5SMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZSMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjAVpdGVtc5RdlGgCYXUu"
-                            }
-                        ],
-                        "outputs": [
-                            {
-                                "type": "exec",
-                                "label": "ran",
-                                "GID": 45,
-                                "dtype": "DType.Untyped",
-                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "job",
-                                "GID": 46,
-                                "dtype": "DType.Data",
-                                "dtype state": "gASVjgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjB9weWlyb25fYXRvbWlzdGljcy5sYW1tcHMubGFtbXBzlIwGTGFtbXBzlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "energy_pot",
-                                "GID": 47,
-                                "dtype": "DType.Float",
-                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURwAAAAAAAAAAjAN2YWyURwAAAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu",
-                                "otype_namespace": "atomistics",
-                                "otype_name": "atomistic_taker_output_energy_pot"
-                            },
-                            {
-                                "type": "data",
-                                "label": "forces",
-                                "GID": 48,
-                                "dtype": "DType.List",
-                                "dtype state": "gASVgQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJdS4=",
-                                "otype_namespace": "atomistics",
-                                "otype_name": "atomistic_taker_output_forces"
-                            }
-                        ],
-                        "GID": 34,
-                        "pos x": 747.3129971956733,
-                        "pos y": 493.13186813186815
-                    },
-                    {
                         "identifier": "Lammps_Node",
                         "version": "v0.2",
                         "state data": "gAR9lC4=",
@@ -364,7 +110,7 @@
                             {
                                 "type": "data",
                                 "label": "project",
-                                "GID": 51,
+                                "GID": 49,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjBlweWlyb25fYXRvbWlzdGljcy5wcm9qZWN0lIwHUHJvamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg==",
                                 "otype_namespace": "atomistics",
@@ -373,7 +119,7 @@
                             {
                                 "type": "data",
                                 "label": "structure",
-                                "GID": 52,
+                                "GID": 50,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVmgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCxweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLnN0cnVjdHVyZS5hdG9tc5SMBUF0b21zlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu",
                                 "otype_namespace": "atomistics",
@@ -382,7 +128,7 @@
                             {
                                 "type": "data",
                                 "label": "potential",
-                                "GID": 53,
+                                "GID": 51,
                                 "val": "gASVJwAAAAAAAACMIzE5OTctLUFja2xhbmQtRy1KLS1GZS0tTEFNTVBTLS1pcHIxlC4=",
                                 "dtype": "DType.Choice",
                                 "dtype state": "gASVLxkAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAhidWlsdGluc5SMA3N0cpSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjAVpdGVtc5RdlCiMIzE5OTctLUFja2xhbmQtRy1KLS1GZS0tTEFNTVBTLS1pcHIxlIwfMTk5OC0tTWV5ZXItUi0tRmUtLUxBTU1QUy0taXByMZSMHzIwMDEtLUxlZS1CLUotLUZlLS1MQU1NUFMtLWlwcjGUjCIyMDAxLS1MZWUtQi1KLS1GZS1Dci0tTEFNTVBTLS1pcHIxlIwmMjAwMy0tTWVuZGVsZXYtTS1JLS1GZS0yLS1MQU1NUFMtLWlwcjOUjCYyMDAzLS1NZW5kZWxldi1NLUktLUZlLTUtLUxBTU1QUy0taXByMZSMJTIwMDQtLUFja2xhbmQtRy1KLS1GZS1QLS1MQU1NUFMtLWlwcjGUjCAyMDA0LS1aaG91LVgtVy0tRmUtLUxBTU1QUy0taXByMpSMIjIwMDUtLUxlZS1CLUotLUZlLUN1LS1MQU1NUFMtLWlwcjGUjCcyMDA1LS1NZW5kZWxldi1NLUktLUFsLUZlLS1MQU1NUFMtLWlwcjGUjCEyMDA2LS1DaGFtYXRpLUgtLUZlLS1MQU1NUFMtLWlwcjGUjCAyMDA2LS1LaW0tSi0tRmUtUHQtLUxBTU1QUy0taXByMZSMITIwMDYtLUxlZS1CLUotLUZlLUMtLUxBTU1QUy0taXByMZSMITIwMDYtLUxlZS1CLUotLUZlLU4tLUxBTU1QUy0taXByMZSMITIwMDctLUxlZS1CLUotLUZlLUgtLUxBTU1QUy0taXByMZSMJjIwMDctLU1lbmRlbGV2LU0tSS0tVi1GZS0tTEFNTVBTLS1pcHIxlIwlMjAwOC0tSGVwYnVybi1ELUotLUZlLUMtLUxBTU1QUy0taXByMZSMHzIwMDgtLVNhLUktLUZlLU5iLS1MQU1NUFMtLWlwcjGUjB8yMDA4LS1TYS1JLS1GZS1UaS0tTEFNTVBTLS1pcHIxlIwlMjAwOS0tQm9ubnktRy0tRmUtQ3UtTmktLUxBTU1QUy0taXByMZSMIjIwMDktLUJvbm55LUctLUZlLU5pLS1MQU1NUFMtLWlwcjGUjCQyMDA5LS1LaW0tSC1LLS1GZS1UaS1DLS1MQU1NUFMtLWlwcjKUjCIyMDA5LS1LaW0tWS1NLS1GZS1Nbi0tTEFNTVBTLS1pcHIxlIwkMjAwOS0tT2xzc29uLVAtQS1ULS1GZS0tTEFNTVBTLS1pcHIxlIwmMjAwOS0tU3R1a293c2tpLUEtLUZlLUNyLS1MQU1NUFMtLWlwcjGUjCQyMDEwLS1LaW0tSC1LLS1GZS1OYi1DLS1MQU1NUFMtLWlwcjGUjCAyMDEwLS1MZWUtRS0tRmUtQWwtLUxBTU1QUy0taXByMZSMITIwMTAtLU1hbGVyYmEtTC0tRmUtLUxBTU1QUy0taXByMZSMIjIwMTEtLUJvbm55LUctLUZlLUNyLS1MQU1NUFMtLWlwcjKUjCIyMDExLS1Cb25ueS1HLS1GZS1Dci0tTEFNTVBTLS1pcHIzlIwlMjAxMS0tQm9ubnktRy0tRmUtTmktQ3ItLUxBTU1QUy0taXByMZSMJTIwMTEtLUJvbm55LUctLUZlLU5pLUNyLS1MQU1NUFMtLWlwcjKUjCMyMDExLS1DaGllc2EtUy0tRmUtMzMtLUxBTU1QUy0taXByMZSMLTIwMTItLUplbGluZWstQi0tQWwtU2ktTWctQ3UtRmUtLUxBTU1QUy0taXByMpSMIDIwMTItLUtvLVctUy0tRmUtUC0tTEFNTVBTLS1pcHIxlIwiMjAxMi0tUHJvdmlsbGUtTC0tRmUtLUxBTU1QUy0taXByMZSMJDIwMTMtLUJvbm55LUctLUZlLUNyLVctLUxBTU1QUy0taXByMpSMJDIwMTMtLUJvbm55LUctLUZlLUNyLVctLUxBTU1QUy0taXByM5SMJTIwMTMtLUJvbm55LUctLUZlLU5pLUNyLS1MQU1NUFMtLWlwcjGUjCEyMDEzLS1Cb25ueS1HLS1GZS1XLS1MQU1NUFMtLWlwcjGUjCoyMDEzLS1IZW5yaWtzc29uLUstTy1FLS1GZS1DLS1MQU1NUFMtLWlwcjGUjCgyMDE0LS1MaXlhbmFnZS1MLVMtSS0tRmUtQy0tTEFNTVBTLS1pcHIylIwfMjAxNS0tQXNhZGktRS0tRmUtLUxBTU1QUy0taXByMZSMIzIwMTUtLUVpY2gtUy1NLS1GZS1Dci0tTEFNTVBTLS1pcHIxlIwoMjAxNy0tQmVsYW5kLUwtSy0tRmUtTmktQ3ItLUxBTU1QUy0taXByMZSMIzIwMTctLUNob2ktVy1NLS1Dby1GZS0tTEFNTVBTLS1pcHIxlIwiMjAxNy0tV3UtQy0tTmktQ3ItRmUtLUxBTU1QUy0taXByMZSMHzIwMTctLVd1LUMtLU5pLUZlLS1MQU1NUFMtLWlwcjGUjCwyMDE4LS1DaG9pLVctTS0tQ28tTmktQ3ItRmUtTW4tLUxBTU1QUy0taXByMZSMIzIwMTgtLUV0ZXNhbWktUy1BLS1GZS0tTEFNTVBTLS1pcHIxlIwsMjAxOC0tRmFya2FzLUQtLUZlLU5pLUNyLUNvLUN1LS1MQU1NUFMtLWlwcjKUjCQyMDE4LS1KZW9uZy1HLVUtLVBkLUZlLS1MQU1NUFMtLWlwcjGUjCYyMDE4LS1aaG91LVgtVy0tRmUtTmktQ3ItLUxBTU1QUy0taXByMZSMJjIwMTgtLVpob3UtWC1XLS1GZS1OaS1Dci0tTEFNTVBTLS1pcHIylIwnMjAxOS0tQXNsYW0tSS0tRmUtTW4tU2ktQy0tTEFNTVBTLS1pcHIxlIwmMjAxOS0tQnlnZ21hc3Rhci1KLS1GZS1PLS1MQU1NUFMtLWlwcjGUjCoyMDE5LS1NZW5kZWxldi1NLUktLUZlLU5pLUNyLS1MQU1NUFMtLWlwcjGUjCQyMDIwLS1CeWdnbWFzdGFyLUotLUZlLS1MQU1NUFMtLWlwcjGUjCwyMDIwLS1GYXJrYXMtRC0tRmUtTmktQ3ItQ28tQWwtLUxBTU1QUy0taXByMZSMLDIwMjAtLUdyb2dlci1SLS1Dby1Dci1GZS1Nbi1OaS0tTEFNTVBTLS1pcHIxlIweMjAyMC0tTW9yaS1ILS1GZS0tTEFNTVBTLS1pcHIxlIwvMjAyMS0tRGVsdWlnaS1PLVItLUZlLU5pLUNyLUNvLUN1LS1MQU1NUFMtLWlwcjGUjCIyMDIxLS1TdGFyaWtvdi1TLS1GZS0tTEFNTVBTLS1pcHIxlIwiMjAyMS0tU3Rhcmlrb3YtUy0tRmUtLUxBTU1QUy0taXByMpSMHzIwMjEtLVdlbi1NLS1GZS1ILS1MQU1NUFMtLWlwcjGUjCMyMDIyLS1NYWhhdGEtQS0tQWwtRmUtLUxBTU1QUy0taXByMZSMJzIwMjItLVN0YXJpa292LVMtLUZlLUNyLUgtLUxBTU1QUy0taXByMZSMHTIwMjItLVN1bi1ZLS1GZS0tTEFNTVBTLS1pcHIxlIw6RUFNX0R5bmFtb19BY2tsYW5kQmFjb25DYWxkZXJfMTk5N19GZV9fTU9fMTQyNzk5NzE3NTE2XzAwNZSMQUVBTV9EeW5hbW9fQWNrbGFuZE1lbmRlbGV2U3JvbG92aXR6XzIwMDRfRmVQX19NT184ODQzNDMxNDYzMTBfMDA1lIw7RUFNX0R5bmFtb19Cb25ueUNhc3RpbkJ1bGxlbnNfMjAxM19GZVdfX01PXzczNzU2NzI0MjYzMV8wMDCUjEBFQU1fRHluYW1vX0Jvbm55Q2FzdGluVGVyZW50eWV2XzIwMTNfRmVOaUNyX19NT183NjMxOTc5NDEwMzlfMDAwlIw/RUFNX0R5bmFtb19Cb25ueVBhc2lhbm90Q2FzdGluXzIwMDlfRmVDdU5pX19NT180NjkzNDM5NzMxNzFfMDA1lIw+RUFNX0R5bmFtb19Cb25ueVBhc2lhbm90TWFsZXJiYV8yMDA5X0ZlTmlfX01PXzI2NzcyMTQwODkzNF8wMDWUjEFFQU1fRHluYW1vX0NoYW1hdGlQYXBhbmljb2xhb3VNaXNoaW5fMjAwNl9GZV9fTU9fOTYwNjk5NTEzNDI0XzAwMJSMN0VBTV9EeW5hbW9fSGVwYnVybkFja2xhbmRfMjAwOF9GZUNfX01PXzE0Mzk3NzE1MjcyOF8wMDWUjDBFQU1fRHluYW1vX01hcmluaWNhXzIwMDdfRmVfX01PXzQ2NjgwODg3NzEzMF8wMDCUjDBFQU1fRHluYW1vX01hcmluaWNhXzIwMTFfRmVfX01PXzI1NTMxNTQwNzkxMF8wMDCUjD1FQU1fRHluYW1vX01lbmRlbGV2Qm9yb3Zpa292XzIwMjBfRmVOaUNyX19NT185MjIzNjMzNDA1NzBfMDAwlIw3RUFNX0R5bmFtb19NZW5kZWxldkhhblNvbl8yMDA3X1ZGZV9fTU9fMjQ5NzA2ODEwNTI3XzAwNZSMRkVBTV9EeW5hbW9fTWVuZGVsZXZIYW5Tcm9sb3ZpdHpfMjAwM1BvdGVudGlhbDJfRmVfX01PXzc2OTU4MjM2MzQzOV8wMDWUjEZFQU1fRHluYW1vX01lbmRlbGV2SGFuU3JvbG92aXR6XzIwMDNQb3RlbnRpYWw1X0ZlX19NT185NDI0MjA3MDY4NThfMDA1lIw8RUFNX0R5bmFtb19NZW5kZWxldkhhblNyb2xvdml0el8yMDAzX0ZlX19NT184MDc5OTc4MjY0NDlfMDAwlIxCRUFNX0R5bmFtb19NZW5kZWxldlNyb2xvdml0ekFja2xhbmRfMjAwNV9BbEZlX19NT181Nzc0NTM4OTE5NDFfMDA1lIwwRUFNX0R5bmFtb19NZW5kZWxldl8yMDAzX0ZlX19NT181NDY2NzM1NDkwODVfMDAwlIxJRUFNX0R5bmFtb19aaG91Sm9obnNvbldhZGxleV8yMDA0TklTVHJldGFidWxhdGlvbl9GZV9fTU9fNjgxMDg4Mjk4MjA4XzAwMJSMOUVBTV9EeW5hbW9fWmhvdUpvaG5zb25XYWRsZXlfMjAwNF9GZV9fTU9fNjUwMjc5OTA1MjMwXzAwNZSMRkVBTV9NYWduZXRpYzJHUXVpbnRpY19DaGllc2FEZXJsZXREdWRhcmV2XzIwMTFfRmVfX01PXzE0MDQ0NDMyMTYwN18wMDKUjDxFQU1fTWFnbmV0aWNDdWJpY19EdWRhcmV2RGVybGV0XzIwMDVfRmVfX01PXzEzNTAzNDIyOTI4Ml8wMDKUjENFQU1fTWFnbmV0aWNDdWJpY19NZW5kZWxldkhhblNyb2xvdml0el8yMDAzX0ZlX19NT184NTYyOTU5NTI0MjVfMDAylIw8TUVBTV9MQU1NUFNfQXNhZGlaYWVlbU5vdXJhbmlhbl8yMDE1X0ZlX19NT180OTIzMTA4OTg3NzlfMDAwlIw7TUVBTV9MQU1NUFNfQ2hvaUpvU29obl8yMDE4X0NvTmlDckZlTW5fX01PXzExNTQ1NDc0NzUwM18wMDCUjDZNRUFNX0xBTU1QU19DaG9pS2ltU2VvbF8yMDE3X0NvRmVfX01PXzE3OTE1ODI1NzE4MF8wMDCUjDVNRUFNX0xBTU1QU19FdGVzYW1pQXNhZGlfMjAxOF9GZV9fTU9fNTQ5OTAwMjg3NDIxXzAwMJSMR01FQU1fTEFNTVBTX0plbGluZWtHcm9oSG9yc3RlbWV5ZXJfMjAxMl9BbFNpTWdDdUZlX19NT18yNjI1MTk1MjA2NzhfMDAwlIw2TUVBTV9MQU1NUFNfSmVvbmdQYXJrRG9fMjAxOF9QZEZlX19NT185MjQ3MzY2MjIyMDNfMDAwlIw2TUVBTV9MQU1NUFNfS2ltSnVuZ0xlZV8yMDA5X0ZlVGlDX19NT18xMTAxMTkyMDQ3MjNfMDAwlIw2TUVBTV9MQU1NUFNfS2ltSnVuZ0xlZV8yMDEwX0ZlTmJDX19NT18wNzI2ODk3MTg2MTZfMDAwlIwxTUVBTV9MQU1NUFNfS2ltTGVlXzIwMDZfUHRGZV9fTU9fMzQzMTY4MTAxNDkwXzAwMJSMNU1FQU1fTEFNTVBTX0tpbVNoaW5MZWVfMjAwOV9GZU1uX19NT18wNTg3MzU0MDA0NjJfMDAwlIwyTUVBTV9MQU1NUFNfS29KaW1MZWVfMjAxMl9GZVBfX01PXzE3OTQyMDM2Mzk0NF8wMDCUjDFNRUFNX0xBTU1QU19MZWVKYW5nXzIwMDdfRmVIX19NT18wOTU2MTA5NTE5NTdfMDAwlIwzTUVBTV9MQU1NUFNfTGVlTGVlS2ltXzIwMDZfRmVOX19NT180MzI4NjE3NjY3MzhfMDAwlIwxTUVBTV9MQU1NUFNfTGVlTGVlXzIwMTBfRmVBbF9fTU9fMzMyMjExNTIyMDUwXzAwMJSMN01FQU1fTEFNTVBTX0xlZVdpcnRoU2hpbV8yMDA1X0ZlQ3VfX01PXzA2MzYyNjA2NTQzN18wMDCUjC1NRUFNX0xBTU1QU19MZWVfMjAwNl9GZUNfX01PXzg1Njk1NjE3ODY2OV8wMDCUjDpNRUFNX0xBTU1QU19MaXlhbmFnZUtpbUhvdXplXzIwMTRfRmVDX19NT18wNzUyNzk4MDAxOTVfMDAwlIwwTUVBTV9MQU1NUFNfU2FMZWVfMjAwOF9GZVRpX19NT18yNjA1NDY5Njc3OTNfMDAwlIwwTUVBTV9MQU1NUFNfU2FMZWVfMjAwOF9OYkZlX19NT18xNjIwMzYxNDEyNjFfMDAwlIw0TUVBTV9MQU1NUFNfV3VMZWVTdV8yMDE3X05pQ3JGZV9fTU9fOTEyNjM2MTA3MTA4XzAwMJSMMk1FQU1fTEFNTVBTX1d1TGVlU3VfMjAxN19OaUZlX19NT18zMjEyMzMxNzY0OThfMDAwlIwxTUpfTW9ycmlzQWdhTGV2YXNob3ZfMjAwOF9GZV9fTU9fODU3MjgyNzU0MzA3XzAwM5SMRE1vcnNlX1NoaWZ0ZWRfR2lyaWZhbGNvV2VpemVyXzE5NTlIaWdoQ3V0b2ZmX0ZlX19NT18xNDc2MDMxMjg0MzdfMDA0lIxDTW9yc2VfU2hpZnRlZF9HaXJpZmFsY29XZWl6ZXJfMTk1OUxvd0N1dG9mZl9GZV9fTU9fMzMxMjg1NDk1NjE3XzAwNJSMQ01vcnNlX1NoaWZ0ZWRfR2lyaWZhbGNvV2VpemVyXzE5NTlNZWRDdXRvZmZfRmVfX01PXzk4NDM1ODM0NDE5Nl8wMDSUjD1UZXJzb2ZmX0xBTU1QU19NdWVsbGVyRXJoYXJ0QWxiZV8yMDA3X0ZlX19NT18xMzc5NjQzMTA3MDJfMDAzlIxFU2ltX0xBTU1QU19FQU1DRF9TdHVrb3dza2lTYWRpZ2hFcmhhcnRfMjAwOV9GZUNyX19TTV83NzU1NjQ0OTk1MTNfMDAwlIxBU2ltX0xBTU1QU19FQU1fQm9ubnlDYXN0aW5CdWxsZW5zXzIwMTNfRmVDcldfX1NNXzY5OTI1NzM1MDcwNF8wMDCUjERTaW1fTEFNTVBTX0VBTV9Cb25ueVBhc2lhbm90VGVyZW50eWV2XzIwMTFfRmVDcl9fU01fMjM3MDg5Mjk4NDYzXzAwMJSMQFNpbV9MQU1NUFNfTUVBTV9Bc2FkaVphZWVtTm91cmFuaWFuXzIwMTVfRmVfX1NNXzA0MjYzMDY4MDk5M18wMDCUjDlTaW1fTEFNTVBTX01FQU1fRXRlc2FtaUFzYWRpXzIwMThfRmVfX1NNXzI2NzAxNjYwODc1NV8wMDCUjEtTaW1fTEFNTVBTX01FQU1fSmVsaW5la0dyb2hIb3JzdGVtZXllcl8yMDEyX0FsU2lNZ0N1RmVfX1NNXzY1NjUxNzM1MjQ4NV8wMDCUjDpTaW1fTEFNTVBTX01FQU1fS2ltSnVuZ0xlZV8yMDA5X0ZlVGlDX19TTV81MzEwMzgyNzQ0NzFfMDAwlIw+U2ltX0xBTU1QU19NRUFNX0xpeWFuYWdlS2ltSG91emVfMjAxNF9GZUNfX1NNXzY1MjQyNTc3NzgwOF8wMDCUjEhTaW1fTEFNTVBTX1JlYXhGRl9BcnlhbnBvdXJWYW5EdWluS3ViaWNraV8yMDEwX0ZlSE9fX1NNXzIyMjk2NDIxNjAwMV8wMDGUjEVTaW1fTEFNTVBTX1RlcnNvZmZaQkxfQnlnZ21hc3RhckdyYW5iZXJnXzIwMjBfRmVfX1NNXzk1ODg2Mzg5NTIzNF8wMDCUjE1TaW1fTEFNTVBTX1RlcnNvZmZaQkxfSGVucmlrc3NvbkJqb3JrYXNOb3JkbHVuZF8yMDEzX0ZlQ19fU01fNDczNDYzNDk4MjY5XzAwMJRldS4="
@@ -392,14 +138,14 @@
                             {
                                 "type": "data",
                                 "label": "engine",
-                                "GID": 54,
+                                "GID": 52,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVjgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjB9weWlyb25fYXRvbWlzdGljcy5sYW1tcHMubGFtbXBzlIwGTGFtbXBzlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu",
                                 "otype_namespace": "atomistics",
                                 "otype_name": "lammps_output_job"
                             }
                         ],
-                        "GID": 50,
+                        "GID": 48,
                         "pos x": 444.0336519201053,
                         "pos y": 82.14285714285714
                     },
@@ -412,7 +158,7 @@
                             {
                                 "type": "data",
                                 "label": "element",
-                                "GID": 57,
+                                "GID": 54,
                                 "val": "gASVBgAAAAAAAACMAkZllC4=",
                                 "dtype": "DType.String",
                                 "dtype state": "gASViwAAAAAAAAB9lCiMB2RlZmF1bHSUjAJGZZSMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA3N0cpSTlIwFbnVtcHmUjARzdHJflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu",
@@ -422,7 +168,7 @@
                             {
                                 "type": "data",
                                 "label": "crystal_structure",
-                                "GID": 58,
+                                "GID": 55,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Choice",
                                 "dtype state": "gASVwgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiYwFaXRlbXOUXZQoTowCc2OUjANmY2OUjANiY2OUjANoY3CUjAdkaWFtb25klIwKemluY2JsZW5kZZSMCHJvY2tzYWx0lIwOY2VzaXVtY2hsb3JpZGWUjAhmbHVvcml0ZZSMCHd1cnR6aXRllGV1Lg=="
@@ -430,7 +176,7 @@
                             {
                                 "type": "data",
                                 "label": "a",
-                                "GID": 59,
+                                "GID": 56,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVmQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZSMCGRlY2ltYWxzlEsKdS4="
@@ -438,7 +184,7 @@
                             {
                                 "type": "data",
                                 "label": "c",
-                                "GID": 60,
+                                "GID": 57,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVmQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZSMCGRlY2ltYWxzlEsKdS4="
@@ -446,7 +192,7 @@
                             {
                                 "type": "data",
                                 "label": "c_over_a",
-                                "GID": 61,
+                                "GID": 58,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVmQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZSMCGRlY2ltYWxzlEsKdS4="
@@ -454,7 +200,7 @@
                             {
                                 "type": "data",
                                 "label": "u",
-                                "GID": 62,
+                                "GID": 59,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVmQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZSMCGRlY2ltYWxzlEsKdS4="
@@ -462,7 +208,7 @@
                             {
                                 "type": "data",
                                 "label": "orthorhombic",
-                                "GID": 63,
+                                "GID": 60,
                                 "val": "gASJLg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -470,7 +216,7 @@
                             {
                                 "type": "data",
                                 "label": "cubic",
-                                "GID": 64,
+                                "GID": 61,
                                 "val": "gASJLg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -480,16 +226,16 @@
                             {
                                 "type": "data",
                                 "label": "structure",
-                                "GID": 65,
+                                "GID": 62,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVmgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCxweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLnN0cnVjdHVyZS5hdG9tc5SMBUF0b21zlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu",
                                 "otype_namespace": "atomistics",
                                 "otype_name": "bulk_structure_output_structure"
                             }
                         ],
-                        "GID": 56,
-                        "pos x": 107.78916041893207,
-                        "pos y": 128.2967032967033
+                        "GID": 53,
+                        "pos x": 104.84101976511027,
+                        "pos y": 225.06593406593407
                     },
                     {
                         "identifier": "Lammps_Node",
@@ -500,7 +246,7 @@
                             {
                                 "type": "data",
                                 "label": "project",
-                                "GID": 68,
+                                "GID": 64,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjBlweWlyb25fYXRvbWlzdGljcy5wcm9qZWN0lIwHUHJvamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg==",
                                 "otype_namespace": "atomistics",
@@ -509,7 +255,7 @@
                             {
                                 "type": "data",
                                 "label": "structure",
-                                "GID": 69,
+                                "GID": 65,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVmgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCxweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLnN0cnVjdHVyZS5hdG9tc5SMBUF0b21zlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu",
                                 "otype_namespace": "atomistics",
@@ -518,7 +264,7 @@
                             {
                                 "type": "data",
                                 "label": "potential",
-                                "GID": 70,
+                                "GID": 66,
                                 "val": "gASVJwAAAAAAAACMIzE5OTctLUFja2xhbmQtRy1KLS1GZS0tTEFNTVBTLS1pcHIxlC4=",
                                 "dtype": "DType.Choice",
                                 "dtype state": "gASVLxkAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAhidWlsdGluc5SMA3N0cpSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjAVpdGVtc5RdlCiMIzE5OTctLUFja2xhbmQtRy1KLS1GZS0tTEFNTVBTLS1pcHIxlIwfMTk5OC0tTWV5ZXItUi0tRmUtLUxBTU1QUy0taXByMZSMHzIwMDEtLUxlZS1CLUotLUZlLS1MQU1NUFMtLWlwcjGUjCIyMDAxLS1MZWUtQi1KLS1GZS1Dci0tTEFNTVBTLS1pcHIxlIwmMjAwMy0tTWVuZGVsZXYtTS1JLS1GZS0yLS1MQU1NUFMtLWlwcjOUjCYyMDAzLS1NZW5kZWxldi1NLUktLUZlLTUtLUxBTU1QUy0taXByMZSMJTIwMDQtLUFja2xhbmQtRy1KLS1GZS1QLS1MQU1NUFMtLWlwcjGUjCAyMDA0LS1aaG91LVgtVy0tRmUtLUxBTU1QUy0taXByMpSMIjIwMDUtLUxlZS1CLUotLUZlLUN1LS1MQU1NUFMtLWlwcjGUjCcyMDA1LS1NZW5kZWxldi1NLUktLUFsLUZlLS1MQU1NUFMtLWlwcjGUjCEyMDA2LS1DaGFtYXRpLUgtLUZlLS1MQU1NUFMtLWlwcjGUjCAyMDA2LS1LaW0tSi0tRmUtUHQtLUxBTU1QUy0taXByMZSMITIwMDYtLUxlZS1CLUotLUZlLUMtLUxBTU1QUy0taXByMZSMITIwMDYtLUxlZS1CLUotLUZlLU4tLUxBTU1QUy0taXByMZSMITIwMDctLUxlZS1CLUotLUZlLUgtLUxBTU1QUy0taXByMZSMJjIwMDctLU1lbmRlbGV2LU0tSS0tVi1GZS0tTEFNTVBTLS1pcHIxlIwlMjAwOC0tSGVwYnVybi1ELUotLUZlLUMtLUxBTU1QUy0taXByMZSMHzIwMDgtLVNhLUktLUZlLU5iLS1MQU1NUFMtLWlwcjGUjB8yMDA4LS1TYS1JLS1GZS1UaS0tTEFNTVBTLS1pcHIxlIwlMjAwOS0tQm9ubnktRy0tRmUtQ3UtTmktLUxBTU1QUy0taXByMZSMIjIwMDktLUJvbm55LUctLUZlLU5pLS1MQU1NUFMtLWlwcjGUjCQyMDA5LS1LaW0tSC1LLS1GZS1UaS1DLS1MQU1NUFMtLWlwcjKUjCIyMDA5LS1LaW0tWS1NLS1GZS1Nbi0tTEFNTVBTLS1pcHIxlIwkMjAwOS0tT2xzc29uLVAtQS1ULS1GZS0tTEFNTVBTLS1pcHIxlIwmMjAwOS0tU3R1a293c2tpLUEtLUZlLUNyLS1MQU1NUFMtLWlwcjGUjCQyMDEwLS1LaW0tSC1LLS1GZS1OYi1DLS1MQU1NUFMtLWlwcjGUjCAyMDEwLS1MZWUtRS0tRmUtQWwtLUxBTU1QUy0taXByMZSMITIwMTAtLU1hbGVyYmEtTC0tRmUtLUxBTU1QUy0taXByMZSMIjIwMTEtLUJvbm55LUctLUZlLUNyLS1MQU1NUFMtLWlwcjKUjCIyMDExLS1Cb25ueS1HLS1GZS1Dci0tTEFNTVBTLS1pcHIzlIwlMjAxMS0tQm9ubnktRy0tRmUtTmktQ3ItLUxBTU1QUy0taXByMZSMJTIwMTEtLUJvbm55LUctLUZlLU5pLUNyLS1MQU1NUFMtLWlwcjKUjCMyMDExLS1DaGllc2EtUy0tRmUtMzMtLUxBTU1QUy0taXByMZSMLTIwMTItLUplbGluZWstQi0tQWwtU2ktTWctQ3UtRmUtLUxBTU1QUy0taXByMpSMIDIwMTItLUtvLVctUy0tRmUtUC0tTEFNTVBTLS1pcHIxlIwiMjAxMi0tUHJvdmlsbGUtTC0tRmUtLUxBTU1QUy0taXByMZSMJDIwMTMtLUJvbm55LUctLUZlLUNyLVctLUxBTU1QUy0taXByMpSMJDIwMTMtLUJvbm55LUctLUZlLUNyLVctLUxBTU1QUy0taXByM5SMJTIwMTMtLUJvbm55LUctLUZlLU5pLUNyLS1MQU1NUFMtLWlwcjGUjCEyMDEzLS1Cb25ueS1HLS1GZS1XLS1MQU1NUFMtLWlwcjGUjCoyMDEzLS1IZW5yaWtzc29uLUstTy1FLS1GZS1DLS1MQU1NUFMtLWlwcjGUjCgyMDE0LS1MaXlhbmFnZS1MLVMtSS0tRmUtQy0tTEFNTVBTLS1pcHIylIwfMjAxNS0tQXNhZGktRS0tRmUtLUxBTU1QUy0taXByMZSMIzIwMTUtLUVpY2gtUy1NLS1GZS1Dci0tTEFNTVBTLS1pcHIxlIwoMjAxNy0tQmVsYW5kLUwtSy0tRmUtTmktQ3ItLUxBTU1QUy0taXByMZSMIzIwMTctLUNob2ktVy1NLS1Dby1GZS0tTEFNTVBTLS1pcHIxlIwiMjAxNy0tV3UtQy0tTmktQ3ItRmUtLUxBTU1QUy0taXByMZSMHzIwMTctLVd1LUMtLU5pLUZlLS1MQU1NUFMtLWlwcjGUjCwyMDE4LS1DaG9pLVctTS0tQ28tTmktQ3ItRmUtTW4tLUxBTU1QUy0taXByMZSMIzIwMTgtLUV0ZXNhbWktUy1BLS1GZS0tTEFNTVBTLS1pcHIxlIwsMjAxOC0tRmFya2FzLUQtLUZlLU5pLUNyLUNvLUN1LS1MQU1NUFMtLWlwcjKUjCQyMDE4LS1KZW9uZy1HLVUtLVBkLUZlLS1MQU1NUFMtLWlwcjGUjCYyMDE4LS1aaG91LVgtVy0tRmUtTmktQ3ItLUxBTU1QUy0taXByMZSMJjIwMTgtLVpob3UtWC1XLS1GZS1OaS1Dci0tTEFNTVBTLS1pcHIylIwnMjAxOS0tQXNsYW0tSS0tRmUtTW4tU2ktQy0tTEFNTVBTLS1pcHIxlIwmMjAxOS0tQnlnZ21hc3Rhci1KLS1GZS1PLS1MQU1NUFMtLWlwcjGUjCoyMDE5LS1NZW5kZWxldi1NLUktLUZlLU5pLUNyLS1MQU1NUFMtLWlwcjGUjCQyMDIwLS1CeWdnbWFzdGFyLUotLUZlLS1MQU1NUFMtLWlwcjGUjCwyMDIwLS1GYXJrYXMtRC0tRmUtTmktQ3ItQ28tQWwtLUxBTU1QUy0taXByMZSMLDIwMjAtLUdyb2dlci1SLS1Dby1Dci1GZS1Nbi1OaS0tTEFNTVBTLS1pcHIxlIweMjAyMC0tTW9yaS1ILS1GZS0tTEFNTVBTLS1pcHIxlIwvMjAyMS0tRGVsdWlnaS1PLVItLUZlLU5pLUNyLUNvLUN1LS1MQU1NUFMtLWlwcjGUjCIyMDIxLS1TdGFyaWtvdi1TLS1GZS0tTEFNTVBTLS1pcHIxlIwiMjAyMS0tU3Rhcmlrb3YtUy0tRmUtLUxBTU1QUy0taXByMpSMHzIwMjEtLVdlbi1NLS1GZS1ILS1MQU1NUFMtLWlwcjGUjCMyMDIyLS1NYWhhdGEtQS0tQWwtRmUtLUxBTU1QUy0taXByMZSMJzIwMjItLVN0YXJpa292LVMtLUZlLUNyLUgtLUxBTU1QUy0taXByMZSMHTIwMjItLVN1bi1ZLS1GZS0tTEFNTVBTLS1pcHIxlIw6RUFNX0R5bmFtb19BY2tsYW5kQmFjb25DYWxkZXJfMTk5N19GZV9fTU9fMTQyNzk5NzE3NTE2XzAwNZSMQUVBTV9EeW5hbW9fQWNrbGFuZE1lbmRlbGV2U3JvbG92aXR6XzIwMDRfRmVQX19NT184ODQzNDMxNDYzMTBfMDA1lIw7RUFNX0R5bmFtb19Cb25ueUNhc3RpbkJ1bGxlbnNfMjAxM19GZVdfX01PXzczNzU2NzI0MjYzMV8wMDCUjEBFQU1fRHluYW1vX0Jvbm55Q2FzdGluVGVyZW50eWV2XzIwMTNfRmVOaUNyX19NT183NjMxOTc5NDEwMzlfMDAwlIw/RUFNX0R5bmFtb19Cb25ueVBhc2lhbm90Q2FzdGluXzIwMDlfRmVDdU5pX19NT180NjkzNDM5NzMxNzFfMDA1lIw+RUFNX0R5bmFtb19Cb25ueVBhc2lhbm90TWFsZXJiYV8yMDA5X0ZlTmlfX01PXzI2NzcyMTQwODkzNF8wMDWUjEFFQU1fRHluYW1vX0NoYW1hdGlQYXBhbmljb2xhb3VNaXNoaW5fMjAwNl9GZV9fTU9fOTYwNjk5NTEzNDI0XzAwMJSMN0VBTV9EeW5hbW9fSGVwYnVybkFja2xhbmRfMjAwOF9GZUNfX01PXzE0Mzk3NzE1MjcyOF8wMDWUjDBFQU1fRHluYW1vX01hcmluaWNhXzIwMDdfRmVfX01PXzQ2NjgwODg3NzEzMF8wMDCUjDBFQU1fRHluYW1vX01hcmluaWNhXzIwMTFfRmVfX01PXzI1NTMxNTQwNzkxMF8wMDCUjD1FQU1fRHluYW1vX01lbmRlbGV2Qm9yb3Zpa292XzIwMjBfRmVOaUNyX19NT185MjIzNjMzNDA1NzBfMDAwlIw3RUFNX0R5bmFtb19NZW5kZWxldkhhblNvbl8yMDA3X1ZGZV9fTU9fMjQ5NzA2ODEwNTI3XzAwNZSMRkVBTV9EeW5hbW9fTWVuZGVsZXZIYW5Tcm9sb3ZpdHpfMjAwM1BvdGVudGlhbDJfRmVfX01PXzc2OTU4MjM2MzQzOV8wMDWUjEZFQU1fRHluYW1vX01lbmRlbGV2SGFuU3JvbG92aXR6XzIwMDNQb3RlbnRpYWw1X0ZlX19NT185NDI0MjA3MDY4NThfMDA1lIw8RUFNX0R5bmFtb19NZW5kZWxldkhhblNyb2xvdml0el8yMDAzX0ZlX19NT184MDc5OTc4MjY0NDlfMDAwlIxCRUFNX0R5bmFtb19NZW5kZWxldlNyb2xvdml0ekFja2xhbmRfMjAwNV9BbEZlX19NT181Nzc0NTM4OTE5NDFfMDA1lIwwRUFNX0R5bmFtb19NZW5kZWxldl8yMDAzX0ZlX19NT181NDY2NzM1NDkwODVfMDAwlIxJRUFNX0R5bmFtb19aaG91Sm9obnNvbldhZGxleV8yMDA0TklTVHJldGFidWxhdGlvbl9GZV9fTU9fNjgxMDg4Mjk4MjA4XzAwMJSMOUVBTV9EeW5hbW9fWmhvdUpvaG5zb25XYWRsZXlfMjAwNF9GZV9fTU9fNjUwMjc5OTA1MjMwXzAwNZSMRkVBTV9NYWduZXRpYzJHUXVpbnRpY19DaGllc2FEZXJsZXREdWRhcmV2XzIwMTFfRmVfX01PXzE0MDQ0NDMyMTYwN18wMDKUjDxFQU1fTWFnbmV0aWNDdWJpY19EdWRhcmV2RGVybGV0XzIwMDVfRmVfX01PXzEzNTAzNDIyOTI4Ml8wMDKUjENFQU1fTWFnbmV0aWNDdWJpY19NZW5kZWxldkhhblNyb2xvdml0el8yMDAzX0ZlX19NT184NTYyOTU5NTI0MjVfMDAylIw8TUVBTV9MQU1NUFNfQXNhZGlaYWVlbU5vdXJhbmlhbl8yMDE1X0ZlX19NT180OTIzMTA4OTg3NzlfMDAwlIw7TUVBTV9MQU1NUFNfQ2hvaUpvU29obl8yMDE4X0NvTmlDckZlTW5fX01PXzExNTQ1NDc0NzUwM18wMDCUjDZNRUFNX0xBTU1QU19DaG9pS2ltU2VvbF8yMDE3X0NvRmVfX01PXzE3OTE1ODI1NzE4MF8wMDCUjDVNRUFNX0xBTU1QU19FdGVzYW1pQXNhZGlfMjAxOF9GZV9fTU9fNTQ5OTAwMjg3NDIxXzAwMJSMR01FQU1fTEFNTVBTX0plbGluZWtHcm9oSG9yc3RlbWV5ZXJfMjAxMl9BbFNpTWdDdUZlX19NT18yNjI1MTk1MjA2NzhfMDAwlIw2TUVBTV9MQU1NUFNfSmVvbmdQYXJrRG9fMjAxOF9QZEZlX19NT185MjQ3MzY2MjIyMDNfMDAwlIw2TUVBTV9MQU1NUFNfS2ltSnVuZ0xlZV8yMDA5X0ZlVGlDX19NT18xMTAxMTkyMDQ3MjNfMDAwlIw2TUVBTV9MQU1NUFNfS2ltSnVuZ0xlZV8yMDEwX0ZlTmJDX19NT18wNzI2ODk3MTg2MTZfMDAwlIwxTUVBTV9MQU1NUFNfS2ltTGVlXzIwMDZfUHRGZV9fTU9fMzQzMTY4MTAxNDkwXzAwMJSMNU1FQU1fTEFNTVBTX0tpbVNoaW5MZWVfMjAwOV9GZU1uX19NT18wNTg3MzU0MDA0NjJfMDAwlIwyTUVBTV9MQU1NUFNfS29KaW1MZWVfMjAxMl9GZVBfX01PXzE3OTQyMDM2Mzk0NF8wMDCUjDFNRUFNX0xBTU1QU19MZWVKYW5nXzIwMDdfRmVIX19NT18wOTU2MTA5NTE5NTdfMDAwlIwzTUVBTV9MQU1NUFNfTGVlTGVlS2ltXzIwMDZfRmVOX19NT180MzI4NjE3NjY3MzhfMDAwlIwxTUVBTV9MQU1NUFNfTGVlTGVlXzIwMTBfRmVBbF9fTU9fMzMyMjExNTIyMDUwXzAwMJSMN01FQU1fTEFNTVBTX0xlZVdpcnRoU2hpbV8yMDA1X0ZlQ3VfX01PXzA2MzYyNjA2NTQzN18wMDCUjC1NRUFNX0xBTU1QU19MZWVfMjAwNl9GZUNfX01PXzg1Njk1NjE3ODY2OV8wMDCUjDpNRUFNX0xBTU1QU19MaXlhbmFnZUtpbUhvdXplXzIwMTRfRmVDX19NT18wNzUyNzk4MDAxOTVfMDAwlIwwTUVBTV9MQU1NUFNfU2FMZWVfMjAwOF9GZVRpX19NT18yNjA1NDY5Njc3OTNfMDAwlIwwTUVBTV9MQU1NUFNfU2FMZWVfMjAwOF9OYkZlX19NT18xNjIwMzYxNDEyNjFfMDAwlIw0TUVBTV9MQU1NUFNfV3VMZWVTdV8yMDE3X05pQ3JGZV9fTU9fOTEyNjM2MTA3MTA4XzAwMJSMMk1FQU1fTEFNTVBTX1d1TGVlU3VfMjAxN19OaUZlX19NT18zMjEyMzMxNzY0OThfMDAwlIwxTUpfTW9ycmlzQWdhTGV2YXNob3ZfMjAwOF9GZV9fTU9fODU3MjgyNzU0MzA3XzAwM5SMRE1vcnNlX1NoaWZ0ZWRfR2lyaWZhbGNvV2VpemVyXzE5NTlIaWdoQ3V0b2ZmX0ZlX19NT18xNDc2MDMxMjg0MzdfMDA0lIxDTW9yc2VfU2hpZnRlZF9HaXJpZmFsY29XZWl6ZXJfMTk1OUxvd0N1dG9mZl9GZV9fTU9fMzMxMjg1NDk1NjE3XzAwNJSMQ01vcnNlX1NoaWZ0ZWRfR2lyaWZhbGNvV2VpemVyXzE5NTlNZWRDdXRvZmZfRmVfX01PXzk4NDM1ODM0NDE5Nl8wMDSUjD1UZXJzb2ZmX0xBTU1QU19NdWVsbGVyRXJoYXJ0QWxiZV8yMDA3X0ZlX19NT18xMzc5NjQzMTA3MDJfMDAzlIxFU2ltX0xBTU1QU19FQU1DRF9TdHVrb3dza2lTYWRpZ2hFcmhhcnRfMjAwOV9GZUNyX19TTV83NzU1NjQ0OTk1MTNfMDAwlIxBU2ltX0xBTU1QU19FQU1fQm9ubnlDYXN0aW5CdWxsZW5zXzIwMTNfRmVDcldfX1NNXzY5OTI1NzM1MDcwNF8wMDCUjERTaW1fTEFNTVBTX0VBTV9Cb25ueVBhc2lhbm90VGVyZW50eWV2XzIwMTFfRmVDcl9fU01fMjM3MDg5Mjk4NDYzXzAwMJSMQFNpbV9MQU1NUFNfTUVBTV9Bc2FkaVphZWVtTm91cmFuaWFuXzIwMTVfRmVfX1NNXzA0MjYzMDY4MDk5M18wMDCUjDlTaW1fTEFNTVBTX01FQU1fRXRlc2FtaUFzYWRpXzIwMThfRmVfX1NNXzI2NzAxNjYwODc1NV8wMDCUjEtTaW1fTEFNTVBTX01FQU1fSmVsaW5la0dyb2hIb3JzdGVtZXllcl8yMDEyX0FsU2lNZ0N1RmVfX1NNXzY1NjUxNzM1MjQ4NV8wMDCUjDpTaW1fTEFNTVBTX01FQU1fS2ltSnVuZ0xlZV8yMDA5X0ZlVGlDX19TTV81MzEwMzgyNzQ0NzFfMDAwlIw+U2ltX0xBTU1QU19NRUFNX0xpeWFuYWdlS2ltSG91emVfMjAxNF9GZUNfX1NNXzY1MjQyNTc3NzgwOF8wMDCUjEhTaW1fTEFNTVBTX1JlYXhGRl9BcnlhbnBvdXJWYW5EdWluS3ViaWNraV8yMDEwX0ZlSE9fX1NNXzIyMjk2NDIxNjAwMV8wMDGUjEVTaW1fTEFNTVBTX1RlcnNvZmZaQkxfQnlnZ21hc3RhckdyYW5iZXJnXzIwMjBfRmVfX1NNXzk1ODg2Mzg5NTIzNF8wMDCUjE1TaW1fTEFNTVBTX1RlcnNvZmZaQkxfSGVucmlrc3NvbkJqb3JrYXNOb3JkbHVuZF8yMDEzX0ZlQ19fU01fNDczNDYzNDk4MjY5XzAwMJRldS4="
@@ -528,14 +274,14 @@
                             {
                                 "type": "data",
                                 "label": "engine",
-                                "GID": 71,
+                                "GID": 67,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVjgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjB9weWlyb25fYXRvbWlzdGljcy5sYW1tcHMubGFtbXBzlIwGTGFtbXBzlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu",
                                 "otype_namespace": "atomistics",
                                 "otype_name": "lammps_output_job"
                             }
                         ],
-                        "GID": 67,
+                        "GID": 63,
                         "pos x": 450.62668116522633,
                         "pos y": 519.5054945054945
                     },
@@ -548,7 +294,7 @@
                             {
                                 "type": "data",
                                 "label": "element",
-                                "GID": 74,
+                                "GID": 69,
                                 "val": "gASVBgAAAAAAAACMAkZllC4=",
                                 "dtype": "DType.String",
                                 "dtype state": "gASViwAAAAAAAAB9lCiMB2RlZmF1bHSUjAJGZZSMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA3N0cpSTlIwFbnVtcHmUjARzdHJflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -556,7 +302,7 @@
                             {
                                 "type": "data",
                                 "label": "surface_type",
-                                "GID": 75,
+                                "GID": 70,
                                 "val": "gASVCgAAAAAAAACMBmJjYzEwMJQu",
                                 "dtype": "DType.Choice",
                                 "dtype state": "gASV0QAAAAAAAAB9lCiMB2RlZmF1bHSUjAZiY2MxMDCUjAN2YWyUaAKMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiYwFaXRlbXOUXZQoaAKMBmJjYzExMJSMBmJjYzExMZSMCmRpYW1vbmQxMDCUjApkaWFtb25kMTExlIwGZmNjMTAwlIwGZmNjMTEwlIwGZmNjMTExlIwGZmNjMjExlIwHaGNwMDAwMZSMCGhjcDEwbTEwlGV1Lg=="
@@ -564,7 +310,7 @@
                             {
                                 "type": "data",
                                 "label": "size_a",
-                                "GID": 76,
+                                "GID": 71,
                                 "val": "gARLAS4=",
                                 "dtype": "DType.Integer",
                                 "dtype state": "gASViwAAAAAAAAB9lCiMB2RlZmF1bHSUSwGMA3ZhbJRLAYwDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA2ludJSTlIwFbnVtcHmUjAdpbnRlZ2VylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -572,7 +318,7 @@
                             {
                                 "type": "data",
                                 "label": "size_b",
-                                "GID": 77,
+                                "GID": 72,
                                 "val": "gARLAS4=",
                                 "dtype": "DType.Integer",
                                 "dtype state": "gASViwAAAAAAAAB9lCiMB2RlZmF1bHSUSwGMA3ZhbJRLAYwDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA2ludJSTlIwFbnVtcHmUjAdpbnRlZ2VylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -580,7 +326,7 @@
                             {
                                 "type": "data",
                                 "label": "size_c",
-                                "GID": 78,
+                                "GID": 73,
                                 "val": "gARLAS4=",
                                 "dtype": "DType.Integer",
                                 "dtype state": "gASViwAAAAAAAAB9lCiMB2RlZmF1bHSUSwGMA3ZhbJRLAYwDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA2ludJSTlIwFbnVtcHmUjAdpbnRlZ2VylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -588,7 +334,7 @@
                             {
                                 "type": "data",
                                 "label": "vacuum",
-                                "GID": 79,
+                                "GID": 74,
                                 "val": "gASVCgAAAAAAAABHQCQAAAAAAAAu",
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSUR0AkAAAAAAAAjAN2YWyUR0AkAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
@@ -596,7 +342,7 @@
                             {
                                 "type": "data",
                                 "label": "center",
-                                "GID": 80,
+                                "GID": 75,
                                 "val": "gASJLg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -604,7 +350,7 @@
                             {
                                 "type": "data",
                                 "label": "orthogonal",
-                                "GID": 81,
+                                "GID": 76,
                                 "val": "gASILg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiIwDdmFslIiMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -612,7 +358,7 @@
                             {
                                 "type": "data",
                                 "label": "a",
-                                "GID": 82,
+                                "GID": 77,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVmQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZSMCGRlY2ltYWxzlEsKdS4="
@@ -622,16 +368,16 @@
                             {
                                 "type": "data",
                                 "label": "structure",
-                                "GID": 83,
+                                "GID": 78,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVmgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCxweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLnN0cnVjdHVyZS5hdG9tc5SMBUF0b21zlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu",
                                 "otype_namespace": "atomistics",
                                 "otype_name": "surface_structure_output_structure"
                             }
                         ],
-                        "GID": 73,
-                        "pos x": 114.38218966405312,
-                        "pos y": 482.14285714285717
+                        "GID": 68,
+                        "pos x": 106.49006622516555,
+                        "pos y": 497.8955223880597
                     },
                     {
                         "identifier": "Project_Node",
@@ -642,105 +388,397 @@
                             {
                                 "type": "data",
                                 "label": "name",
-                                "GID": 86,
+                                "GID": 94,
                                 "val": "gASVCwAAAAAAAACMB3N1cmZhY2WULg==",
                                 "dtype": "DType.String",
                                 "dtype state": "gASVigAAAAAAAAB9lCiMB2RlZmF1bHSUjAEulIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwDc3RylJOUjAVudW1weZSMBHN0cl+Uk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
+                            },
+                            {
+                                "type": "exec",
+                                "label": "remove",
+                                "GID": 95,
+                                "val": "gAROLg==",
+                                "dtype": "DType.Untyped",
+                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "enable_remove",
+                                "GID": 96,
+                                "val": "gASJLg==",
+                                "dtype": "DType.Boolean",
+                                "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "remove_name",
+                                "GID": 97,
+                                "val": "gASVBAAAAAAAAACMAJQu",
+                                "dtype": "DType.String",
+                                "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUjACUjAN2YWyUaAKMA2RvY5RoAowGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA3N0cpSTlIwFbnVtcHmUjARzdHJflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "remove_all",
+                                "GID": 98,
+                                "val": "gASJLg==",
+                                "dtype": "DType.Boolean",
+                                "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "recursive",
+                                "GID": 99,
+                                "val": "gASILg==",
+                                "dtype": "DType.Boolean",
+                                "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiIwDdmFslIiMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
                             }
                         ],
                         "outputs": [
                             {
                                 "type": "data",
                                 "label": "project",
-                                "GID": 87,
+                                "GID": 100,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjBlweWlyb25fYXRvbWlzdGljcy5wcm9qZWN0lIwHUHJvamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg==",
                                 "otype_namespace": "atomistics",
                                 "otype_name": "project_output_atomistics_project"
                             }
                         ],
-                        "GID": 85,
-                        "pos x": 120.97521890917416,
-                        "pos y": 22.802197802197803
+                        "GID": 93,
+                        "pos x": 20.066225165562912,
+                        "pos y": 0.5820895522388128
+                    },
+                    {
+                        "identifier": "CalcMinimize_Node",
+                        "version": null,
+                        "state data": "gAR9lC4=",
+                        "additional data": {},
+                        "inputs": [
+                            {
+                                "type": "exec",
+                                "label": "run",
+                                "GID": 102,
+                                "val": "gAROLg==",
+                                "dtype": "DType.Untyped",
+                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
+                            },
+                            {
+                                "type": "exec",
+                                "label": "reset",
+                                "GID": 103,
+                                "val": "gAROLg==",
+                                "dtype": "DType.Untyped",
+                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "name",
+                                "GID": 104,
+                                "val": "gASVCAAAAAAAAACMBGJ1bGuULg==",
+                                "dtype": "DType.String",
+                                "dtype state": "gASVjQAAAAAAAAB9lCiMB2RlZmF1bHSUjARjYWxjlIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwDc3RylJOUjAVudW1weZSMBHN0cl+Uk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
+                            },
+                            {
+                                "type": "data",
+                                "label": "job",
+                                "GID": 105,
+                                "dtype": "DType.Data",
+                                "dtype state": "gASVjgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjB9weWlyb25fYXRvbWlzdGljcy5sYW1tcHMubGFtbXBzlIwGTGFtbXBzlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu",
+                                "otype_namespace": "atomistics",
+                                "otype_name": "atomistic_taker_job"
+                            },
+                            {
+                                "type": "data",
+                                "label": "ionic_energy_tolerance",
+                                "GID": 106,
+                                "val": "gASVCgAAAAAAAABHAAAAAAAAAAAu",
+                                "dtype": "DType.Float",
+                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURwAAAAAAAAAAjAN2YWyURwAAAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "ionic_force_tolerance",
+                                "GID": 107,
+                                "val": "gASVCgAAAAAAAABHPxo24uscQy0u",
+                                "dtype": "DType.Float",
+                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURz8aNuLrHEMtjAN2YWyURz8aNuLrHEMtjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "max_iter",
+                                "GID": 108,
+                                "val": "gASVBgAAAAAAAABKoIYBAC4=",
+                                "dtype": "DType.Integer",
+                                "dtype state": "gASVkQAAAAAAAAB9lCiMB2RlZmF1bHSUSqCGAQCMA3ZhbJRKoIYBAIwDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA2ludJSTlIwFbnVtcHmUjAdpbnRlZ2VylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "pressure",
+                                "GID": 109,
+                                "val": "gAROLg==",
+                                "dtype": "DType.Data",
+                                "dtype state": "gASVlgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlGgIjARsaXN0lJOUjAVudW1weZSMB25kYXJyYXmUk5RljAphbGxvd19ub25llIiMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
+                            },
+                            {
+                                "type": "data",
+                                "label": "n_print",
+                                "GID": 110,
+                                "val": "gARLZC4=",
+                                "dtype": "DType.Integer",
+                                "dtype state": "gASViwAAAAAAAAB9lCiMB2RlZmF1bHSUS2SMA3ZhbJRLZIwDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA2ludJSTlIwFbnVtcHmUjAdpbnRlZ2VylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "style",
+                                "GID": 111,
+                                "val": "gASVBgAAAAAAAACMAmNnlC4=",
+                                "dtype": "DType.Choice",
+                                "dtype state": "gASVZwAAAAAAAAB9lCiMB2RlZmF1bHSUjAJjZ5SMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZSMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjAVpdGVtc5RdlGgCYXUu"
+                            }
+                        ],
+                        "outputs": [
+                            {
+                                "type": "exec",
+                                "label": "ran",
+                                "GID": 112,
+                                "dtype": "DType.Untyped",
+                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "job",
+                                "GID": 113,
+                                "dtype": "DType.Data",
+                                "dtype state": "gASVjgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjB9weWlyb25fYXRvbWlzdGljcy5sYW1tcHMubGFtbXBzlIwGTGFtbXBzlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "energy_pot",
+                                "GID": 114,
+                                "dtype": "DType.Float",
+                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURwAAAAAAAAAAjAN2YWyURwAAAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu",
+                                "otype_namespace": "atomistics",
+                                "otype_name": "atomistic_taker_output_energy_pot"
+                            },
+                            {
+                                "type": "data",
+                                "label": "forces",
+                                "GID": 115,
+                                "dtype": "DType.List",
+                                "dtype state": "gASVgQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJdS4=",
+                                "otype_namespace": "atomistics",
+                                "otype_name": "atomistic_taker_output_forces"
+                            }
+                        ],
+                        "GID": 101,
+                        "pos x": 748.4273847035233,
+                        "pos y": 9.615384615384615
+                    },
+                    {
+                        "identifier": "CalcMinimize_Node",
+                        "version": null,
+                        "state data": "gAR9lC4=",
+                        "additional data": {},
+                        "inputs": [
+                            {
+                                "type": "exec",
+                                "label": "run",
+                                "GID": 117,
+                                "val": "gAROLg==",
+                                "dtype": "DType.Untyped",
+                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
+                            },
+                            {
+                                "type": "exec",
+                                "label": "reset",
+                                "GID": 118,
+                                "val": "gAROLg==",
+                                "dtype": "DType.Untyped",
+                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "name",
+                                "GID": 119,
+                                "val": "gASVCAAAAAAAAACMBHN1cmaULg==",
+                                "dtype": "DType.String",
+                                "dtype state": "gASVjQAAAAAAAAB9lCiMB2RlZmF1bHSUjARjYWxjlIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwDc3RylJOUjAVudW1weZSMBHN0cl+Uk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
+                            },
+                            {
+                                "type": "data",
+                                "label": "job",
+                                "GID": 120,
+                                "dtype": "DType.Data",
+                                "dtype state": "gASVjgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjB9weWlyb25fYXRvbWlzdGljcy5sYW1tcHMubGFtbXBzlIwGTGFtbXBzlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu",
+                                "otype_namespace": "atomistics",
+                                "otype_name": "atomistic_taker_job"
+                            },
+                            {
+                                "type": "data",
+                                "label": "ionic_energy_tolerance",
+                                "GID": 121,
+                                "val": "gASVCgAAAAAAAABHAAAAAAAAAAAu",
+                                "dtype": "DType.Float",
+                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURwAAAAAAAAAAjAN2YWyURwAAAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "ionic_force_tolerance",
+                                "GID": 122,
+                                "val": "gASVCgAAAAAAAABHPxo24uscQy0u",
+                                "dtype": "DType.Float",
+                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURz8aNuLrHEMtjAN2YWyURz8aNuLrHEMtjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "max_iter",
+                                "GID": 123,
+                                "val": "gASVBgAAAAAAAABKoIYBAC4=",
+                                "dtype": "DType.Integer",
+                                "dtype state": "gASVkQAAAAAAAAB9lCiMB2RlZmF1bHSUSqCGAQCMA3ZhbJRKoIYBAIwDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA2ludJSTlIwFbnVtcHmUjAdpbnRlZ2VylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "pressure",
+                                "GID": 124,
+                                "val": "gAROLg==",
+                                "dtype": "DType.Data",
+                                "dtype state": "gASVlgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlGgIjARsaXN0lJOUjAVudW1weZSMB25kYXJyYXmUk5RljAphbGxvd19ub25llIiMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
+                            },
+                            {
+                                "type": "data",
+                                "label": "n_print",
+                                "GID": 125,
+                                "val": "gARLZC4=",
+                                "dtype": "DType.Integer",
+                                "dtype state": "gASViwAAAAAAAAB9lCiMB2RlZmF1bHSUS2SMA3ZhbJRLZIwDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA2ludJSTlIwFbnVtcHmUjAdpbnRlZ2VylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "style",
+                                "GID": 126,
+                                "val": "gASVBgAAAAAAAACMAmNnlC4=",
+                                "dtype": "DType.Choice",
+                                "dtype state": "gASVZwAAAAAAAAB9lCiMB2RlZmF1bHSUjAJjZ5SMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZSMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjAVpdGVtc5RdlGgCYXUu"
+                            }
+                        ],
+                        "outputs": [
+                            {
+                                "type": "exec",
+                                "label": "ran",
+                                "GID": 127,
+                                "dtype": "DType.Untyped",
+                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "job",
+                                "GID": 128,
+                                "dtype": "DType.Data",
+                                "dtype state": "gASVjgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjB9weWlyb25fYXRvbWlzdGljcy5sYW1tcHMubGFtbXBzlIwGTGFtbXBzlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "energy_pot",
+                                "GID": 129,
+                                "dtype": "DType.Float",
+                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURwAAAAAAAAAAjAN2YWyURwAAAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu",
+                                "otype_namespace": "atomistics",
+                                "otype_name": "atomistic_taker_output_energy_pot"
+                            },
+                            {
+                                "type": "data",
+                                "label": "forces",
+                                "GID": 130,
+                                "dtype": "DType.List",
+                                "dtype state": "gASVgQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJdS4=",
+                                "otype_namespace": "atomistics",
+                                "otype_name": "atomistic_taker_output_forces"
+                            }
+                        ],
+                        "GID": 116,
+                        "pos x": 755.0272128329991,
+                        "pos y": 389.83516483516485
                     }
                 ],
                 "connections": [
                     {
-                        "GID": 90,
+                        "GID": 82,
                         "parent node index": 1,
                         "output port index": 0,
                         "connected node": 0,
                         "connected input port index": 1
                     },
                     {
-                        "GID": 33,
+                        "GID": 133,
                         "parent node index": 2,
-                        "output port index": 2,
-                        "connected node": 1,
+                        "output port index": 0,
+                        "connected node": 7,
+                        "connected input port index": 3
+                    },
+                    {
+                        "GID": 86,
+                        "parent node index": 3,
+                        "output port index": 0,
+                        "connected node": 2,
                         "connected input port index": 1
                     },
                     {
-                        "GID": 49,
+                        "GID": 87,
                         "parent node index": 3,
-                        "output port index": 2,
+                        "output port index": 0,
                         "connected node": 1,
-                        "connected input port index": 3
+                        "connected input port index": 0
                     },
                     {
-                        "GID": 55,
+                        "GID": 135,
                         "parent node index": 4,
                         "output port index": 0,
-                        "connected node": 2,
+                        "connected node": 8,
                         "connected input port index": 3
                     },
                     {
-                        "GID": 66,
+                        "GID": 89,
                         "parent node index": 5,
                         "output port index": 0,
                         "connected node": 4,
                         "connected input port index": 1
                     },
                     {
-                        "GID": 91,
+                        "GID": 90,
                         "parent node index": 5,
-                        "output port index": 0,
-                        "connected node": 1,
-                        "connected input port index": 0
-                    },
-                    {
-                        "GID": 72,
-                        "parent node index": 6,
-                        "output port index": 0,
-                        "connected node": 3,
-                        "connected input port index": 3
-                    },
-                    {
-                        "GID": 84,
-                        "parent node index": 7,
-                        "output port index": 0,
-                        "connected node": 6,
-                        "connected input port index": 1
-                    },
-                    {
-                        "GID": 92,
-                        "parent node index": 7,
                         "output port index": 0,
                         "connected node": 1,
                         "connected input port index": 2
                     },
                     {
-                        "GID": 88,
-                        "parent node index": 8,
+                        "GID": 134,
+                        "parent node index": 6,
+                        "output port index": 0,
+                        "connected node": 2,
+                        "connected input port index": 0
+                    },
+                    {
+                        "GID": 136,
+                        "parent node index": 6,
                         "output port index": 0,
                         "connected node": 4,
                         "connected input port index": 0
                     },
                     {
-                        "GID": 89,
+                        "GID": 132,
+                        "parent node index": 7,
+                        "output port index": 2,
+                        "connected node": 1,
+                        "connected input port index": 1
+                    },
+                    {
+                        "GID": 131,
                         "parent node index": 8,
-                        "output port index": 0,
-                        "connected node": 6,
-                        "connected input port index": 0
+                        "output port index": 2,
+                        "connected node": 1,
+                        "connected input port index": 3
                     }
                 ],
                 "GID": 7


### PR DESCRIPTION
This aim's to address one of Joerg's concerns in #189:

> the job output etc. exists only when running the job from scratch. Reloading appears to be not working. Also deleting does not remove the jobs. I had to do this manually by creating a project object in the jupyter notebook.

This issue runs headfirst into the tension between ironflow's objective of being functional and the fact that pyiron jobs are really, really not functional. Specifically, the problem here lies in comparing the name+input of an ironflow node to serialized input of an existing pyiron job of the same name. This might be straightforward if we could [hash](https://github.com/pyiron/pyiron_base/pull/903) the [input data](https://github.com/pyiron/pyiron_base/issues/1051) as proposed by Sam, but right now we still can't.

So the current setup was intended to rigidly ensure that from _within ironflow_ the user could not not tamper with any pyiron jobs that they had not themselves created. For example, deleting jobs (with the job node's `remove` button) would only work if it was deleting a job that node had already created that session. Imagine this restriction were not in place and that we had two calc nodes using the same job node; we could run the first, then go over to the second and remove the first's job, silently corrupting its data!

In the long run I think there are good solutions to this, ranging from a more rigorous interface that exploits IO hash comparisons right over to a better alignment of the underlying pyiron model with ironflow in terms of how data storage is treated (i.e. some of the directions we're currently heading with "pyiron 1.0").

Right now though, the criticism is well taken that job management is a huge pain. As a sort of compromise, here I extend the `Project` node to give an interface for job deletion. This is "restricted" behind an `enable_remove` boolean input, so users can't just accidentally or hastily hit the `remove` button and start killing things -- IMO this is analogous to the previous restriction that the user had to type something like `gui.selected_node.outputs.values.project.remove_jobs()`, but now it's a little more convenient and exists inside the gui framework.

The node now looks like this:
<img width="348" alt="Screen Shot 2023-04-14 at 14 14 25" src="https://user-images.githubusercontent.com/20283329/232158560-8e3daca2-a378-4268-ad46-0e550739ed32.png">

And if you open the control panel these are the defaults:
<img width="387" alt="Screen Shot 2023-04-14 at 14 14 32" src="https://user-images.githubusercontent.com/20283329/232158578-a6c6b013-a9f3-49e6-9a6b-e1b9ed5dc9e2.png">

