### PR TITLE
Handle the edge case where you slice 0

### DIFF
--- a/ironflow/gui/draws_widgets.py
+++ b/ironflow/gui/draws_widgets.py
@@ -42,7 +42,10 @@ def draws_widgets(fnc: Callable) -> Callable:
         n_widgets_i = len(widgets.Widget.widgets)
         result = fnc(self, *args, **kwargs)
         n_widgets_drawn = len(widgets.Widget.widgets) - n_widgets_i
-        self._drawn_widgets += list(widgets.Widget.widgets.values())[-n_widgets_drawn:]
+        if n_widgets_drawn > 0:
+            self._drawn_widgets += list(
+                widgets.Widget.widgets.values()
+            )[-n_widgets_drawn:]
         return result
 
     return wrapper

--- a/ironflow/gui/draws_widgets.py
+++ b/ironflow/gui/draws_widgets.py
@@ -43,9 +43,9 @@ def draws_widgets(fnc: Callable) -> Callable:
         result = fnc(self, *args, **kwargs)
         n_widgets_drawn = len(widgets.Widget.widgets) - n_widgets_i
         if n_widgets_drawn > 0:
-            self._drawn_widgets += list(
-                widgets.Widget.widgets.values()
-            )[-n_widgets_drawn:]
+            self._drawn_widgets += list(widgets.Widget.widgets.values())[
+                -n_widgets_drawn:
+            ]
         return result
 
     return wrapper


### PR DESCRIPTION
[-0:] is the same as [0:], and radically different for how, e.g. [-1:] vs [1:] works. Derp.

Solves the issue of the entire display getting closed down when you (sometimes) turn off the node representation widget.

Closes the last part of #189 