### PR TITLE
Add grain boundaries and better input

### DIFF
--- a/ironflow/nodes/pyiron/atomistics_nodes.py
+++ b/ironflow/nodes/pyiron/atomistics_nodes.py
@@ -418,6 +418,7 @@ class GBStructure_Node(OutputsOnlyAtoms):
     Outputs:
         structure (pyiron_atomistics.Atoms): A GB based of the `initial_struct`.
     """
+
     title = "GBStructure"
     init_inputs = [
         NodeInputBP(
@@ -439,23 +440,23 @@ class GBStructure_Node(OutputsOnlyAtoms):
         ),
         NodeInputBP(label="to_primitive", dtype=dtypes.Boolean(default=False)),
         NodeInputBP(label="delete_layer", dtype=dtypes.String(default="0b0t0b0t")),
-        NodeInputBP(label="add_if_dist", dtype=dtypes.Float(default=0.)),
+        NodeInputBP(label="add_if_dist", dtype=dtypes.Float(default=0.0)),
         NodeInputBP(label="uc_a", dtype=dtypes.Integer(default=1)),
         NodeInputBP(label="uc_b", dtype=dtypes.Integer(default=1)),
     ]
 
     def node_function(
-            self,
-            initial_struct,
-            axis,
-            sigma,
-            plane,
-            to_primitive,
-            delete_layer,
-            add_if_dist,
-            uc_a,
-            uc_b,
-            **kwargs,
+        self,
+        initial_struct,
+        axis,
+        sigma,
+        plane,
+        to_primitive,
+        delete_layer,
+        add_if_dist,
+        uc_a,
+        uc_b,
+        **kwargs,
     ) -> dict:
         return {
             "structure": STRUCTURE_FACTORY.aimsgb.build(
@@ -574,7 +575,7 @@ def pressure_input():
                 np.ndarray,
                 np.floating,
                 np.integer,
-            ]
+            ],
         ),
         label="pressure",
     )
@@ -1523,9 +1524,7 @@ class Input_Node(DataNode):
 
     title = "Input"
 
-    init_inputs = [
-        NodeInputBP(label="input", dtype=dtypes.String())
-    ]
+    init_inputs = [NodeInputBP(label="input", dtype=dtypes.String())]
 
     init_outputs = [
         NodeOutputBP(label="as_str", dtype=dtypes.String()),
@@ -1556,9 +1555,7 @@ class InputArray_Node(DataNode):
 
     title = "InputArray"
 
-    init_inputs = [
-        NodeInputBP(label="input", dtype=dtypes.String())
-    ]
+    init_inputs = [NodeInputBP(label="input", dtype=dtypes.String())]
 
     init_outputs = [
         NodeOutputBP(label="as_str", dtype=dtypes.List(valid_classes=str)),

--- a/ironflow/nodes/pyiron/atomistics_nodes.py
+++ b/ironflow/nodes/pyiron/atomistics_nodes.py
@@ -1508,6 +1508,73 @@ class MaterialProperty_Node(DataNode):
         return {"value": source}  # * conversion if source is not None else None}
 
 
+class Input_Node(DataNode):
+    """
+    Give data as a string and cast it to a specific type.
+    """
+
+    title = "Input"
+
+    init_inputs = [
+        NodeInputBP(label="input", dtype=dtypes.String())
+    ]
+
+    init_outputs = [
+        NodeOutputBP(label="as_str", dtype=dtypes.String()),
+        NodeOutputBP(label="as_int", dtype=dtypes.Integer()),
+        NodeOutputBP(label="as_float", dtype=dtypes.Float()),
+    ]
+
+    def node_function(self, input, **kwargs) -> dict:
+        try:
+            as_int = int(input)
+        except ValueError:
+            as_int = None
+        try:
+            as_float = float(input)
+        except ValueError:
+            as_float = None
+        return {
+            "as_str": str(input),
+            "as_int": as_int,
+            "as_float": as_float,
+        }
+
+
+class InputArray_Node(DataNode):
+    """
+    Give data as a comma-separated string and cast it to a specific type of array.
+    """
+
+    title = "InputArray"
+
+    init_inputs = [
+        NodeInputBP(label="input", dtype=dtypes.String())
+    ]
+
+    init_outputs = [
+        NodeOutputBP(label="as_str", dtype=dtypes.List(valid_classes=str)),
+        NodeOutputBP(label="as_int", dtype=dtypes.List(valid_classes=np.integer)),
+        NodeOutputBP(label="as_float", dtype=dtypes.List(valid_classes=np.floating)),
+    ]
+
+    def node_function(self, input, **kwargs) -> dict:
+        as_str = np.array(input.split(","))
+        try:
+            as_int = as_str.astype(int)
+        except ValueError:
+            as_int = None
+        try:
+            as_float = as_str.astype(float)
+        except ValueError:
+            as_float = None
+        return {
+            "as_str": as_str,
+            "as_int": as_int,
+            "as_float": as_float,
+        }
+
+
 nodes = [
     Project_Node,
     BulkStructure_Node,

--- a/ironflow/nodes/pyiron/atomistics_nodes.py
+++ b/ironflow/nodes/pyiron/atomistics_nodes.py
@@ -392,6 +392,86 @@ class SlabStructure_Node(OutputsOnlyAtoms):
         }
 
 
+class GBStructure_Node(OutputsOnlyAtoms):
+    """
+    Generate a grain boundary structure based on the aimsgb.GrainBoundary module.
+
+    Inputs:
+        axis : Rotational axis for the GB you want to construct (for example, axis=[1,0,0])
+        sigma (int) : The sigma value of the GB you want to construct (for example, sigma=5)
+        plane: The grain boundary plane of the GB you want to construct (for example, plane=[2,1,0])
+        initial_struct : Initial bulk structure from which you want to construct the GB (a pyiron
+                        structure object).
+        delete_layer : To delete layers of the GB. For example, delete_layer='1b0t1b0t'. The first
+                       4 characters is for first grain and the other 4 is for second grain. b means
+                       bottom layer and t means top layer. Integer represents the number of layers
+                       to be deleted. The first t and second b from the left hand side represents
+                       the layers at the GB interface. Default value is delete_layer='0b0t0b0t', which
+                       means no deletion of layers.
+        add_if_dist : If you want to add extra interface distance, you can specify add_if_dist.
+                       Default value is add_if_dist=0.0
+        to_primitive : To generate primitive or non-primitive GB structure. Default value is
+                        to_primitive=False
+        uc_a (int): Number of unit cell of grain A. Default to 1.
+        uc_b (int): Number of unit cell of grain B. Default to 1.
+
+    Outputs:
+        structure (pyiron_atomistics.Atoms): A GB based of the `initial_struct`.
+    """
+    title = "GBStructure"
+    init_inputs = [
+        NodeInputBP(
+            label="initial_struct",
+            dtype=dtypes.Data(valid_classes=Atoms),
+            # otype=ONTO.gb_structure_input_structure
+        ),
+        NodeInputBP(
+            label="axis",
+            dtype=dtypes.List(valid_classes=[int, np.integer], default=[0, 0, 1]),
+        ),
+        NodeInputBP(
+            label="sigma",
+            dtype=dtypes.Integer(default=5),
+        ),
+        NodeInputBP(
+            label="plane",
+            dtype=dtypes.List(valid_classes=[int, np.integer], default=[1, 2, 0]),
+        ),
+        NodeInputBP(label="to_primitive", dtype=dtypes.Boolean(default=False)),
+        NodeInputBP(label="delete_layer", dtype=dtypes.String(default="0b0t0b0t")),
+        NodeInputBP(label="add_if_dist", dtype=dtypes.Float(default=0.)),
+        NodeInputBP(label="uc_a", dtype=dtypes.Integer(default=1)),
+        NodeInputBP(label="uc_b", dtype=dtypes.Integer(default=1)),
+    ]
+
+    def node_function(
+            self,
+            initial_struct,
+            axis,
+            sigma,
+            plane,
+            to_primitive,
+            delete_layer,
+            add_if_dist,
+            uc_a,
+            uc_b,
+            **kwargs,
+    ) -> dict:
+        return {
+            "structure": STRUCTURE_FACTORY.aimsgb.build(
+                axis,
+                sigma,
+                plane,
+                initial_struct,
+                to_primitive=to_primitive,
+                delete_layer=delete_layer,
+                add_if_dist=add_if_dist,
+                uc_a=uc_a,
+                uc_b=uc_b,
+            )
+        }
+
+
 class Repeat_Node(OutputsOnlyAtoms):
     """
     Repeat atomic structure supercell.

--- a/ironflow/nodes/pyiron/atomistics_nodes.py
+++ b/ironflow/nodes/pyiron/atomistics_nodes.py
@@ -566,7 +566,15 @@ class CalcStatic_Node(AtomisticTaker):
 def pressure_input():
     return NodeInputBP(
         dtype=dtypes.Data(
-            default=None, allow_none=True, valid_classes=[float, list, np.ndarray]
+            default=None,
+            allow_none=True,
+            valid_classes=[
+                float,
+                list,
+                np.ndarray,
+                np.floating,
+                np.integer,
+            ]
         ),
         label="pressure",
     )

--- a/notebooks/example.json
+++ b/notebooks/example.json
@@ -15,7 +15,7 @@
                             {
                                 "type": "data",
                                 "label": "element",
-                                "GID": 12,
+                                "GID": 9,
                                 "val": "gASVBgAAAAAAAACMAkZllC4=",
                                 "dtype": "DType.String",
                                 "dtype state": "gASViwAAAAAAAAB9lCiMB2RlZmF1bHSUjAJGZZSMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA3N0cpSTlIwFbnVtcHmUjARzdHJflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu",
@@ -25,7 +25,7 @@
                             {
                                 "type": "data",
                                 "label": "crystal_structure",
-                                "GID": 13,
+                                "GID": 10,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Choice",
                                 "dtype state": "gASVwgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiYwFaXRlbXOUXZQoTowCc2OUjANmY2OUjANiY2OUjANoY3CUjAdkaWFtb25klIwKemluY2JsZW5kZZSMCHJvY2tzYWx0lIwOY2VzaXVtY2hsb3JpZGWUjAhmbHVvcml0ZZSMCHd1cnR6aXRllGV1Lg=="
@@ -33,7 +33,7 @@
                             {
                                 "type": "data",
                                 "label": "a",
-                                "GID": 14,
+                                "GID": 11,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVmQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZSMCGRlY2ltYWxzlEsKdS4="
@@ -41,7 +41,7 @@
                             {
                                 "type": "data",
                                 "label": "c",
-                                "GID": 15,
+                                "GID": 12,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVmQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZSMCGRlY2ltYWxzlEsKdS4="
@@ -49,7 +49,7 @@
                             {
                                 "type": "data",
                                 "label": "c_over_a",
-                                "GID": 16,
+                                "GID": 13,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVmQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZSMCGRlY2ltYWxzlEsKdS4="
@@ -57,7 +57,7 @@
                             {
                                 "type": "data",
                                 "label": "u",
-                                "GID": 17,
+                                "GID": 14,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVmQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZSMCGRlY2ltYWxzlEsKdS4="
@@ -65,7 +65,7 @@
                             {
                                 "type": "data",
                                 "label": "orthorhombic",
-                                "GID": 18,
+                                "GID": 15,
                                 "val": "gASJLg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -73,7 +73,7 @@
                             {
                                 "type": "data",
                                 "label": "cubic",
-                                "GID": 19,
+                                "GID": 16,
                                 "val": "gASJLg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -83,14 +83,14 @@
                             {
                                 "type": "data",
                                 "label": "structure",
-                                "GID": 20,
+                                "GID": 17,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVmgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCxweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLnN0cnVjdHVyZS5hdG9tc5SMBUF0b21zlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu",
                                 "otype_namespace": "atomistics",
                                 "otype_name": "bulk_structure_output_structure"
                             }
                         ],
-                        "GID": 11,
+                        "GID": 8,
                         "pos x": 68.64508736751647,
                         "pos y": 345.05494505494505
                     },
@@ -103,14 +103,14 @@
                             {
                                 "type": "data",
                                 "label": "structure",
-                                "GID": 22,
+                                "GID": 19,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVmgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCxweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLnN0cnVjdHVyZS5hdG9tc5SMBUF0b21zlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
                             },
                             {
                                 "type": "data",
                                 "label": "all",
-                                "GID": 23,
+                                "GID": 20,
                                 "val": "gARLAy4=",
                                 "dtype": "DType.Integer",
                                 "dtype state": "gASViwAAAAAAAAB9lCiMB2RlZmF1bHSUSwGMA3ZhbJRLAYwDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA2ludJSTlIwFbnVtcHmUjAdpbnRlZ2VylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -120,12 +120,12 @@
                             {
                                 "type": "data",
                                 "label": "structure",
-                                "GID": 24,
+                                "GID": 21,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVmgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCxweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLnN0cnVjdHVyZS5hdG9tc5SMBUF0b21zlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
                             }
                         ],
-                        "GID": 21,
+                        "GID": 18,
                         "pos x": 322.6353480378115,
                         "pos y": 339.4065934065934
                     },
@@ -138,7 +138,7 @@
                             {
                                 "type": "data",
                                 "label": "project",
-                                "GID": 26,
+                                "GID": 23,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjBlweWlyb25fYXRvbWlzdGljcy5wcm9qZWN0lIwHUHJvamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg==",
                                 "otype_namespace": "atomistics",
@@ -147,7 +147,7 @@
                             {
                                 "type": "data",
                                 "label": "structure",
-                                "GID": 27,
+                                "GID": 24,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVmgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCxweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLnN0cnVjdHVyZS5hdG9tc5SMBUF0b21zlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu",
                                 "otype_namespace": "atomistics",
@@ -156,7 +156,7 @@
                             {
                                 "type": "data",
                                 "label": "potential",
-                                "GID": 28,
+                                "GID": 25,
                                 "val": "gASVJwAAAAAAAACMIzE5OTctLUFja2xhbmQtRy1KLS1GZS0tTEFNTVBTLS1pcHIxlC4=",
                                 "dtype": "DType.Choice",
                                 "dtype state": "gASVLxkAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAhidWlsdGluc5SMA3N0cpSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjAVpdGVtc5RdlCiMIzE5OTctLUFja2xhbmQtRy1KLS1GZS0tTEFNTVBTLS1pcHIxlIwfMTk5OC0tTWV5ZXItUi0tRmUtLUxBTU1QUy0taXByMZSMHzIwMDEtLUxlZS1CLUotLUZlLS1MQU1NUFMtLWlwcjGUjCIyMDAxLS1MZWUtQi1KLS1GZS1Dci0tTEFNTVBTLS1pcHIxlIwmMjAwMy0tTWVuZGVsZXYtTS1JLS1GZS0yLS1MQU1NUFMtLWlwcjOUjCYyMDAzLS1NZW5kZWxldi1NLUktLUZlLTUtLUxBTU1QUy0taXByMZSMJTIwMDQtLUFja2xhbmQtRy1KLS1GZS1QLS1MQU1NUFMtLWlwcjGUjCAyMDA0LS1aaG91LVgtVy0tRmUtLUxBTU1QUy0taXByMpSMIjIwMDUtLUxlZS1CLUotLUZlLUN1LS1MQU1NUFMtLWlwcjGUjCcyMDA1LS1NZW5kZWxldi1NLUktLUFsLUZlLS1MQU1NUFMtLWlwcjGUjCEyMDA2LS1DaGFtYXRpLUgtLUZlLS1MQU1NUFMtLWlwcjGUjCAyMDA2LS1LaW0tSi0tRmUtUHQtLUxBTU1QUy0taXByMZSMITIwMDYtLUxlZS1CLUotLUZlLUMtLUxBTU1QUy0taXByMZSMITIwMDYtLUxlZS1CLUotLUZlLU4tLUxBTU1QUy0taXByMZSMITIwMDctLUxlZS1CLUotLUZlLUgtLUxBTU1QUy0taXByMZSMJjIwMDctLU1lbmRlbGV2LU0tSS0tVi1GZS0tTEFNTVBTLS1pcHIxlIwlMjAwOC0tSGVwYnVybi1ELUotLUZlLUMtLUxBTU1QUy0taXByMZSMHzIwMDgtLVNhLUktLUZlLU5iLS1MQU1NUFMtLWlwcjGUjB8yMDA4LS1TYS1JLS1GZS1UaS0tTEFNTVBTLS1pcHIxlIwlMjAwOS0tQm9ubnktRy0tRmUtQ3UtTmktLUxBTU1QUy0taXByMZSMIjIwMDktLUJvbm55LUctLUZlLU5pLS1MQU1NUFMtLWlwcjGUjCQyMDA5LS1LaW0tSC1LLS1GZS1UaS1DLS1MQU1NUFMtLWlwcjKUjCIyMDA5LS1LaW0tWS1NLS1GZS1Nbi0tTEFNTVBTLS1pcHIxlIwkMjAwOS0tT2xzc29uLVAtQS1ULS1GZS0tTEFNTVBTLS1pcHIxlIwmMjAwOS0tU3R1a293c2tpLUEtLUZlLUNyLS1MQU1NUFMtLWlwcjGUjCQyMDEwLS1LaW0tSC1LLS1GZS1OYi1DLS1MQU1NUFMtLWlwcjGUjCAyMDEwLS1MZWUtRS0tRmUtQWwtLUxBTU1QUy0taXByMZSMITIwMTAtLU1hbGVyYmEtTC0tRmUtLUxBTU1QUy0taXByMZSMIjIwMTEtLUJvbm55LUctLUZlLUNyLS1MQU1NUFMtLWlwcjKUjCIyMDExLS1Cb25ueS1HLS1GZS1Dci0tTEFNTVBTLS1pcHIzlIwlMjAxMS0tQm9ubnktRy0tRmUtTmktQ3ItLUxBTU1QUy0taXByMZSMJTIwMTEtLUJvbm55LUctLUZlLU5pLUNyLS1MQU1NUFMtLWlwcjKUjCMyMDExLS1DaGllc2EtUy0tRmUtMzMtLUxBTU1QUy0taXByMZSMLTIwMTItLUplbGluZWstQi0tQWwtU2ktTWctQ3UtRmUtLUxBTU1QUy0taXByMpSMIDIwMTItLUtvLVctUy0tRmUtUC0tTEFNTVBTLS1pcHIxlIwiMjAxMi0tUHJvdmlsbGUtTC0tRmUtLUxBTU1QUy0taXByMZSMJDIwMTMtLUJvbm55LUctLUZlLUNyLVctLUxBTU1QUy0taXByMpSMJDIwMTMtLUJvbm55LUctLUZlLUNyLVctLUxBTU1QUy0taXByM5SMJTIwMTMtLUJvbm55LUctLUZlLU5pLUNyLS1MQU1NUFMtLWlwcjGUjCEyMDEzLS1Cb25ueS1HLS1GZS1XLS1MQU1NUFMtLWlwcjGUjCoyMDEzLS1IZW5yaWtzc29uLUstTy1FLS1GZS1DLS1MQU1NUFMtLWlwcjGUjCgyMDE0LS1MaXlhbmFnZS1MLVMtSS0tRmUtQy0tTEFNTVBTLS1pcHIylIwfMjAxNS0tQXNhZGktRS0tRmUtLUxBTU1QUy0taXByMZSMIzIwMTUtLUVpY2gtUy1NLS1GZS1Dci0tTEFNTVBTLS1pcHIxlIwoMjAxNy0tQmVsYW5kLUwtSy0tRmUtTmktQ3ItLUxBTU1QUy0taXByMZSMIzIwMTctLUNob2ktVy1NLS1Dby1GZS0tTEFNTVBTLS1pcHIxlIwiMjAxNy0tV3UtQy0tTmktQ3ItRmUtLUxBTU1QUy0taXByMZSMHzIwMTctLVd1LUMtLU5pLUZlLS1MQU1NUFMtLWlwcjGUjCwyMDE4LS1DaG9pLVctTS0tQ28tTmktQ3ItRmUtTW4tLUxBTU1QUy0taXByMZSMIzIwMTgtLUV0ZXNhbWktUy1BLS1GZS0tTEFNTVBTLS1pcHIxlIwsMjAxOC0tRmFya2FzLUQtLUZlLU5pLUNyLUNvLUN1LS1MQU1NUFMtLWlwcjKUjCQyMDE4LS1KZW9uZy1HLVUtLVBkLUZlLS1MQU1NUFMtLWlwcjGUjCYyMDE4LS1aaG91LVgtVy0tRmUtTmktQ3ItLUxBTU1QUy0taXByMZSMJjIwMTgtLVpob3UtWC1XLS1GZS1OaS1Dci0tTEFNTVBTLS1pcHIylIwnMjAxOS0tQXNsYW0tSS0tRmUtTW4tU2ktQy0tTEFNTVBTLS1pcHIxlIwmMjAxOS0tQnlnZ21hc3Rhci1KLS1GZS1PLS1MQU1NUFMtLWlwcjGUjCoyMDE5LS1NZW5kZWxldi1NLUktLUZlLU5pLUNyLS1MQU1NUFMtLWlwcjGUjCQyMDIwLS1CeWdnbWFzdGFyLUotLUZlLS1MQU1NUFMtLWlwcjGUjCwyMDIwLS1GYXJrYXMtRC0tRmUtTmktQ3ItQ28tQWwtLUxBTU1QUy0taXByMZSMLDIwMjAtLUdyb2dlci1SLS1Dby1Dci1GZS1Nbi1OaS0tTEFNTVBTLS1pcHIxlIweMjAyMC0tTW9yaS1ILS1GZS0tTEFNTVBTLS1pcHIxlIwvMjAyMS0tRGVsdWlnaS1PLVItLUZlLU5pLUNyLUNvLUN1LS1MQU1NUFMtLWlwcjGUjCIyMDIxLS1TdGFyaWtvdi1TLS1GZS0tTEFNTVBTLS1pcHIxlIwiMjAyMS0tU3Rhcmlrb3YtUy0tRmUtLUxBTU1QUy0taXByMpSMHzIwMjEtLVdlbi1NLS1GZS1ILS1MQU1NUFMtLWlwcjGUjCMyMDIyLS1NYWhhdGEtQS0tQWwtRmUtLUxBTU1QUy0taXByMZSMJzIwMjItLVN0YXJpa292LVMtLUZlLUNyLUgtLUxBTU1QUy0taXByMZSMHTIwMjItLVN1bi1ZLS1GZS0tTEFNTVBTLS1pcHIxlIw6RUFNX0R5bmFtb19BY2tsYW5kQmFjb25DYWxkZXJfMTk5N19GZV9fTU9fMTQyNzk5NzE3NTE2XzAwNZSMQUVBTV9EeW5hbW9fQWNrbGFuZE1lbmRlbGV2U3JvbG92aXR6XzIwMDRfRmVQX19NT184ODQzNDMxNDYzMTBfMDA1lIw7RUFNX0R5bmFtb19Cb25ueUNhc3RpbkJ1bGxlbnNfMjAxM19GZVdfX01PXzczNzU2NzI0MjYzMV8wMDCUjEBFQU1fRHluYW1vX0Jvbm55Q2FzdGluVGVyZW50eWV2XzIwMTNfRmVOaUNyX19NT183NjMxOTc5NDEwMzlfMDAwlIw/RUFNX0R5bmFtb19Cb25ueVBhc2lhbm90Q2FzdGluXzIwMDlfRmVDdU5pX19NT180NjkzNDM5NzMxNzFfMDA1lIw+RUFNX0R5bmFtb19Cb25ueVBhc2lhbm90TWFsZXJiYV8yMDA5X0ZlTmlfX01PXzI2NzcyMTQwODkzNF8wMDWUjEFFQU1fRHluYW1vX0NoYW1hdGlQYXBhbmljb2xhb3VNaXNoaW5fMjAwNl9GZV9fTU9fOTYwNjk5NTEzNDI0XzAwMJSMN0VBTV9EeW5hbW9fSGVwYnVybkFja2xhbmRfMjAwOF9GZUNfX01PXzE0Mzk3NzE1MjcyOF8wMDWUjDBFQU1fRHluYW1vX01hcmluaWNhXzIwMDdfRmVfX01PXzQ2NjgwODg3NzEzMF8wMDCUjDBFQU1fRHluYW1vX01hcmluaWNhXzIwMTFfRmVfX01PXzI1NTMxNTQwNzkxMF8wMDCUjD1FQU1fRHluYW1vX01lbmRlbGV2Qm9yb3Zpa292XzIwMjBfRmVOaUNyX19NT185MjIzNjMzNDA1NzBfMDAwlIw3RUFNX0R5bmFtb19NZW5kZWxldkhhblNvbl8yMDA3X1ZGZV9fTU9fMjQ5NzA2ODEwNTI3XzAwNZSMRkVBTV9EeW5hbW9fTWVuZGVsZXZIYW5Tcm9sb3ZpdHpfMjAwM1BvdGVudGlhbDJfRmVfX01PXzc2OTU4MjM2MzQzOV8wMDWUjEZFQU1fRHluYW1vX01lbmRlbGV2SGFuU3JvbG92aXR6XzIwMDNQb3RlbnRpYWw1X0ZlX19NT185NDI0MjA3MDY4NThfMDA1lIw8RUFNX0R5bmFtb19NZW5kZWxldkhhblNyb2xvdml0el8yMDAzX0ZlX19NT184MDc5OTc4MjY0NDlfMDAwlIxCRUFNX0R5bmFtb19NZW5kZWxldlNyb2xvdml0ekFja2xhbmRfMjAwNV9BbEZlX19NT181Nzc0NTM4OTE5NDFfMDA1lIwwRUFNX0R5bmFtb19NZW5kZWxldl8yMDAzX0ZlX19NT181NDY2NzM1NDkwODVfMDAwlIxJRUFNX0R5bmFtb19aaG91Sm9obnNvbldhZGxleV8yMDA0TklTVHJldGFidWxhdGlvbl9GZV9fTU9fNjgxMDg4Mjk4MjA4XzAwMJSMOUVBTV9EeW5hbW9fWmhvdUpvaG5zb25XYWRsZXlfMjAwNF9GZV9fTU9fNjUwMjc5OTA1MjMwXzAwNZSMRkVBTV9NYWduZXRpYzJHUXVpbnRpY19DaGllc2FEZXJsZXREdWRhcmV2XzIwMTFfRmVfX01PXzE0MDQ0NDMyMTYwN18wMDKUjDxFQU1fTWFnbmV0aWNDdWJpY19EdWRhcmV2RGVybGV0XzIwMDVfRmVfX01PXzEzNTAzNDIyOTI4Ml8wMDKUjENFQU1fTWFnbmV0aWNDdWJpY19NZW5kZWxldkhhblNyb2xvdml0el8yMDAzX0ZlX19NT184NTYyOTU5NTI0MjVfMDAylIw8TUVBTV9MQU1NUFNfQXNhZGlaYWVlbU5vdXJhbmlhbl8yMDE1X0ZlX19NT180OTIzMTA4OTg3NzlfMDAwlIw7TUVBTV9MQU1NUFNfQ2hvaUpvU29obl8yMDE4X0NvTmlDckZlTW5fX01PXzExNTQ1NDc0NzUwM18wMDCUjDZNRUFNX0xBTU1QU19DaG9pS2ltU2VvbF8yMDE3X0NvRmVfX01PXzE3OTE1ODI1NzE4MF8wMDCUjDVNRUFNX0xBTU1QU19FdGVzYW1pQXNhZGlfMjAxOF9GZV9fTU9fNTQ5OTAwMjg3NDIxXzAwMJSMR01FQU1fTEFNTVBTX0plbGluZWtHcm9oSG9yc3RlbWV5ZXJfMjAxMl9BbFNpTWdDdUZlX19NT18yNjI1MTk1MjA2NzhfMDAwlIw2TUVBTV9MQU1NUFNfSmVvbmdQYXJrRG9fMjAxOF9QZEZlX19NT185MjQ3MzY2MjIyMDNfMDAwlIw2TUVBTV9MQU1NUFNfS2ltSnVuZ0xlZV8yMDA5X0ZlVGlDX19NT18xMTAxMTkyMDQ3MjNfMDAwlIw2TUVBTV9MQU1NUFNfS2ltSnVuZ0xlZV8yMDEwX0ZlTmJDX19NT18wNzI2ODk3MTg2MTZfMDAwlIwxTUVBTV9MQU1NUFNfS2ltTGVlXzIwMDZfUHRGZV9fTU9fMzQzMTY4MTAxNDkwXzAwMJSMNU1FQU1fTEFNTVBTX0tpbVNoaW5MZWVfMjAwOV9GZU1uX19NT18wNTg3MzU0MDA0NjJfMDAwlIwyTUVBTV9MQU1NUFNfS29KaW1MZWVfMjAxMl9GZVBfX01PXzE3OTQyMDM2Mzk0NF8wMDCUjDFNRUFNX0xBTU1QU19MZWVKYW5nXzIwMDdfRmVIX19NT18wOTU2MTA5NTE5NTdfMDAwlIwzTUVBTV9MQU1NUFNfTGVlTGVlS2ltXzIwMDZfRmVOX19NT180MzI4NjE3NjY3MzhfMDAwlIwxTUVBTV9MQU1NUFNfTGVlTGVlXzIwMTBfRmVBbF9fTU9fMzMyMjExNTIyMDUwXzAwMJSMN01FQU1fTEFNTVBTX0xlZVdpcnRoU2hpbV8yMDA1X0ZlQ3VfX01PXzA2MzYyNjA2NTQzN18wMDCUjC1NRUFNX0xBTU1QU19MZWVfMjAwNl9GZUNfX01PXzg1Njk1NjE3ODY2OV8wMDCUjDpNRUFNX0xBTU1QU19MaXlhbmFnZUtpbUhvdXplXzIwMTRfRmVDX19NT18wNzUyNzk4MDAxOTVfMDAwlIwwTUVBTV9MQU1NUFNfU2FMZWVfMjAwOF9GZVRpX19NT18yNjA1NDY5Njc3OTNfMDAwlIwwTUVBTV9MQU1NUFNfU2FMZWVfMjAwOF9OYkZlX19NT18xNjIwMzYxNDEyNjFfMDAwlIw0TUVBTV9MQU1NUFNfV3VMZWVTdV8yMDE3X05pQ3JGZV9fTU9fOTEyNjM2MTA3MTA4XzAwMJSMMk1FQU1fTEFNTVBTX1d1TGVlU3VfMjAxN19OaUZlX19NT18zMjEyMzMxNzY0OThfMDAwlIwxTUpfTW9ycmlzQWdhTGV2YXNob3ZfMjAwOF9GZV9fTU9fODU3MjgyNzU0MzA3XzAwM5SMRE1vcnNlX1NoaWZ0ZWRfR2lyaWZhbGNvV2VpemVyXzE5NTlIaWdoQ3V0b2ZmX0ZlX19NT18xNDc2MDMxMjg0MzdfMDA0lIxDTW9yc2VfU2hpZnRlZF9HaXJpZmFsY29XZWl6ZXJfMTk1OUxvd0N1dG9mZl9GZV9fTU9fMzMxMjg1NDk1NjE3XzAwNJSMQ01vcnNlX1NoaWZ0ZWRfR2lyaWZhbGNvV2VpemVyXzE5NTlNZWRDdXRvZmZfRmVfX01PXzk4NDM1ODM0NDE5Nl8wMDSUjD1UZXJzb2ZmX0xBTU1QU19NdWVsbGVyRXJoYXJ0QWxiZV8yMDA3X0ZlX19NT18xMzc5NjQzMTA3MDJfMDAzlIxFU2ltX0xBTU1QU19FQU1DRF9TdHVrb3dza2lTYWRpZ2hFcmhhcnRfMjAwOV9GZUNyX19TTV83NzU1NjQ0OTk1MTNfMDAwlIxBU2ltX0xBTU1QU19FQU1fQm9ubnlDYXN0aW5CdWxsZW5zXzIwMTNfRmVDcldfX1NNXzY5OTI1NzM1MDcwNF8wMDCUjERTaW1fTEFNTVBTX0VBTV9Cb25ueVBhc2lhbm90VGVyZW50eWV2XzIwMTFfRmVDcl9fU01fMjM3MDg5Mjk4NDYzXzAwMJSMQFNpbV9MQU1NUFNfTUVBTV9Bc2FkaVphZWVtTm91cmFuaWFuXzIwMTVfRmVfX1NNXzA0MjYzMDY4MDk5M18wMDCUjDlTaW1fTEFNTVBTX01FQU1fRXRlc2FtaUFzYWRpXzIwMThfRmVfX1NNXzI2NzAxNjYwODc1NV8wMDCUjEtTaW1fTEFNTVBTX01FQU1fSmVsaW5la0dyb2hIb3JzdGVtZXllcl8yMDEyX0FsU2lNZ0N1RmVfX1NNXzY1NjUxNzM1MjQ4NV8wMDCUjDpTaW1fTEFNTVBTX01FQU1fS2ltSnVuZ0xlZV8yMDA5X0ZlVGlDX19TTV81MzEwMzgyNzQ0NzFfMDAwlIw+U2ltX0xBTU1QU19NRUFNX0xpeWFuYWdlS2ltSG91emVfMjAxNF9GZUNfX1NNXzY1MjQyNTc3NzgwOF8wMDCUjEhTaW1fTEFNTVBTX1JlYXhGRl9BcnlhbnBvdXJWYW5EdWluS3ViaWNraV8yMDEwX0ZlSE9fX1NNXzIyMjk2NDIxNjAwMV8wMDGUjEVTaW1fTEFNTVBTX1RlcnNvZmZaQkxfQnlnZ21hc3RhckdyYW5iZXJnXzIwMjBfRmVfX1NNXzk1ODg2Mzg5NTIzNF8wMDCUjE1TaW1fTEFNTVBTX1RlcnNvZmZaQkxfSGVucmlrc3NvbkJqb3JrYXNOb3JkbHVuZF8yMDEzX0ZlQ19fU01fNDczNDYzNDk4MjY5XzAwMJRldS4="
@@ -166,14 +166,14 @@
                             {
                                 "type": "data",
                                 "label": "engine",
-                                "GID": 29,
+                                "GID": 26,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVjgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjB9weWlyb25fYXRvbWlzdGljcy5sYW1tcHMubGFtbXBzlIwGTGFtbXBzlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu",
                                 "otype_namespace": "atomistics",
                                 "otype_name": "lammps_output_job"
                             }
                         ],
-                        "GID": 25,
+                        "GID": 22,
                         "pos x": 595.4282440561444,
                         "pos y": 248.4835164835165
                     },
@@ -186,21 +186,21 @@
                             {
                                 "type": "data",
                                 "label": "x",
-                                "GID": 50,
+                                "GID": 28,
                                 "dtype": "DType.Untyped",
                                 "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
                             },
                             {
                                 "type": "data",
                                 "label": "y",
-                                "GID": 51,
+                                "GID": 29,
                                 "dtype": "DType.Untyped",
                                 "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
                             },
                             {
                                 "type": "data",
                                 "label": "fig",
-                                "GID": 52,
+                                "GID": 30,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVgAAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjBFtYXRwbG90bGliLmZpZ3VyZZSMBkZpZ3VyZZSTlGGMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
@@ -208,7 +208,7 @@
                             {
                                 "type": "data",
                                 "label": "marker",
-                                "GID": 53,
+                                "GID": 31,
                                 "val": "gASVBQAAAAAAAACMAW+ULg==",
                                 "dtype": "DType.Choice",
                                 "dtype state": "gASVzgAAAAAAAAB9lCiMB2RlZmF1bHSUjAFvlIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlIwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlF2UKIwEbm9uZZSMAS6UjAEslGgCjAF2lIwBXpSMATyUjAE+lIwBMZSMATKUjAEzlIwBNJSMATiUjAFzlIwBcJSMAVCUjAEqlIwBaJSMAUiUjAErlIwBeJSMAViUjAFklIwBRJSMAXyUjAFflGV1Lg=="
@@ -216,7 +216,7 @@
                             {
                                 "type": "data",
                                 "label": "linestyle",
-                                "GID": 54,
+                                "GID": 32,
                                 "val": "gASVCAAAAAAAAACMBG5vbmWULg==",
                                 "dtype": "DType.Choice",
                                 "dtype state": "gASVjgAAAAAAAAB9lCiMB2RlZmF1bHSUjARub25llIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlIwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlF2UKGgCjAVzb2xpZJSMBmRvdHRlZJSMBmRhc2hlZJSMB2Rhc2hkb3SUZXUu"
@@ -224,7 +224,7 @@
                             {
                                 "type": "data",
                                 "label": "color",
-                                "GID": 55,
+                                "GID": 33,
                                 "val": "gAROLg==",
                                 "dtype": "DType.String",
                                 "dtype state": "gASVhgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANzdHKUk5SMBW51bXB5lIwEc3RyX5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
@@ -232,7 +232,7 @@
                             {
                                 "type": "data",
                                 "label": "alpha",
-                                "GID": 56,
+                                "GID": 34,
                                 "val": "gASVCgAAAAAAAABHP/AAAAAAAAAu",
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURz/wAAAAAAAAjAN2YWyURz/wAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
@@ -240,7 +240,7 @@
                             {
                                 "type": "data",
                                 "label": "label",
-                                "GID": 57,
+                                "GID": 35,
                                 "val": "gAROLg==",
                                 "dtype": "DType.String",
                                 "dtype state": "gASVhgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANzdHKUk5SMBW51bXB5lIwEc3RyX5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
@@ -248,7 +248,7 @@
                             {
                                 "type": "data",
                                 "label": "xlabel",
-                                "GID": 58,
+                                "GID": 36,
                                 "val": "gAROLg==",
                                 "dtype": "DType.String",
                                 "dtype state": "gASVhgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANzdHKUk5SMBW51bXB5lIwEc3RyX5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
@@ -256,7 +256,7 @@
                             {
                                 "type": "data",
                                 "label": "ylabel",
-                                "GID": 59,
+                                "GID": 37,
                                 "val": "gAROLg==",
                                 "dtype": "DType.String",
                                 "dtype state": "gASVhgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANzdHKUk5SMBW51bXB5lIwEc3RyX5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
@@ -264,7 +264,7 @@
                             {
                                 "type": "data",
                                 "label": "title",
-                                "GID": 60,
+                                "GID": 38,
                                 "val": "gAROLg==",
                                 "dtype": "DType.String",
                                 "dtype state": "gASVhgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANzdHKUk5SMBW51bXB5lIwEc3RyX5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
@@ -272,7 +272,7 @@
                             {
                                 "type": "data",
                                 "label": "legend",
-                                "GID": 61,
+                                "GID": 39,
                                 "val": "gASJLg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -280,7 +280,7 @@
                             {
                                 "type": "data",
                                 "label": "tight_layout",
-                                "GID": 62,
+                                "GID": 40,
                                 "val": "gASILg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiIwDdmFslIiMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -290,12 +290,12 @@
                             {
                                 "type": "data",
                                 "label": "fig",
-                                "GID": 63,
+                                "GID": 41,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVgAAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjBFtYXRwbG90bGliLmZpZ3VyZZSMBkZpZ3VyZZSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
                             }
                         ],
-                        "GID": 49,
+                        "GID": 27,
                         "pos x": 1527.2071039816672,
                         "pos y": 158.24175824175825
                     },
@@ -308,22 +308,22 @@
                             {
                                 "type": "data",
                                 "label": "job",
-                                "GID": 65,
+                                "GID": 43,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVpgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCpweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLmpvYi5hdG9taXN0aWOUjBNBdG9taXN0aWNHZW5lcmljSm9ilJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
                             },
                             {
                                 "type": "data",
                                 "label": "field",
-                                "GID": 66,
+                                "GID": 44,
                                 "val": "gASVCQAAAAAAAACMBXN0ZXBzlC4=",
                                 "dtype": "DType.Choice",
-                                "dtype state": "gASVUgEAAAAAAAB9lCiMB2RlZmF1bHSUjAVzdGVwc5SMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZSMCGJ1aWx0aW5zlIwDc3RylJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlI+UKIwKZW5lcmd5X3BvdJSMC3RlbXBlcmF0dXJllIwKZW5lcmd5X3RvdJRoAowQY29tcHV0YXRpb25fdGltZZSME3RvdGFsX2Rpc3BsYWNlbWVudHOUjAlwb3NpdGlvbnOUjAdpbmRpY2VzlIwFY2VsbHOUjA1kaXNwbGFjZW1lbnRzlIwGZm9yY2VzlIwJcHJlc3N1cmVzlIwGdm9sdW1llIwTdW53cmFwcGVkX3Bvc2l0aW9uc5SMCWZvcmNlX21heJSMEWdldF9kaXNwbGFjZW1lbnRzlJB1Lg=="
+                                "dtype state": "gASVUgEAAAAAAAB9lCiMB2RlZmF1bHSUjAVzdGVwc5SMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZSMCGJ1aWx0aW5zlIwDc3RylJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlI+UKGgCjAdpbmRpY2VzlIwTdW53cmFwcGVkX3Bvc2l0aW9uc5SMBWNlbGxzlIwGdm9sdW1llIwNZGlzcGxhY2VtZW50c5SME3RvdGFsX2Rpc3BsYWNlbWVudHOUjAlmb3JjZV9tYXiUjAt0ZW1wZXJhdHVyZZSMCmVuZXJneV9wb3SUjAlwcmVzc3VyZXOUjAplbmVyZ3lfdG90lIwJcG9zaXRpb25zlIwQY29tcHV0YXRpb25fdGltZZSMBmZvcmNlc5SMEWdldF9kaXNwbGFjZW1lbnRzlJB1Lg=="
                             },
                             {
                                 "type": "data",
                                 "label": "transpose",
-                                "GID": 67,
+                                "GID": 45,
                                 "val": "gASJLg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -331,7 +331,7 @@
                             {
                                 "type": "data",
                                 "label": "index",
-                                "GID": 68,
+                                "GID": 46,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Integer",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANpbnSUk5SMBW51bXB5lIwHaW50ZWdlcpSTlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
@@ -341,12 +341,12 @@
                             {
                                 "type": "data",
                                 "label": "output",
-                                "GID": 69,
+                                "GID": 47,
                                 "dtype": "DType.List",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANpbnSUk5RoCIwFZmxvYXSUk5SMBW51bXB5lIwGbnVtYmVylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIl1Lg=="
                             }
                         ],
-                        "GID": 64,
+                        "GID": 42,
                         "pos x": 1212.6152964766543,
                         "pos y": 98.9010989010989
                     },
@@ -359,22 +359,22 @@
                             {
                                 "type": "data",
                                 "label": "job",
-                                "GID": 71,
+                                "GID": 49,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVpgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCpweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLmpvYi5hdG9taXN0aWOUjBNBdG9taXN0aWNHZW5lcmljSm9ilJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
                             },
                             {
                                 "type": "data",
                                 "label": "field",
-                                "GID": 72,
+                                "GID": 50,
                                 "val": "gASVDwAAAAAAAACMC3RlbXBlcmF0dXJllC4=",
                                 "dtype": "DType.Choice",
-                                "dtype state": "gASVUgEAAAAAAAB9lCiMB2RlZmF1bHSUjAVzdGVwc5SMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZSMCGJ1aWx0aW5zlIwDc3RylJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlI+UKIwKZW5lcmd5X3BvdJSMC3RlbXBlcmF0dXJllIwKZW5lcmd5X3RvdJRoAowQY29tcHV0YXRpb25fdGltZZSME3RvdGFsX2Rpc3BsYWNlbWVudHOUjAlwb3NpdGlvbnOUjAdpbmRpY2VzlIwFY2VsbHOUjA1kaXNwbGFjZW1lbnRzlIwGZm9yY2VzlIwJcHJlc3N1cmVzlIwGdm9sdW1llIwTdW53cmFwcGVkX3Bvc2l0aW9uc5SMCWZvcmNlX21heJSMEWdldF9kaXNwbGFjZW1lbnRzlJB1Lg=="
+                                "dtype state": "gASVUgEAAAAAAAB9lCiMB2RlZmF1bHSUjAVzdGVwc5SMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZSMCGJ1aWx0aW5zlIwDc3RylJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlI+UKGgCjAdpbmRpY2VzlIwTdW53cmFwcGVkX3Bvc2l0aW9uc5SMBWNlbGxzlIwGdm9sdW1llIwNZGlzcGxhY2VtZW50c5SME3RvdGFsX2Rpc3BsYWNlbWVudHOUjAlmb3JjZV9tYXiUjAt0ZW1wZXJhdHVyZZSMCmVuZXJneV9wb3SUjAlwcmVzc3VyZXOUjAplbmVyZ3lfdG90lIwJcG9zaXRpb25zlIwQY29tcHV0YXRpb25fdGltZZSMBmZvcmNlc5SMEWdldF9kaXNwbGFjZW1lbnRzlJB1Lg=="
                             },
                             {
                                 "type": "data",
                                 "label": "transpose",
-                                "GID": 73,
+                                "GID": 51,
                                 "val": "gASJLg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -382,7 +382,7 @@
                             {
                                 "type": "data",
                                 "label": "index",
-                                "GID": 74,
+                                "GID": 52,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Integer",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANpbnSUk5SMBW51bXB5lIwHaW50ZWdlcpSTlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
@@ -392,12 +392,12 @@
                             {
                                 "type": "data",
                                 "label": "output",
-                                "GID": 75,
+                                "GID": 53,
                                 "dtype": "DType.List",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANpbnSUk5RoCIwFZmxvYXSUk5SMBW51bXB5lIwGbnVtYmVylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIl1Lg=="
                             }
                         ],
-                        "GID": 70,
+                        "GID": 48,
                         "pos x": 1225.8149527356059,
                         "pos y": 358.24175824175825
                     },
@@ -410,7 +410,7 @@
                             {
                                 "type": "data",
                                 "label": "name",
-                                "GID": 231,
+                                "GID": 55,
                                 "val": "gASVCwAAAAAAAACMB2V4YW1wbGWULg==",
                                 "dtype": "DType.String",
                                 "dtype state": "gASVigAAAAAAAAB9lCiMB2RlZmF1bHSUjAEulIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwDc3RylJOUjAVudW1weZSMBHN0cl+Uk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
@@ -418,7 +418,7 @@
                             {
                                 "type": "exec",
                                 "label": "remove",
-                                "GID": 232,
+                                "GID": 56,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Untyped",
                                 "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
@@ -426,7 +426,7 @@
                             {
                                 "type": "data",
                                 "label": "enable_remove",
-                                "GID": 233,
+                                "GID": 57,
                                 "val": "gASJLg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -434,7 +434,7 @@
                             {
                                 "type": "data",
                                 "label": "remove_name",
-                                "GID": 234,
+                                "GID": 58,
                                 "val": "gASVBAAAAAAAAACMAJQu",
                                 "dtype": "DType.String",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUjACUjAN2YWyUaAKMA2RvY5RoAowGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA3N0cpSTlIwFbnVtcHmUjARzdHJflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -442,7 +442,7 @@
                             {
                                 "type": "data",
                                 "label": "remove_all",
-                                "GID": 235,
+                                "GID": 59,
                                 "val": "gASJLg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -450,7 +450,7 @@
                             {
                                 "type": "data",
                                 "label": "recursive",
-                                "GID": 236,
+                                "GID": 60,
                                 "val": "gASILg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiIwDdmFslIiMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -460,14 +460,14 @@
                             {
                                 "type": "data",
                                 "label": "project",
-                                "GID": 237,
+                                "GID": 61,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjBlweWlyb25fYXRvbWlzdGljcy5wcm9qZWN0lIwHUHJvamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg==",
                                 "otype_namespace": "atomistics",
                                 "otype_name": "project_output_atomistics_project"
                             }
                         ],
-                        "GID": 230,
+                        "GID": 54,
                         "pos x": 86.42384105960265,
                         "pos y": 44.776119402985074
                     },
@@ -480,7 +480,7 @@
                             {
                                 "type": "exec",
                                 "label": "run",
-                                "GID": 239,
+                                "GID": 63,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Untyped",
                                 "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
@@ -488,7 +488,7 @@
                             {
                                 "type": "exec",
                                 "label": "reset",
-                                "GID": 240,
+                                "GID": 64,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Untyped",
                                 "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
@@ -496,7 +496,7 @@
                             {
                                 "type": "data",
                                 "label": "name",
-                                "GID": 241,
+                                "GID": 65,
                                 "val": "gASVCwAAAAAAAACMB2NhbGNfbWSULg==",
                                 "dtype": "DType.String",
                                 "dtype state": "gASVjQAAAAAAAAB9lCiMB2RlZmF1bHSUjARjYWxjlIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwDc3RylJOUjAVudW1weZSMBHN0cl+Uk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
@@ -504,7 +504,7 @@
                             {
                                 "type": "data",
                                 "label": "job",
-                                "GID": 242,
+                                "GID": 66,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVjgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjB9weWlyb25fYXRvbWlzdGljcy5sYW1tcHMubGFtbXBzlIwGTGFtbXBzlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu",
                                 "otype_namespace": "atomistics",
@@ -513,7 +513,7 @@
                             {
                                 "type": "data",
                                 "label": "temperature",
-                                "GID": 243,
+                                "GID": 67,
                                 "val": "gASVCgAAAAAAAABHQHLAAAAAAAAu",
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVmQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZSMCGRlY2ltYWxzlEsKdS4="
@@ -521,7 +521,7 @@
                             {
                                 "type": "data",
                                 "label": "pressure",
-                                "GID": 244,
+                                "GID": 68,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVlgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlGgIjARsaXN0lJOUjAVudW1weZSMB25kYXJyYXmUk5RljAphbGxvd19ub25llIiMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
@@ -529,7 +529,7 @@
                             {
                                 "type": "data",
                                 "label": "n_ionic_steps",
-                                "GID": 245,
+                                "GID": 69,
                                 "val": "gASVBAAAAAAAAABN6AMu",
                                 "dtype": "DType.Integer",
                                 "dtype state": "gASVjQAAAAAAAAB9lCiMB2RlZmF1bHSUTegDjAN2YWyUTegDjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwDaW50lJOUjAVudW1weZSMB2ludGVnZXKUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
@@ -537,7 +537,7 @@
                             {
                                 "type": "data",
                                 "label": "time_step",
-                                "GID": 246,
+                                "GID": 70,
                                 "val": "gASVCgAAAAAAAABHP/AAAAAAAAAu",
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURz/wAAAAAAAAjAN2YWyURz/wAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
@@ -545,7 +545,7 @@
                             {
                                 "type": "data",
                                 "label": "n_print",
-                                "GID": 247,
+                                "GID": 71,
                                 "val": "gARLCi4=",
                                 "dtype": "DType.Integer",
                                 "dtype state": "gASViwAAAAAAAAB9lCiMB2RlZmF1bHSUS2SMA3ZhbJRLZIwDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA2ludJSTlIwFbnVtcHmUjAdpbnRlZ2VylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -553,7 +553,7 @@
                             {
                                 "type": "data",
                                 "label": "temperature_damping_timescale",
-                                "GID": 248,
+                                "GID": 72,
                                 "val": "gASVCgAAAAAAAABHQFkAAAAAAAAu",
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSUR0BZAAAAAAAAjAN2YWyUR0BZAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
@@ -561,7 +561,7 @@
                             {
                                 "type": "data",
                                 "label": "pressure_damping_timescale",
-                                "GID": 249,
+                                "GID": 73,
                                 "val": "gASVCgAAAAAAAABHQI9AAAAAAAAu",
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSUR0CPQAAAAAAAjAN2YWyUR0CPQAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
@@ -569,7 +569,7 @@
                             {
                                 "type": "data",
                                 "label": "seed",
-                                "GID": 250,
+                                "GID": 74,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Integer",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANpbnSUk5SMBW51bXB5lIwHaW50ZWdlcpSTlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
@@ -577,7 +577,7 @@
                             {
                                 "type": "data",
                                 "label": "initial_temperature",
-                                "GID": 251,
+                                "GID": 75,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVmQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZSMCGRlY2ltYWxzlEsKdS4="
@@ -585,7 +585,7 @@
                             {
                                 "type": "data",
                                 "label": "dynamics",
-                                "GID": 252,
+                                "GID": 76,
                                 "val": "gASVDAAAAAAAAACMCGxhbmdldmlulC4=",
                                 "dtype": "DType.Choice",
                                 "dtype state": "gASVfAAAAAAAAAB9lCiMB2RlZmF1bHSUjAhsYW5nZXZpbpSMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZSMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjAVpdGVtc5RdlChoAowLbm9zZS1ob292ZXKUZXUu"
@@ -595,21 +595,21 @@
                             {
                                 "type": "exec",
                                 "label": "ran",
-                                "GID": 253,
+                                "GID": 77,
                                 "dtype": "DType.Untyped",
                                 "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
                             },
                             {
                                 "type": "data",
                                 "label": "job",
-                                "GID": 254,
+                                "GID": 78,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVjgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjB9weWlyb25fYXRvbWlzdGljcy5sYW1tcHMubGFtbXBzlIwGTGFtbXBzlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
                             },
                             {
                                 "type": "data",
                                 "label": "energy_pot",
-                                "GID": 255,
+                                "GID": 79,
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURwAAAAAAAAAAjAN2YWyURwAAAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu",
                                 "otype_namespace": "atomistics",
@@ -618,70 +618,70 @@
                             {
                                 "type": "data",
                                 "label": "forces",
-                                "GID": 256,
+                                "GID": 80,
                                 "dtype": "DType.List",
                                 "dtype state": "gASVgQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJdS4=",
                                 "otype_namespace": "atomistics",
                                 "otype_name": "atomistic_taker_output_forces"
                             }
                         ],
-                        "GID": 238,
+                        "GID": 62,
                         "pos x": 918.8198224004584,
                         "pos y": 100.28571428571428
                     }
                 ],
                 "connections": [
                     {
-                        "GID": 77,
+                        "GID": 81,
                         "parent node index": 0,
                         "output port index": 0,
                         "connected node": 1,
                         "connected input port index": 0
                     },
                     {
-                        "GID": 78,
+                        "GID": 82,
                         "parent node index": 1,
                         "output port index": 0,
                         "connected node": 2,
                         "connected input port index": 1
                     },
                     {
-                        "GID": 257,
+                        "GID": 83,
                         "parent node index": 2,
                         "output port index": 0,
                         "connected node": 7,
                         "connected input port index": 3
                     },
                     {
-                        "GID": 82,
+                        "GID": 84,
                         "parent node index": 4,
                         "output port index": 0,
                         "connected node": 3,
                         "connected input port index": 0
                     },
                     {
-                        "GID": 83,
+                        "GID": 85,
                         "parent node index": 5,
                         "output port index": 0,
                         "connected node": 3,
                         "connected input port index": 1
                     },
                     {
-                        "GID": 260,
+                        "GID": 86,
                         "parent node index": 6,
                         "output port index": 0,
                         "connected node": 2,
                         "connected input port index": 0
                     },
                     {
-                        "GID": 258,
+                        "GID": 87,
                         "parent node index": 7,
                         "output port index": 1,
                         "connected node": 4,
                         "connected input port index": 0
                     },
                     {
-                        "GID": 259,
+                        "GID": 88,
                         "parent node index": 7,
                         "output port index": 1,
                         "connected node": 5,
@@ -707,7 +707,7 @@
                             {
                                 "type": "data",
                                 "label": "min",
-                                "GID": 95,
+                                "GID": 97,
                                 "val": "gASVCgAAAAAAAABHQA5mZmZmZmYu",
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURz/wAAAAAAAAjAN2YWyURz/wAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
@@ -715,7 +715,7 @@
                             {
                                 "type": "data",
                                 "label": "max",
-                                "GID": 96,
+                                "GID": 98,
                                 "val": "gASVCgAAAAAAAABHQBDMzMzMzM0u",
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSUR0AAAAAAAAAAjAN2YWyUR0AAAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
@@ -723,7 +723,7 @@
                             {
                                 "type": "data",
                                 "label": "steps",
-                                "GID": 97,
+                                "GID": 99,
                                 "val": "gARLCS4=",
                                 "dtype": "DType.Integer",
                                 "dtype state": "gASViwAAAAAAAAB9lCiMB2RlZmF1bHSUSwqMA3ZhbJRLCowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA2ludJSTlIwFbnVtcHmUjAdpbnRlZ2VylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -733,12 +733,12 @@
                             {
                                 "type": "data",
                                 "label": "linspace",
-                                "GID": 98,
+                                "GID": 100,
                                 "dtype": "DType.List",
                                 "dtype state": "gASVawAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAVudW1weZSMCGZsb2F0aW5nlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIl1Lg=="
                             }
                         ],
-                        "GID": 94,
+                        "GID": 96,
                         "pos x": 21.243196791750222,
                         "pos y": 305.6263736263736
                     },
@@ -751,7 +751,7 @@
                             {
                                 "type": "data",
                                 "label": "element",
-                                "GID": 100,
+                                "GID": 102,
                                 "val": "gASVBgAAAAAAAACMAkFslC4=",
                                 "dtype": "DType.String",
                                 "dtype state": "gASViwAAAAAAAAB9lCiMB2RlZmF1bHSUjAJGZZSMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA3N0cpSTlIwFbnVtcHmUjARzdHJflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu",
@@ -761,7 +761,7 @@
                             {
                                 "type": "data",
                                 "label": "crystal_structure",
-                                "GID": 101,
+                                "GID": 103,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Choice",
                                 "dtype state": "gASVwgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiYwFaXRlbXOUXZQoTowCc2OUjANmY2OUjANiY2OUjANoY3CUjAdkaWFtb25klIwKemluY2JsZW5kZZSMCHJvY2tzYWx0lIwOY2VzaXVtY2hsb3JpZGWUjAhmbHVvcml0ZZSMCHd1cnR6aXRllGV1Lg=="
@@ -769,29 +769,13 @@
                             {
                                 "type": "data",
                                 "label": "a",
-                                "GID": 102,
+                                "GID": 104,
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVmQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSIjARzaXpllIwBbZSMCGRlY2ltYWxzlEsKdS4="
                             },
                             {
                                 "type": "data",
                                 "label": "c",
-                                "GID": 103,
-                                "val": "gAROLg==",
-                                "dtype": "DType.Float",
-                                "dtype state": "gASVmQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZSMCGRlY2ltYWxzlEsKdS4="
-                            },
-                            {
-                                "type": "data",
-                                "label": "c_over_a",
-                                "GID": 104,
-                                "val": "gAROLg==",
-                                "dtype": "DType.Float",
-                                "dtype state": "gASVmQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZSMCGRlY2ltYWxzlEsKdS4="
-                            },
-                            {
-                                "type": "data",
-                                "label": "u",
                                 "GID": 105,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Float",
@@ -799,8 +783,24 @@
                             },
                             {
                                 "type": "data",
-                                "label": "orthorhombic",
+                                "label": "c_over_a",
                                 "GID": 106,
+                                "val": "gAROLg==",
+                                "dtype": "DType.Float",
+                                "dtype state": "gASVmQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZSMCGRlY2ltYWxzlEsKdS4="
+                            },
+                            {
+                                "type": "data",
+                                "label": "u",
+                                "GID": 107,
+                                "val": "gAROLg==",
+                                "dtype": "DType.Float",
+                                "dtype state": "gASVmQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZSMCGRlY2ltYWxzlEsKdS4="
+                            },
+                            {
+                                "type": "data",
+                                "label": "orthorhombic",
+                                "GID": 108,
                                 "val": "gASJLg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -808,7 +808,7 @@
                             {
                                 "type": "data",
                                 "label": "cubic",
-                                "GID": 107,
+                                "GID": 109,
                                 "val": "gASJLg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -818,14 +818,14 @@
                             {
                                 "type": "data",
                                 "label": "structure",
-                                "GID": 108,
+                                "GID": 110,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVmgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCxweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLnN0cnVjdHVyZS5hdG9tc5SMBUF0b21zlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIiMBHNpemWUjAFtlHUu",
                                 "otype_namespace": "atomistics",
                                 "otype_name": "bulk_structure_output_structure"
                             }
                         ],
-                        "GID": 99,
+                        "GID": 101,
                         "pos x": 294.03609281008306,
                         "pos y": 178.08791208791212
                     },
@@ -838,7 +838,7 @@
                             {
                                 "type": "data",
                                 "label": "project",
-                                "GID": 110,
+                                "GID": 112,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjBlweWlyb25fYXRvbWlzdGljcy5wcm9qZWN0lIwHUHJvamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg==",
                                 "otype_namespace": "atomistics",
@@ -847,7 +847,7 @@
                             {
                                 "type": "data",
                                 "label": "structure",
-                                "GID": 111,
+                                "GID": 113,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVmgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCxweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLnN0cnVjdHVyZS5hdG9tc5SMBUF0b21zlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIiMBHNpemWUjAFtlHUu",
                                 "otype_namespace": "atomistics",
@@ -856,7 +856,7 @@
                             {
                                 "type": "data",
                                 "label": "potential",
-                                "GID": 112,
+                                "GID": 114,
                                 "val": "gASVKwAAAAAAAACMJzE5OTUtLUFuZ2Vsby1KLUUtLU5pLUFsLUgtLUxBTU1QUy0taXByMZQu",
                                 "dtype": "DType.Choice",
                                 "dtype state": "gASVnxsAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAhidWlsdGluc5SMA3N0cpSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjAVpdGVtc5RdlCiMJzE5OTUtLUFuZ2Vsby1KLUUtLU5pLUFsLUgtLUxBTU1QUy0taXByMZSMJjE5OTYtLUZhcmthcy1ELS1OYi1UaS1BbC0tTEFNTVBTLS1pcHIxlIwiMTk5Ny0tTGl1LVgtWS0tQWwtTWctLUxBTU1QUy0taXByMZSMIjE5OTgtLUxpdS1YLVktLUFsLU1nLS1MQU1NUFMtLWlwcjGUjCIxOTk5LS1MaXUtWC1ZLS1BbC1DdS0tTEFNTVBTLS1pcHIxlIwgMTk5OS0tTWlzaGluLVktLUFsLS1MQU1NUFMtLWlwcjGUjCIyMDAwLS1MYW5kYS1BLS1BbC1QYi0tTEFNTVBTLS1pcHIxlIwkMjAwMC0tU3R1cmdlb24tSi1CLS1BbC0tTEFNTVBTLS1pcHIxlIwjMjAwMi0tTWlzaGluLVktLU5pLUFsLS1MQU1NUFMtLWlwcjGUjB8yMDAzLS1MZWUtQi1KLS1BbC0tTEFNTVBTLS1pcHIxlIwgMjAwMy0tWm9wZS1SLVItLUFsLS1MQU1NUFMtLWlwcjGUjCMyMDAzLS1ab3BlLVItUi0tVGktQWwtLUxBTU1QUy0taXByMZSMHzIwMDQtLUxpdS1YLVktLUFsLS1MQU1NUFMtLWlwcjGUjCMyMDA0LS1NaXNoaW4tWS0tTmktQWwtLUxBTU1QUy0taXByMZSMIzIwMDQtLU1pc2hpbi1ZLS1OaS1BbC0tTEFNTVBTLS1pcHIylIwgMjAwNC0tWmhvdS1YLVctLUFsLS1MQU1NUFMtLWlwcjKUjCcyMDA1LS1NZW5kZWxldi1NLUktLUFsLUZlLS1MQU1NUFMtLWlwcjGUjCQyMDA3LS1TaWx2YS1BLUMtLUFsLU5pLS1MQU1NUFMtLWlwcjGUjCQyMDA4LS1NZW5kZWxldi1NLUktLUFsLS1MQU1NUFMtLWlwcjGUjCIyMDA5LS1LaW0tWS1NLS1NZy1BbC0tTEFNTVBTLS1pcHIxlIwnMjAwOS0tTWVuZGVsZXYtTS1JLS1BbC1NZy0tTEFNTVBTLS1pcHIxlIwoMjAwOS0tUHVyamEtUHVuLUctUC0tTmktQWwtLUxBTU1QUy0taXByMZSMJzIwMDktLVpoYWtob3Zza2lpLVYtVi0tQWwtLUxBTU1QUy0taXByMpSMIDIwMTAtLUxlZS1FLS1GZS1BbC0tTEFNTVBTLS1pcHIxlIwwMjAxMC0tTWVuZGVsZXYtTS1JLS1maWN0aW9uYWwtQWwtMS0tTEFNTVBTLS1pcHIxlIwwMjAxMC0tTWVuZGVsZXYtTS1JLS1maWN0aW9uYWwtQWwtMi0tTEFNTVBTLS1pcHIxlIwwMjAxMC0tTWVuZGVsZXYtTS1JLS1maWN0aW9uYWwtQWwtMy0tTEFNTVBTLS1pcHIxlIwhMjAxMC0tV2luZXktSi1NLS1BbC0tTEFNTVBTLS1pcHIxlIwkMjAxMS0tQXBvc3RvbC1GLS1BbC1DdS0tTEFNTVBTLS1pcHIxlIwgMjAxMS0tS28tVy1TLS1BbC1ILS1MQU1NUFMtLWlwcjGUjCMyMDEyLS1Eb25nLVctUC0tQ28tQWwtLUxBTU1QUy0taXByMZSMLTIwMTItLUplbGluZWstQi0tQWwtU2ktTWctQ3UtRmUtLUxBTU1QUy0taXByMpSMJjIwMTItLVNjaG9wZi1ELS1BbC1Nbi1QZC0tTEFNTVBTLS1pcHIxlIwiMjAxMy0tU2hpbS1KLUgtLVYtQWwtLUxBTU1QUy0taXByMZSMJDIwMTMtLVNoaW0tSi1ILS1WLUFsLUgtLUxBTU1QUy0taXByMZSMIzIwMTUtLUNob3VkaGFyeS1LLS1BbC0tTEFNTVBTLS1pcHIxlIwlMjAxNS0tQ2hvdWRoYXJ5LUstLUFsLU8tLUxBTU1QUy0taXByMZSMJTIwMTUtLUtpbS1ZLUstLU5pLUFsLUNvLS1MQU1NUFMtLWlwcjGUjCIyMDE1LS1LdW1hci1BLS1BbC1OaS0tTEFNTVBTLS1pcHIxlIwkMjAxNS0tS3VtYXItQS0tQWwtTmktTy0tTEFNTVBTLS1pcHIxlIwnMjAxNS0tTWVuZGVsZXYtTS1JLS1BbC1TbS0tTEFNTVBTLS1pcHIxlIwjMjAxNS0tUGFzY3VldC1NLUktLUFsLS1MQU1NUFMtLWlwcjGUjCUyMDE1LS1QYXNjdWV0LU0tSS0tQWwtVS0tTEFNTVBTLS1pcHIylIwoMjAxNS0tUHVyamEtUHVuLUctUC0tQWwtQ28tLUxBTU1QUy0taXByMpSMKzIwMTUtLVB1cmphLVB1bi1HLVAtLU5pLUFsLUNvLS1MQU1NUFMtLWlwcjKUjCIyMDE2LS1LaW0tWS1LLS1BbC1UaS0tTEFNTVBTLS1pcHIxlIwjMjAxNi0tWmhvdS1YLVctLUFsLUN1LS1MQU1NUFMtLWlwcjKUjB4yMDE3LS1Cb3R1LVYtLUFsLS1MQU1NUFMtLWlwcjGUjCIyMDE3LS1LaW0tSi1TLS1QdC1BbC0tTEFNTVBTLS1pcHIxlIwlMjAxNy0tS2ltLVktSy0tTmktQWwtVGktLUxBTU1QUy0taXByMZSMKDIwMTgtLURpY2tlbC1ELUUtLU1nLUFsLVpuLS1MQU1NUFMtLWlwcjGUjCQyMDE4LS1KZW9uZy1HLVUtLVBkLUFsLS1MQU1NUFMtLWlwcjGUjCUyMDE4LS1aaG91LVgtVy0tQWwtQ3UtSC0tTEFNTVBTLS1pcHIxlIwmMjAxOS0tUGx1bW1lci1HLS1UaS1BbC1DLS1MQU1NUFMtLWlwcjGUjCwyMDIwLS1GYXJrYXMtRC0tRmUtTmktQ3ItQ28tQWwtLUxBTU1QUy0taXByMZSMJTIwMjAtLVB1cmphLVB1bi1HLVAtLUFsLS1MQU1NUFMtLWlwcjGUjCgyMDIwLS1TdGFyaWtvdi1TLS1TaS1BdS1BbC0tTEFNTVBTLS1pcHIxlIwoMjAyMC0tU3Rhcmlrb3YtUy0tU2ktQXUtQWwtLUxBTU1QUy0taXByMpSMJjIwMjEtLVBsdW1tZXItRy0tVGktQWwtQy0tTEFNTVBTLS1pcHIxlIwhMjAyMS0tU29uZy1ILS1BbC1TbS0tTEFNTVBTLS1pcHIxlIwqMjAyMi0tRmVyZWlkb25uZWphZC1SLS1BbC1IZi0tTEFNTVBTLS1pcHIxlIwqMjAyMi0tRmVyZWlkb25uZWphZC1SLS1BbC1OYi0tTEFNTVBTLS1pcHIxlIwqMjAyMi0tRmVyZWlkb25uZWphZC1SLS1BbC1UYS0tTEFNTVBTLS1pcHIxlIwqMjAyMi0tRmVyZWlkb25uZWphZC1SLS1BbC1UaS0tTEFNTVBTLS1pcHIxlIwqMjAyMi0tRmVyZWlkb25uZWphZC1SLS1BbC1aci0tTEFNTVBTLS1pcHIxlIwjMjAyMi0tTWFoYXRhLUEtLUFsLUN1LS1MQU1NUFMtLWlwcjGUjCMyMDIyLS1NYWhhdGEtQS0tQWwtRmUtLUxBTU1QUy0taXByMZSMIzIwMjItLU1haGF0YS1BLS1BbC1OaS0tTEFNTVBTLS1pcHIxlIwnMjAyMi0tTWVuZGVsZXYtTS1JLS1OaS1BbC0tTEFNTVBTLS1pcHIxlIxCRUFNX0N1YmljTmF0dXJhbFNwbGluZV9FcmNvbGVzc2lBZGFtc18xOTk0X0FsX19NT184MDA1MDk0NTg3MTJfMDAylIw8RUFNX0R5bmFtb19BbmdlbG9Nb29keUJhc2tlc18xOTk1X05pQWxIX19NT180MTg5NzgyMzcwNThfMDA1lIwvRUFNX0R5bmFtb19DYWlZZV8xOTk2X0FsQ3VfX01PXzk0MjU1MTA0MDA0N18wMDWUjDZFQU1fRHluYW1vX0VyY29sZXNzaUFkYW1zXzE5OTRfQWxfX01PXzEyMzYyOTQyMjA0NV8wMDWUjDdFQU1fRHluYW1vX0Zhcmthc0pvbmVzXzE5OTZfTmJUaUFsX19NT18wNDI2OTEzNjc3ODBfMDAwlIw8RUFNX0R5bmFtb19KYWNvYnNlbk5vcnNrb3ZQdXNrYV8xOTg3X0FsX19NT180MTE2OTIxMzMzNjZfMDAwlIw9RUFNX0R5bmFtb19MYW5kYVd5bmJsYXR0U2llZ2VsXzIwMDBfQWxQYl9fTU9fNjk5MTM3Mzk2MzgxXzAwNZSMMkVBTV9EeW5hbW9fTGl1QWRhbXNfMTk5OF9BbE1nX19NT18wMTk4NzM3MTU3ODZfMDAwlIw5RUFNX0R5bmFtb19MaXVFcmNvbGVzc2lBZGFtc18yMDA0X0FsX19NT18wNTExNTc2NzE1MDVfMDAwlIw3RUFNX0R5bmFtb19MaXVMaXVCb3J1Y2tpXzE5OTlfQWxDdV9fTU9fMDIwODUxMDY5NTcyXzAwMJSMO0VBTV9EeW5hbW9fTGl1T2hvdG5pY2t5QWRhbXNfMTk5N19BbE1nX19NT181NTk4NzA2MTM1NDlfMDAwlIw8RUFNX0R5bmFtb19NZW5kZWxldkFzdGFSYWhtYW5fMjAwOV9BbE1nX19NT182NTgyNzg1NDk3ODRfMDA1lIw4RUFNX0R5bmFtb19NZW5kZWxldkZhbmdZZV8yMDE1X0FsU21fX01PXzMzODYwMDIwMDczOV8wMDCUjDxFQU1fRHluYW1vX01lbmRlbGV2S3JhbWVyQmVja2VyXzIwMDhfQWxfX01PXzEwNjk2OTcwMTAyM18wMDWUjEJFQU1fRHluYW1vX01lbmRlbGV2U3JvbG92aXR6QWNrbGFuZF8yMDA1X0FsRmVfX01PXzU3NzQ1Mzg5MTk0MV8wMDWUjDhFQU1fRHluYW1vX01pc2hpbkZhcmthc01laGxfMTk5OV9BbF9fTU9fNjUxODAxNDg2Njc5XzAwNZSMR0VBTV9EeW5hbW9fTWlzaGluTWVobFBhcGFjb25zdGFudG9wb3Vsb3NfMjAwMl9OaUFsX19NT18xMDk5MzM1NjE1MDdfMDA1lIwwRUFNX0R5bmFtb19NaXNoaW5fMjAwNF9OaUFsX19NT18xMDEyMTQzMTA2ODlfMDA1lIwzRUFNX0R5bmFtb19QdW5NaXNoaW5fMjAwOV9OaUFsX19NT183NTEzNTQ0MDM3OTFfMDA1lIw6RUFNX0R5bmFtb19QdW5ZYW1ha292TWlzaGluXzIwMTNfQWxDb19fTU9fNjc4OTUyNjEyNDEzXzAwMJSMPEVBTV9EeW5hbW9fUHVuWWFtYWtvdk1pc2hpbl8yMDEzX05pQWxDb19fTU9fODI2NTkxMzU5NTA4XzAwMJSMP0VBTV9EeW5hbW9fU2Nob3BmQnJvbW1lckZyaWdhbl8yMDEyX0FsTW5QZF9fTU9fMTM3NTcyODE3ODQyXzAwMJSMNUVBTV9EeW5hbW9fU3R1cmdlb25MYWlyZF8yMDAwX0FsX19NT18xMjA4MDg4MDU1NDFfMDA1lIw2RUFNX0R5bmFtb19WYWlsaGVGYXJrYXNfMTk5N19Db0FsX19NT18yODQ5NjMxNzk0OThfMDA1lIw4RUFNX0R5bmFtb19XaW5leUt1Ym90YUd1cHRhXzIwMTBfQWxfX01PXzE0OTMxNjg2NTYwOF8wMDWUjDJFQU1fRHluYW1vX1poYWtob3Zza3lfMjAwOV9BbF9fTU9fNTE5NjEzODkzMTk2XzAwMJSMSUVBTV9EeW5hbW9fWmhvdUpvaG5zb25XYWRsZXlfMjAwNE5JU1RyZXRhYnVsYXRpb25fQWxfX01PXzA2MDU2Nzg2ODU1OF8wMDCUjDlFQU1fRHluYW1vX1pob3VKb2huc29uV2FkbGV5XzIwMDRfQWxfX01PXzEzMTY1MDI2MTUxMF8wMDWUjDlFQU1fRHluYW1vX1pob3VXYWRsZXlKb2huc29uXzIwMDFfQWxfX01PXzA0OTI0MzQ5ODU1NV8wMDCUjDJFQU1fRHluYW1vX1pvcGVNaXNoaW5fMjAwM19BbF9fTU9fNjY0NDcwMTE0MzExXzAwNZSMNEVBTV9EeW5hbW9fWm9wZU1pc2hpbl8yMDAzX1RpQWxfX01PXzExNzY1Njc4Njc2MF8wMDWUjC9FQU1fRXJjb2xlc3NpQWRhbXNfMTk5NF9BbF9fTU9fMzI0NTA3NTM2MzQ1XzAwM5SMOEVBTV9JTURfQnJvbW1lckdhZWhsZXJfMjAwNkFfQWxOaUNvX19NT18xMjI3MDM3MDAyMjNfMDAzlIw4RUFNX0lNRF9Ccm9tbWVyR2FlaGxlcl8yMDA2Ql9BbE5pQ29fX01PXzEyODAzNzQ4NTI3Nl8wMDOUjDxFQU1fSU1EX1NjaG9wZkJyb21tZXJGcmlnYW5fMjAxMl9BbE1uUGRfX01PXzg3ODcxMjk3ODA2Ml8wMDOUjERFQU1fUXVpbnRpY0NsYW1wZWRTcGxpbmVfRXJjb2xlc3NpQWRhbXNfMTk5NF9BbF9fTU9fNDUwMDkzNzI3Mzk2XzAwMpSMREVBTV9RdWludGljSGVybWl0ZVNwbGluZV9FcmNvbGVzc2lBZGFtc18xOTk0X0FsX19NT183ODExMzg2NzE4NjNfMDAylIxRRU1UX0FzYXBfU3RhbmRhcmRfSmFjb2JzZW5TdG9sdHplTm9yc2tvdl8xOTk2X0FsQWdBdUN1TmlQZFB0X19NT18xMTUzMTY3NTA5ODZfMDAxlIxFRU1UX0FzYXBfU3RhbmRhcmRfSmFjb2JzZW5TdG9sdHplTm9yc2tvdl8xOTk2X0FsX19NT182MjMzNzYxMjQ4NjJfMDAxlIxHTUVBTV9MQU1NUFNfQWxteXJhc1Nhbmdpb3Zhbm5pU2FyYWtpbm9zXzIwMTlfTkFsVGlfX01PXzk1ODM5NTE5MDYyN18wMDCUjD9NRUFNX0xBTU1QU19Db3N0YUFncmVuQ2xhdmFndWVyYV8yMDA3X0FsTmlfX01PXzEzMTY0Mjc2ODI4OF8wMDCUjDRNRUFNX0xBTU1QU19Eb25nS2ltS29fMjAxMl9Db0FsX19NT18wOTk3MTY0MTYyMTZfMDAwlIxHTUVBTV9MQU1NUFNfSmVsaW5la0dyb2hIb3JzdGVtZXllcl8yMDEyX0FsU2lNZ0N1RmVfX01PXzI2MjUxOTUyMDY3OF8wMDCUjDZNRUFNX0xBTU1QU19KZW9uZ1BhcmtEb18yMDE4X1BkQWxfX01PXzYxNjQ4MjM1ODgwN18wMDCUjDdNRUFNX0xBTU1QU19LaW1KdW5nTGVlXzIwMTVfTmlBbENvX19NT184NzY2ODcxNjY1MTlfMDAwlIw1TUVBTV9MQU1NUFNfS2ltS2ltSnVuZ18yMDE2X0FsVGlfX01PXzYxODEzMzc2MzM3NV8wMDCUjDdNRUFNX0xBTU1QU19LaW1LaW1KdW5nXzIwMTdfTmlBbFRpX19NT180Nzg5NjcyNTU0MzVfMDAwlIw0TUVBTV9MQU1NUFNfS2ltS2ltTGVlXzIwMDlfQWxNZ19fTU9fMDU4NTM3MDg3Mzg0XzAwMJSMNE1FQU1fTEFNTVBTX0tpbVNlb2xKaV8yMDE3X1B0QWxfX01PXzc5MzE0MTAzNzcwNl8wMDCUjDNNRUFNX0xBTU1QU19Lb1NoaW1MZWVfMjAxMV9BbEhfX01PXzEyNzg0NzA4MDc1MV8wMDCUjDFNRUFNX0xBTU1QU19MZWVMZWVfMjAxMF9GZUFsX19NT18zMzIyMTE1MjIwNTBfMDAwlIw6TUVBTV9MQU1NUFNfUGFzY3VldEZlcm5hbmRlel8yMDE1X0FsVV9fTU9fNTk2MzAwNjczOTE3XzAwMJSMOU1FQU1fTEFNTVBTX1Bhc2N1ZXRGZXJuYW5kZXpfMjAxNV9BbF9fTU9fMzE1ODIwOTc0MTQ5XzAwMJSMNE1FQU1fTEFNTVBTX1NoaW1Lb0tpbV8yMDEzX0FsVkhfX01PXzM0NDcyNDE0NTMzOV8wMDCUjERNb3JzZV9TaGlmdGVkX0dpcmlmYWxjb1dlaXplcl8xOTU5SGlnaEN1dG9mZl9BbF9fTU9fMTQwMTc1NzQ4NjI2XzAwNJSMQ01vcnNlX1NoaWZ0ZWRfR2lyaWZhbGNvV2VpemVyXzE5NTlMb3dDdXRvZmZfQWxfX01PXzQxMTg5ODk1MzY2MV8wMDSUjENNb3JzZV9TaGlmdGVkX0dpcmlmYWxjb1dlaXplcl8xOTU5TWVkQ3V0b2ZmX0FsX19NT18yNzk1NDQ3NDYwOTdfMDA0lIw7U2ltX0xBTU1QU19BRFBfQXBvc3RvbE1pc2hpbl8yMDExX0FsQ3VfX1NNXzY2NzY5Njc2MzU2MV8wMDCUjEpTaW1fTEFNTVBTX0FEUF9TdGFyaWtvdkdvcmRlZXZMeXNvZ29yc2tpeV8yMDIwX1NpQXVBbF9fU01fMTEzODQzODMwNjAyXzAwMJSMPVNpbV9MQU1NUFNfQUdOSV9Cb3R1QmF0cmFDaGFwbWFuXzIwMTdfQWxfX1NNXzY2NjE4MzYzNjg5Nl8wMDCUjDxTaW1fTEFNTVBTX0JPUF9aaG91V2FyZEZvc3Rlcl8yMDE2X0FsQ3VfX1NNXzU2NjM5OTI1ODI3OV8wMDCUjEtTaW1fTEFNTVBTX01FQU1fQWxteXJhc1Nhbmdpb3Zhbm5pU2FyYWtpbm9zXzIwMTlfTkFsVGlfX1NNXzg3MTc5NTI0OTA1Ml8wMDCUjEtTaW1fTEFNTVBTX01FQU1fSmVsaW5la0dyb2hIb3JzdGVtZXllcl8yMDEyX0FsU2lNZ0N1RmVfX1NNXzY1NjUxNzM1MjQ4NV8wMDCUjD5TaW1fTEFNTVBTX01FQU1fUGFzY3VldEZlcm5hbmRlel8yMDE1X0FsVV9fU01fNzIxOTMwMzkxMDAzXzAwMJSMPVNpbV9MQU1NUFNfTUVBTV9QYXNjdWV0RmVybmFuZGV6XzIwMTVfQWxfX1NNXzgxMTU4ODk1NzE4N18wMDCUjEVTaW1fTEFNTVBTX1NNVEJRX1NhbGxlc1BvbGl0YW5vQW16YWxsYWdfMjAxNl9BbE9fX1NNXzg1Mzk2NzM1NTk3Nl8wMDCUjERTaW1fTEFNTVBTX1NNVEJRX1NhbGxlc1BvbGl0YW5vQW16YWxsYWdfMjAxNl9BbF9fU01fNDA0MDk3NjMzOTI0XzAwMJRldS4="
@@ -866,14 +866,14 @@
                             {
                                 "type": "data",
                                 "label": "engine",
-                                "GID": 113,
+                                "GID": 115,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVjgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjB9weWlyb25fYXRvbWlzdGljcy5sYW1tcHMubGFtbXBzlIwGTGFtbXBzlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIiMBHNpemWUjAFtlHUu",
                                 "otype_namespace": "atomistics",
                                 "otype_name": "lammps_output_job"
                             }
                         ],
-                        "GID": 109,
+                        "GID": 111,
                         "pos x": 577.8287023775423,
                         "pos y": 17.714285714285708
                     },
@@ -886,21 +886,21 @@
                             {
                                 "type": "data",
                                 "label": "x",
-                                "GID": 124,
+                                "GID": 117,
                                 "dtype": "DType.Untyped",
                                 "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
                             },
                             {
                                 "type": "data",
                                 "label": "y",
-                                "GID": 125,
+                                "GID": 118,
                                 "dtype": "DType.Untyped",
                                 "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
                             },
                             {
                                 "type": "data",
                                 "label": "fig",
-                                "GID": 126,
+                                "GID": 119,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVgAAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjBFtYXRwbG90bGliLmZpZ3VyZZSMBkZpZ3VyZZSTlGGMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
@@ -908,7 +908,7 @@
                             {
                                 "type": "data",
                                 "label": "marker",
-                                "GID": 127,
+                                "GID": 120,
                                 "val": "gASVBQAAAAAAAACMAW+ULg==",
                                 "dtype": "DType.Choice",
                                 "dtype state": "gASVzgAAAAAAAAB9lCiMB2RlZmF1bHSUjAFvlIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlIwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlF2UKIwEbm9uZZSMAS6UjAEslGgCjAF2lIwBXpSMATyUjAE+lIwBMZSMATKUjAEzlIwBNJSMATiUjAFzlIwBcJSMAVCUjAEqlIwBaJSMAUiUjAErlIwBeJSMAViUjAFklIwBRJSMAXyUjAFflGV1Lg=="
@@ -916,7 +916,7 @@
                             {
                                 "type": "data",
                                 "label": "linestyle",
-                                "GID": 128,
+                                "GID": 121,
                                 "val": "gASVCAAAAAAAAACMBG5vbmWULg==",
                                 "dtype": "DType.Choice",
                                 "dtype state": "gASVjgAAAAAAAAB9lCiMB2RlZmF1bHSUjARub25llIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlIwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlF2UKGgCjAVzb2xpZJSMBmRvdHRlZJSMBmRhc2hlZJSMB2Rhc2hkb3SUZXUu"
@@ -924,7 +924,7 @@
                             {
                                 "type": "data",
                                 "label": "color",
-                                "GID": 129,
+                                "GID": 122,
                                 "val": "gAROLg==",
                                 "dtype": "DType.String",
                                 "dtype state": "gASVhgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANzdHKUk5SMBW51bXB5lIwEc3RyX5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
@@ -932,7 +932,7 @@
                             {
                                 "type": "data",
                                 "label": "alpha",
-                                "GID": 130,
+                                "GID": 123,
                                 "val": "gASVCgAAAAAAAABHP/AAAAAAAAAu",
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURz/wAAAAAAAAjAN2YWyURz/wAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
@@ -940,7 +940,7 @@
                             {
                                 "type": "data",
                                 "label": "label",
-                                "GID": 131,
+                                "GID": 124,
                                 "val": "gAROLg==",
                                 "dtype": "DType.String",
                                 "dtype state": "gASVhgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANzdHKUk5SMBW51bXB5lIwEc3RyX5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
@@ -948,7 +948,7 @@
                             {
                                 "type": "data",
                                 "label": "xlabel",
-                                "GID": 132,
+                                "GID": 125,
                                 "val": "gAROLg==",
                                 "dtype": "DType.String",
                                 "dtype state": "gASVhgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANzdHKUk5SMBW51bXB5lIwEc3RyX5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
@@ -956,7 +956,7 @@
                             {
                                 "type": "data",
                                 "label": "ylabel",
-                                "GID": 133,
+                                "GID": 126,
                                 "val": "gAROLg==",
                                 "dtype": "DType.String",
                                 "dtype state": "gASVhgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANzdHKUk5SMBW51bXB5lIwEc3RyX5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
@@ -964,7 +964,7 @@
                             {
                                 "type": "data",
                                 "label": "title",
-                                "GID": 134,
+                                "GID": 127,
                                 "val": "gAROLg==",
                                 "dtype": "DType.String",
                                 "dtype state": "gASVhgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANzdHKUk5SMBW51bXB5lIwEc3RyX5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
@@ -972,7 +972,7 @@
                             {
                                 "type": "data",
                                 "label": "legend",
-                                "GID": 135,
+                                "GID": 128,
                                 "val": "gASJLg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -980,7 +980,7 @@
                             {
                                 "type": "data",
                                 "label": "tight_layout",
-                                "GID": 136,
+                                "GID": 129,
                                 "val": "gASILg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiIwDdmFslIiMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -990,12 +990,12 @@
                             {
                                 "type": "data",
                                 "label": "fig",
-                                "GID": 137,
+                                "GID": 130,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVgAAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjBFtYXRwbG90bGliLmZpZ3VyZZSMBkZpZ3VyZZSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
                             }
                         ],
-                        "GID": 123,
+                        "GID": 116,
                         "pos x": 1312.6095674591807,
                         "pos y": 306.6923076923077
                     },
@@ -1008,22 +1008,22 @@
                             {
                                 "type": "data",
                                 "label": "job",
-                                "GID": 139,
+                                "GID": 132,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVpgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCpweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLmpvYi5hdG9taXN0aWOUjBNBdG9taXN0aWNHZW5lcmljSm9ilJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIiMBHNpemWUjAFtlHUu"
                             },
                             {
                                 "type": "data",
                                 "label": "field",
-                                "GID": 140,
+                                "GID": 133,
                                 "val": "gASVCgAAAAAAAACMBnZvbHVtZZQu",
                                 "dtype": "DType.Choice",
-                                "dtype state": "gASVUgEAAAAAAAB9lCiMB2RlZmF1bHSUjAVzdGVwc5SMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZSMCGJ1aWx0aW5zlIwDc3RylJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlI+UKIwKZW5lcmd5X3BvdJSMC3RlbXBlcmF0dXJllIwKZW5lcmd5X3RvdJRoAowQY29tcHV0YXRpb25fdGltZZSME3RvdGFsX2Rpc3BsYWNlbWVudHOUjAlwb3NpdGlvbnOUjAdpbmRpY2VzlIwFY2VsbHOUjA1kaXNwbGFjZW1lbnRzlIwGZm9yY2VzlIwJcHJlc3N1cmVzlIwGdm9sdW1llIwTdW53cmFwcGVkX3Bvc2l0aW9uc5SMCWZvcmNlX21heJSMEWdldF9kaXNwbGFjZW1lbnRzlJB1Lg=="
+                                "dtype state": "gASVUgEAAAAAAAB9lCiMB2RlZmF1bHSUjAVzdGVwc5SMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZSMCGJ1aWx0aW5zlIwDc3RylJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlI+UKGgCjAdpbmRpY2VzlIwTdW53cmFwcGVkX3Bvc2l0aW9uc5SMBWNlbGxzlIwGdm9sdW1llIwNZGlzcGxhY2VtZW50c5SME3RvdGFsX2Rpc3BsYWNlbWVudHOUjAlmb3JjZV9tYXiUjAt0ZW1wZXJhdHVyZZSMCmVuZXJneV9wb3SUjAlwcmVzc3VyZXOUjAplbmVyZ3lfdG90lIwJcG9zaXRpb25zlIwQY29tcHV0YXRpb25fdGltZZSMBmZvcmNlc5SMEWdldF9kaXNwbGFjZW1lbnRzlJB1Lg=="
                             },
                             {
                                 "type": "data",
                                 "label": "transpose",
-                                "GID": 141,
+                                "GID": 134,
                                 "val": "gASILg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -1031,7 +1031,7 @@
                             {
                                 "type": "data",
                                 "label": "index",
-                                "GID": 142,
+                                "GID": 135,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Integer",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANpbnSUk5SMBW51bXB5lIwHaW50ZWdlcpSTlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
@@ -1041,12 +1041,12 @@
                             {
                                 "type": "data",
                                 "label": "output",
-                                "GID": 143,
+                                "GID": 136,
                                 "dtype": "DType.List",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANpbnSUk5RoCIwFZmxvYXSUk5SMBW51bXB5lIwGbnVtYmVylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIh1Lg=="
                             }
                         ],
-                        "GID": 138,
+                        "GID": 131,
                         "pos x": 1204.8123746777428,
                         "pos y": 35.48351648351648
                     },
@@ -1059,22 +1059,22 @@
                             {
                                 "type": "data",
                                 "label": "job",
-                                "GID": 145,
+                                "GID": 138,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVpgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCpweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLmpvYi5hdG9taXN0aWOUjBNBdG9taXN0aWNHZW5lcmljSm9ilJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIiMBHNpemWUjAFtlHUu"
                             },
                             {
                                 "type": "data",
                                 "label": "field",
-                                "GID": 146,
+                                "GID": 139,
                                 "val": "gASVDgAAAAAAAACMCmVuZXJneV9wb3SULg==",
                                 "dtype": "DType.Choice",
-                                "dtype state": "gASVUgEAAAAAAAB9lCiMB2RlZmF1bHSUjAVzdGVwc5SMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZSMCGJ1aWx0aW5zlIwDc3RylJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlI+UKIwKZW5lcmd5X3BvdJSMC3RlbXBlcmF0dXJllIwKZW5lcmd5X3RvdJRoAowQY29tcHV0YXRpb25fdGltZZSME3RvdGFsX2Rpc3BsYWNlbWVudHOUjAlwb3NpdGlvbnOUjAdpbmRpY2VzlIwFY2VsbHOUjA1kaXNwbGFjZW1lbnRzlIwGZm9yY2VzlIwJcHJlc3N1cmVzlIwGdm9sdW1llIwTdW53cmFwcGVkX3Bvc2l0aW9uc5SMCWZvcmNlX21heJSMEWdldF9kaXNwbGFjZW1lbnRzlJB1Lg=="
+                                "dtype state": "gASVUgEAAAAAAAB9lCiMB2RlZmF1bHSUjAVzdGVwc5SMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZSMCGJ1aWx0aW5zlIwDc3RylJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlI+UKGgCjAdpbmRpY2VzlIwTdW53cmFwcGVkX3Bvc2l0aW9uc5SMBWNlbGxzlIwGdm9sdW1llIwNZGlzcGxhY2VtZW50c5SME3RvdGFsX2Rpc3BsYWNlbWVudHOUjAlmb3JjZV9tYXiUjAt0ZW1wZXJhdHVyZZSMCmVuZXJneV9wb3SUjAlwcmVzc3VyZXOUjAplbmVyZ3lfdG90lIwJcG9zaXRpb25zlIwQY29tcHV0YXRpb25fdGltZZSMBmZvcmNlc5SMEWdldF9kaXNwbGFjZW1lbnRzlJB1Lg=="
                             },
                             {
                                 "type": "data",
                                 "label": "transpose",
-                                "GID": 147,
+                                "GID": 140,
                                 "val": "gASILg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -1082,7 +1082,7 @@
                             {
                                 "type": "data",
                                 "label": "index",
-                                "GID": 148,
+                                "GID": 141,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Integer",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANpbnSUk5SMBW51bXB5lIwHaW50ZWdlcpSTlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
@@ -1092,12 +1092,12 @@
                             {
                                 "type": "data",
                                 "label": "output",
-                                "GID": 149,
+                                "GID": 142,
                                 "dtype": "DType.List",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANpbnSUk5RoCIwFZmxvYXSUk5SMBW51bXB5lIwGbnVtYmVylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIh1Lg=="
                             }
                         ],
-                        "GID": 144,
+                        "GID": 137,
                         "pos x": 987.0180464050416,
                         "pos y": 308.010989010989
                     },
@@ -1110,7 +1110,7 @@
                             {
                                 "type": "data",
                                 "label": "name",
-                                "GID": 262,
+                                "GID": 144,
                                 "val": "gASVCwAAAAAAAACMB2V4YW1wbGWULg==",
                                 "dtype": "DType.String",
                                 "dtype state": "gASVigAAAAAAAAB9lCiMB2RlZmF1bHSUjAEulIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwDc3RylJOUjAVudW1weZSMBHN0cl+Uk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
@@ -1118,7 +1118,7 @@
                             {
                                 "type": "exec",
                                 "label": "remove",
-                                "GID": 263,
+                                "GID": 145,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Untyped",
                                 "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
@@ -1126,7 +1126,7 @@
                             {
                                 "type": "data",
                                 "label": "enable_remove",
-                                "GID": 264,
+                                "GID": 146,
                                 "val": "gASJLg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -1134,7 +1134,7 @@
                             {
                                 "type": "data",
                                 "label": "remove_name",
-                                "GID": 265,
+                                "GID": 147,
                                 "val": "gASVBAAAAAAAAACMAJQu",
                                 "dtype": "DType.String",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUjACUjAN2YWyUaAKMA2RvY5RoAowGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA3N0cpSTlIwFbnVtcHmUjARzdHJflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -1142,7 +1142,7 @@
                             {
                                 "type": "data",
                                 "label": "remove_all",
-                                "GID": 266,
+                                "GID": 148,
                                 "val": "gASJLg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -1150,7 +1150,7 @@
                             {
                                 "type": "data",
                                 "label": "recursive",
-                                "GID": 267,
+                                "GID": 149,
                                 "val": "gASILg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiIwDdmFslIiMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -1160,14 +1160,14 @@
                             {
                                 "type": "data",
                                 "label": "project",
-                                "GID": 268,
+                                "GID": 150,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjBlweWlyb25fYXRvbWlzdGljcy5wcm9qZWN0lIwHUHJvamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg==",
                                 "otype_namespace": "atomistics",
                                 "otype_name": "project_output_atomistics_project"
                             }
                         ],
-                        "GID": 261,
+                        "GID": 143,
                         "pos x": 22.446290461185907,
                         "pos y": 19.78021978021978
                     },
@@ -1180,7 +1180,7 @@
                             {
                                 "type": "exec",
                                 "label": "run",
-                                "GID": 270,
+                                "GID": 152,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Untyped",
                                 "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
@@ -1188,7 +1188,7 @@
                             {
                                 "type": "exec",
                                 "label": "reset",
-                                "GID": 271,
+                                "GID": 153,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Untyped",
                                 "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
@@ -1196,7 +1196,7 @@
                             {
                                 "type": "data",
                                 "label": "name",
-                                "GID": 272,
+                                "GID": 154,
                                 "val": "gASVDwAAAAAAAACMC2NhbGNfc3RhdGljlC4=",
                                 "dtype": "DType.String",
                                 "dtype state": "gASVjQAAAAAAAAB9lCiMB2RlZmF1bHSUjARjYWxjlIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwDc3RylJOUjAVudW1weZSMBHN0cl+Uk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
@@ -1204,7 +1204,7 @@
                             {
                                 "type": "data",
                                 "label": "job",
-                                "GID": 273,
+                                "GID": 155,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVjgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjB9weWlyb25fYXRvbWlzdGljcy5sYW1tcHMubGFtbXBzlIwGTGFtbXBzlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIiMBHNpemWUjAFtlHUu",
                                 "otype_namespace": "atomistics",
@@ -1215,21 +1215,21 @@
                             {
                                 "type": "exec",
                                 "label": "ran",
-                                "GID": 274,
+                                "GID": 156,
                                 "dtype": "DType.Untyped",
                                 "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
                             },
                             {
                                 "type": "data",
                                 "label": "job",
-                                "GID": 275,
+                                "GID": 157,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVjgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjB9weWlyb25fYXRvbWlzdGljcy5sYW1tcHMubGFtbXBzlIwGTGFtbXBzlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIiMBHNpemWUjAFtlHUu"
                             },
                             {
                                 "type": "data",
                                 "label": "energy_pot",
-                                "GID": 276,
+                                "GID": 158,
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURwAAAAAAAAAAjAN2YWyURwAAAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiIwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu",
                                 "otype_namespace": "atomistics",
@@ -1238,79 +1238,79 @@
                             {
                                 "type": "data",
                                 "label": "forces",
-                                "GID": 277,
+                                "GID": 159,
                                 "dtype": "DType.List",
                                 "dtype state": "gASVgQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSIdS4=",
                                 "otype_namespace": "atomistics",
                                 "otype_name": "atomistic_taker_output_forces"
                             }
                         ],
-                        "GID": 269,
+                        "GID": 151,
                         "pos x": 867.2242910340876,
                         "pos y": 32.967032967032964
                     }
                 ],
                 "connections": [
                     {
-                        "GID": 151,
+                        "GID": 160,
                         "parent node index": 0,
                         "output port index": 0,
                         "connected node": 1,
                         "connected input port index": 2
                     },
                     {
-                        "GID": 152,
+                        "GID": 161,
                         "parent node index": 1,
                         "output port index": 0,
                         "connected node": 2,
                         "connected input port index": 1
                     },
                     {
-                        "GID": 279,
+                        "GID": 162,
                         "parent node index": 2,
                         "output port index": 0,
                         "connected node": 7,
                         "connected input port index": 3
                     },
                     {
-                        "GID": 156,
+                        "GID": 163,
                         "parent node index": 4,
                         "output port index": 0,
                         "connected node": 3,
                         "connected input port index": 0
                     },
                     {
-                        "GID": 157,
+                        "GID": 164,
                         "parent node index": 5,
                         "output port index": 0,
                         "connected node": 3,
                         "connected input port index": 1
                     },
                     {
-                        "GID": 278,
+                        "GID": 165,
                         "parent node index": 6,
                         "output port index": 0,
                         "connected node": 2,
                         "connected input port index": 0
                     },
                     {
-                        "GID": 280,
+                        "GID": 166,
                         "parent node index": 7,
                         "output port index": 1,
                         "connected node": 4,
                         "connected input port index": 0
                     },
                     {
-                        "GID": 281,
+                        "GID": 167,
                         "parent node index": 7,
                         "output port index": 1,
                         "connected node": 5,
                         "connected input port index": 0
                     }
                 ],
-                "GID": 90
+                "GID": 95
             },
-            "GID": 84
+            "GID": 89
         },
         {
             "title": "parameter_study",
@@ -1327,7 +1327,7 @@
                             {
                                 "type": "data",
                                 "label": "element",
-                                "GID": 169,
+                                "GID": 176,
                                 "val": "gASVBgAAAAAAAACMAkZllC4=",
                                 "dtype": "DType.String",
                                 "dtype state": "gASViwAAAAAAAAB9lCiMB2RlZmF1bHSUjAJGZZSMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA3N0cpSTlIwFbnVtcHmUjARzdHJflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu",
@@ -1337,7 +1337,7 @@
                             {
                                 "type": "data",
                                 "label": "crystal_structure",
-                                "GID": 170,
+                                "GID": 177,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Choice",
                                 "dtype state": "gASVwgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiYwFaXRlbXOUXZQoTowCc2OUjANmY2OUjANiY2OUjANoY3CUjAdkaWFtb25klIwKemluY2JsZW5kZZSMCHJvY2tzYWx0lIwOY2VzaXVtY2hsb3JpZGWUjAhmbHVvcml0ZZSMCHd1cnR6aXRllGV1Lg=="
@@ -1345,7 +1345,7 @@
                             {
                                 "type": "data",
                                 "label": "a",
-                                "GID": 171,
+                                "GID": 178,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVmQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZSMCGRlY2ltYWxzlEsKdS4="
@@ -1353,7 +1353,7 @@
                             {
                                 "type": "data",
                                 "label": "c",
-                                "GID": 172,
+                                "GID": 179,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVmQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZSMCGRlY2ltYWxzlEsKdS4="
@@ -1361,7 +1361,7 @@
                             {
                                 "type": "data",
                                 "label": "c_over_a",
-                                "GID": 173,
+                                "GID": 180,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVmQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZSMCGRlY2ltYWxzlEsKdS4="
@@ -1369,7 +1369,7 @@
                             {
                                 "type": "data",
                                 "label": "u",
-                                "GID": 174,
+                                "GID": 181,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVmQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZSMCGRlY2ltYWxzlEsKdS4="
@@ -1377,7 +1377,7 @@
                             {
                                 "type": "data",
                                 "label": "orthorhombic",
-                                "GID": 175,
+                                "GID": 182,
                                 "val": "gASJLg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -1385,7 +1385,7 @@
                             {
                                 "type": "data",
                                 "label": "cubic",
-                                "GID": 176,
+                                "GID": 183,
                                 "val": "gASJLg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -1395,14 +1395,14 @@
                             {
                                 "type": "data",
                                 "label": "structure",
-                                "GID": 177,
+                                "GID": 184,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVmgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCxweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLnN0cnVjdHVyZS5hdG9tc5SMBUF0b21zlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu",
                                 "otype_namespace": "atomistics",
                                 "otype_name": "bulk_structure_output_structure"
                             }
                         ],
-                        "GID": 168,
+                        "GID": 175,
                         "pos x": 46.64566026926382,
                         "pos y": 268.13186813186815
                     },
@@ -1415,7 +1415,7 @@
                             {
                                 "type": "data",
                                 "label": "structure",
-                                "GID": 179,
+                                "GID": 186,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVmgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCxweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLnN0cnVjdHVyZS5hdG9tc5SMBUF0b21zlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
                             }
@@ -1424,12 +1424,12 @@
                             {
                                 "type": "data",
                                 "label": "potentials",
-                                "GID": 180,
+                                "GID": 187,
                                 "dtype": "DType.List",
                                 "dtype state": "gASVaQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAhidWlsdGluc5SMA3N0cpSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJdS4="
                             }
                         ],
-                        "GID": 178,
+                        "GID": 185,
                         "pos x": 318.23546261816097,
                         "pos y": 268.8901098901099
                     },
@@ -1442,14 +1442,14 @@
                             {
                                 "type": "data",
                                 "label": "array",
-                                "GID": 182,
+                                "GID": 189,
                                 "dtype": "DType.List",
                                 "dtype state": "gASVbAAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAhidWlsdGluc5SMBm9iamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJdS4="
                             },
                             {
                                 "type": "data",
                                 "label": "i",
-                                "GID": 183,
+                                "GID": 190,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Integer",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANpbnSUk5SMBW51bXB5lIwHaW50ZWdlcpSTlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
@@ -1457,7 +1457,7 @@
                             {
                                 "type": "data",
                                 "label": "j",
-                                "GID": 184,
+                                "GID": 191,
                                 "val": "gARLFC4=",
                                 "dtype": "DType.Integer",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANpbnSUk5SMBW51bXB5lIwHaW50ZWdlcpSTlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
@@ -1467,12 +1467,12 @@
                             {
                                 "type": "data",
                                 "label": "sliced",
-                                "GID": 185,
+                                "GID": 192,
                                 "dtype": "DType.List",
                                 "dtype state": "gASVbAAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAhidWlsdGluc5SMBm9iamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJdS4="
                             }
                         ],
-                        "GID": 181,
+                        "GID": 188,
                         "pos x": 598.8312804354053,
                         "pos y": 276.9230769230769
                     },
@@ -1485,7 +1485,7 @@
                             {
                                 "type": "data",
                                 "label": "project",
-                                "GID": 187,
+                                "GID": 194,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjBlweWlyb25fYXRvbWlzdGljcy5wcm9qZWN0lIwHUHJvamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg==",
                                 "otype_namespace": "atomistics",
@@ -1494,7 +1494,7 @@
                             {
                                 "type": "data",
                                 "label": "structure",
-                                "GID": 188,
+                                "GID": 195,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVmgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCxweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLnN0cnVjdHVyZS5hdG9tc5SMBUF0b21zlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu",
                                 "otype_namespace": "atomistics",
@@ -1503,7 +1503,7 @@
                             {
                                 "type": "data",
                                 "label": "potential",
-                                "GID": 189,
+                                "GID": 196,
                                 "dtype": "DType.Choice",
                                 "dtype state": "gASVLxkAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAhidWlsdGluc5SMA3N0cpSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSIjAVpdGVtc5RdlCiMIzE5OTctLUFja2xhbmQtRy1KLS1GZS0tTEFNTVBTLS1pcHIxlIwfMTk5OC0tTWV5ZXItUi0tRmUtLUxBTU1QUy0taXByMZSMHzIwMDEtLUxlZS1CLUotLUZlLS1MQU1NUFMtLWlwcjGUjCIyMDAxLS1MZWUtQi1KLS1GZS1Dci0tTEFNTVBTLS1pcHIxlIwmMjAwMy0tTWVuZGVsZXYtTS1JLS1GZS0yLS1MQU1NUFMtLWlwcjOUjCYyMDAzLS1NZW5kZWxldi1NLUktLUZlLTUtLUxBTU1QUy0taXByMZSMJTIwMDQtLUFja2xhbmQtRy1KLS1GZS1QLS1MQU1NUFMtLWlwcjGUjCAyMDA0LS1aaG91LVgtVy0tRmUtLUxBTU1QUy0taXByMpSMIjIwMDUtLUxlZS1CLUotLUZlLUN1LS1MQU1NUFMtLWlwcjGUjCcyMDA1LS1NZW5kZWxldi1NLUktLUFsLUZlLS1MQU1NUFMtLWlwcjGUjCEyMDA2LS1DaGFtYXRpLUgtLUZlLS1MQU1NUFMtLWlwcjGUjCAyMDA2LS1LaW0tSi0tRmUtUHQtLUxBTU1QUy0taXByMZSMITIwMDYtLUxlZS1CLUotLUZlLUMtLUxBTU1QUy0taXByMZSMITIwMDYtLUxlZS1CLUotLUZlLU4tLUxBTU1QUy0taXByMZSMITIwMDctLUxlZS1CLUotLUZlLUgtLUxBTU1QUy0taXByMZSMJjIwMDctLU1lbmRlbGV2LU0tSS0tVi1GZS0tTEFNTVBTLS1pcHIxlIwlMjAwOC0tSGVwYnVybi1ELUotLUZlLUMtLUxBTU1QUy0taXByMZSMHzIwMDgtLVNhLUktLUZlLU5iLS1MQU1NUFMtLWlwcjGUjB8yMDA4LS1TYS1JLS1GZS1UaS0tTEFNTVBTLS1pcHIxlIwlMjAwOS0tQm9ubnktRy0tRmUtQ3UtTmktLUxBTU1QUy0taXByMZSMIjIwMDktLUJvbm55LUctLUZlLU5pLS1MQU1NUFMtLWlwcjGUjCQyMDA5LS1LaW0tSC1LLS1GZS1UaS1DLS1MQU1NUFMtLWlwcjKUjCIyMDA5LS1LaW0tWS1NLS1GZS1Nbi0tTEFNTVBTLS1pcHIxlIwkMjAwOS0tT2xzc29uLVAtQS1ULS1GZS0tTEFNTVBTLS1pcHIxlIwmMjAwOS0tU3R1a293c2tpLUEtLUZlLUNyLS1MQU1NUFMtLWlwcjGUjCQyMDEwLS1LaW0tSC1LLS1GZS1OYi1DLS1MQU1NUFMtLWlwcjGUjCAyMDEwLS1MZWUtRS0tRmUtQWwtLUxBTU1QUy0taXByMZSMITIwMTAtLU1hbGVyYmEtTC0tRmUtLUxBTU1QUy0taXByMZSMIjIwMTEtLUJvbm55LUctLUZlLUNyLS1MQU1NUFMtLWlwcjKUjCIyMDExLS1Cb25ueS1HLS1GZS1Dci0tTEFNTVBTLS1pcHIzlIwlMjAxMS0tQm9ubnktRy0tRmUtTmktQ3ItLUxBTU1QUy0taXByMZSMJTIwMTEtLUJvbm55LUctLUZlLU5pLUNyLS1MQU1NUFMtLWlwcjKUjCMyMDExLS1DaGllc2EtUy0tRmUtMzMtLUxBTU1QUy0taXByMZSMLTIwMTItLUplbGluZWstQi0tQWwtU2ktTWctQ3UtRmUtLUxBTU1QUy0taXByMpSMIDIwMTItLUtvLVctUy0tRmUtUC0tTEFNTVBTLS1pcHIxlIwiMjAxMi0tUHJvdmlsbGUtTC0tRmUtLUxBTU1QUy0taXByMZSMJDIwMTMtLUJvbm55LUctLUZlLUNyLVctLUxBTU1QUy0taXByMpSMJDIwMTMtLUJvbm55LUctLUZlLUNyLVctLUxBTU1QUy0taXByM5SMJTIwMTMtLUJvbm55LUctLUZlLU5pLUNyLS1MQU1NUFMtLWlwcjGUjCEyMDEzLS1Cb25ueS1HLS1GZS1XLS1MQU1NUFMtLWlwcjGUjCoyMDEzLS1IZW5yaWtzc29uLUstTy1FLS1GZS1DLS1MQU1NUFMtLWlwcjGUjCgyMDE0LS1MaXlhbmFnZS1MLVMtSS0tRmUtQy0tTEFNTVBTLS1pcHIylIwfMjAxNS0tQXNhZGktRS0tRmUtLUxBTU1QUy0taXByMZSMIzIwMTUtLUVpY2gtUy1NLS1GZS1Dci0tTEFNTVBTLS1pcHIxlIwoMjAxNy0tQmVsYW5kLUwtSy0tRmUtTmktQ3ItLUxBTU1QUy0taXByMZSMIzIwMTctLUNob2ktVy1NLS1Dby1GZS0tTEFNTVBTLS1pcHIxlIwiMjAxNy0tV3UtQy0tTmktQ3ItRmUtLUxBTU1QUy0taXByMZSMHzIwMTctLVd1LUMtLU5pLUZlLS1MQU1NUFMtLWlwcjGUjCwyMDE4LS1DaG9pLVctTS0tQ28tTmktQ3ItRmUtTW4tLUxBTU1QUy0taXByMZSMIzIwMTgtLUV0ZXNhbWktUy1BLS1GZS0tTEFNTVBTLS1pcHIxlIwsMjAxOC0tRmFya2FzLUQtLUZlLU5pLUNyLUNvLUN1LS1MQU1NUFMtLWlwcjKUjCQyMDE4LS1KZW9uZy1HLVUtLVBkLUZlLS1MQU1NUFMtLWlwcjGUjCYyMDE4LS1aaG91LVgtVy0tRmUtTmktQ3ItLUxBTU1QUy0taXByMZSMJjIwMTgtLVpob3UtWC1XLS1GZS1OaS1Dci0tTEFNTVBTLS1pcHIylIwnMjAxOS0tQXNsYW0tSS0tRmUtTW4tU2ktQy0tTEFNTVBTLS1pcHIxlIwmMjAxOS0tQnlnZ21hc3Rhci1KLS1GZS1PLS1MQU1NUFMtLWlwcjGUjCoyMDE5LS1NZW5kZWxldi1NLUktLUZlLU5pLUNyLS1MQU1NUFMtLWlwcjGUjCQyMDIwLS1CeWdnbWFzdGFyLUotLUZlLS1MQU1NUFMtLWlwcjGUjCwyMDIwLS1GYXJrYXMtRC0tRmUtTmktQ3ItQ28tQWwtLUxBTU1QUy0taXByMZSMLDIwMjAtLUdyb2dlci1SLS1Dby1Dci1GZS1Nbi1OaS0tTEFNTVBTLS1pcHIxlIweMjAyMC0tTW9yaS1ILS1GZS0tTEFNTVBTLS1pcHIxlIwvMjAyMS0tRGVsdWlnaS1PLVItLUZlLU5pLUNyLUNvLUN1LS1MQU1NUFMtLWlwcjGUjCIyMDIxLS1TdGFyaWtvdi1TLS1GZS0tTEFNTVBTLS1pcHIxlIwiMjAyMS0tU3Rhcmlrb3YtUy0tRmUtLUxBTU1QUy0taXByMpSMHzIwMjEtLVdlbi1NLS1GZS1ILS1MQU1NUFMtLWlwcjGUjCMyMDIyLS1NYWhhdGEtQS0tQWwtRmUtLUxBTU1QUy0taXByMZSMJzIwMjItLVN0YXJpa292LVMtLUZlLUNyLUgtLUxBTU1QUy0taXByMZSMHTIwMjItLVN1bi1ZLS1GZS0tTEFNTVBTLS1pcHIxlIw6RUFNX0R5bmFtb19BY2tsYW5kQmFjb25DYWxkZXJfMTk5N19GZV9fTU9fMTQyNzk5NzE3NTE2XzAwNZSMQUVBTV9EeW5hbW9fQWNrbGFuZE1lbmRlbGV2U3JvbG92aXR6XzIwMDRfRmVQX19NT184ODQzNDMxNDYzMTBfMDA1lIw7RUFNX0R5bmFtb19Cb25ueUNhc3RpbkJ1bGxlbnNfMjAxM19GZVdfX01PXzczNzU2NzI0MjYzMV8wMDCUjEBFQU1fRHluYW1vX0Jvbm55Q2FzdGluVGVyZW50eWV2XzIwMTNfRmVOaUNyX19NT183NjMxOTc5NDEwMzlfMDAwlIw/RUFNX0R5bmFtb19Cb25ueVBhc2lhbm90Q2FzdGluXzIwMDlfRmVDdU5pX19NT180NjkzNDM5NzMxNzFfMDA1lIw+RUFNX0R5bmFtb19Cb25ueVBhc2lhbm90TWFsZXJiYV8yMDA5X0ZlTmlfX01PXzI2NzcyMTQwODkzNF8wMDWUjEFFQU1fRHluYW1vX0NoYW1hdGlQYXBhbmljb2xhb3VNaXNoaW5fMjAwNl9GZV9fTU9fOTYwNjk5NTEzNDI0XzAwMJSMN0VBTV9EeW5hbW9fSGVwYnVybkFja2xhbmRfMjAwOF9GZUNfX01PXzE0Mzk3NzE1MjcyOF8wMDWUjDBFQU1fRHluYW1vX01hcmluaWNhXzIwMDdfRmVfX01PXzQ2NjgwODg3NzEzMF8wMDCUjDBFQU1fRHluYW1vX01hcmluaWNhXzIwMTFfRmVfX01PXzI1NTMxNTQwNzkxMF8wMDCUjD1FQU1fRHluYW1vX01lbmRlbGV2Qm9yb3Zpa292XzIwMjBfRmVOaUNyX19NT185MjIzNjMzNDA1NzBfMDAwlIw3RUFNX0R5bmFtb19NZW5kZWxldkhhblNvbl8yMDA3X1ZGZV9fTU9fMjQ5NzA2ODEwNTI3XzAwNZSMRkVBTV9EeW5hbW9fTWVuZGVsZXZIYW5Tcm9sb3ZpdHpfMjAwM1BvdGVudGlhbDJfRmVfX01PXzc2OTU4MjM2MzQzOV8wMDWUjEZFQU1fRHluYW1vX01lbmRlbGV2SGFuU3JvbG92aXR6XzIwMDNQb3RlbnRpYWw1X0ZlX19NT185NDI0MjA3MDY4NThfMDA1lIw8RUFNX0R5bmFtb19NZW5kZWxldkhhblNyb2xvdml0el8yMDAzX0ZlX19NT184MDc5OTc4MjY0NDlfMDAwlIxCRUFNX0R5bmFtb19NZW5kZWxldlNyb2xvdml0ekFja2xhbmRfMjAwNV9BbEZlX19NT181Nzc0NTM4OTE5NDFfMDA1lIwwRUFNX0R5bmFtb19NZW5kZWxldl8yMDAzX0ZlX19NT181NDY2NzM1NDkwODVfMDAwlIxJRUFNX0R5bmFtb19aaG91Sm9obnNvbldhZGxleV8yMDA0TklTVHJldGFidWxhdGlvbl9GZV9fTU9fNjgxMDg4Mjk4MjA4XzAwMJSMOUVBTV9EeW5hbW9fWmhvdUpvaG5zb25XYWRsZXlfMjAwNF9GZV9fTU9fNjUwMjc5OTA1MjMwXzAwNZSMRkVBTV9NYWduZXRpYzJHUXVpbnRpY19DaGllc2FEZXJsZXREdWRhcmV2XzIwMTFfRmVfX01PXzE0MDQ0NDMyMTYwN18wMDKUjDxFQU1fTWFnbmV0aWNDdWJpY19EdWRhcmV2RGVybGV0XzIwMDVfRmVfX01PXzEzNTAzNDIyOTI4Ml8wMDKUjENFQU1fTWFnbmV0aWNDdWJpY19NZW5kZWxldkhhblNyb2xvdml0el8yMDAzX0ZlX19NT184NTYyOTU5NTI0MjVfMDAylIw8TUVBTV9MQU1NUFNfQXNhZGlaYWVlbU5vdXJhbmlhbl8yMDE1X0ZlX19NT180OTIzMTA4OTg3NzlfMDAwlIw7TUVBTV9MQU1NUFNfQ2hvaUpvU29obl8yMDE4X0NvTmlDckZlTW5fX01PXzExNTQ1NDc0NzUwM18wMDCUjDZNRUFNX0xBTU1QU19DaG9pS2ltU2VvbF8yMDE3X0NvRmVfX01PXzE3OTE1ODI1NzE4MF8wMDCUjDVNRUFNX0xBTU1QU19FdGVzYW1pQXNhZGlfMjAxOF9GZV9fTU9fNTQ5OTAwMjg3NDIxXzAwMJSMR01FQU1fTEFNTVBTX0plbGluZWtHcm9oSG9yc3RlbWV5ZXJfMjAxMl9BbFNpTWdDdUZlX19NT18yNjI1MTk1MjA2NzhfMDAwlIw2TUVBTV9MQU1NUFNfSmVvbmdQYXJrRG9fMjAxOF9QZEZlX19NT185MjQ3MzY2MjIyMDNfMDAwlIw2TUVBTV9MQU1NUFNfS2ltSnVuZ0xlZV8yMDA5X0ZlVGlDX19NT18xMTAxMTkyMDQ3MjNfMDAwlIw2TUVBTV9MQU1NUFNfS2ltSnVuZ0xlZV8yMDEwX0ZlTmJDX19NT18wNzI2ODk3MTg2MTZfMDAwlIwxTUVBTV9MQU1NUFNfS2ltTGVlXzIwMDZfUHRGZV9fTU9fMzQzMTY4MTAxNDkwXzAwMJSMNU1FQU1fTEFNTVBTX0tpbVNoaW5MZWVfMjAwOV9GZU1uX19NT18wNTg3MzU0MDA0NjJfMDAwlIwyTUVBTV9MQU1NUFNfS29KaW1MZWVfMjAxMl9GZVBfX01PXzE3OTQyMDM2Mzk0NF8wMDCUjDFNRUFNX0xBTU1QU19MZWVKYW5nXzIwMDdfRmVIX19NT18wOTU2MTA5NTE5NTdfMDAwlIwzTUVBTV9MQU1NUFNfTGVlTGVlS2ltXzIwMDZfRmVOX19NT180MzI4NjE3NjY3MzhfMDAwlIwxTUVBTV9MQU1NUFNfTGVlTGVlXzIwMTBfRmVBbF9fTU9fMzMyMjExNTIyMDUwXzAwMJSMN01FQU1fTEFNTVBTX0xlZVdpcnRoU2hpbV8yMDA1X0ZlQ3VfX01PXzA2MzYyNjA2NTQzN18wMDCUjC1NRUFNX0xBTU1QU19MZWVfMjAwNl9GZUNfX01PXzg1Njk1NjE3ODY2OV8wMDCUjDpNRUFNX0xBTU1QU19MaXlhbmFnZUtpbUhvdXplXzIwMTRfRmVDX19NT18wNzUyNzk4MDAxOTVfMDAwlIwwTUVBTV9MQU1NUFNfU2FMZWVfMjAwOF9GZVRpX19NT18yNjA1NDY5Njc3OTNfMDAwlIwwTUVBTV9MQU1NUFNfU2FMZWVfMjAwOF9OYkZlX19NT18xNjIwMzYxNDEyNjFfMDAwlIw0TUVBTV9MQU1NUFNfV3VMZWVTdV8yMDE3X05pQ3JGZV9fTU9fOTEyNjM2MTA3MTA4XzAwMJSMMk1FQU1fTEFNTVBTX1d1TGVlU3VfMjAxN19OaUZlX19NT18zMjEyMzMxNzY0OThfMDAwlIwxTUpfTW9ycmlzQWdhTGV2YXNob3ZfMjAwOF9GZV9fTU9fODU3MjgyNzU0MzA3XzAwM5SMRE1vcnNlX1NoaWZ0ZWRfR2lyaWZhbGNvV2VpemVyXzE5NTlIaWdoQ3V0b2ZmX0ZlX19NT18xNDc2MDMxMjg0MzdfMDA0lIxDTW9yc2VfU2hpZnRlZF9HaXJpZmFsY29XZWl6ZXJfMTk1OUxvd0N1dG9mZl9GZV9fTU9fMzMxMjg1NDk1NjE3XzAwNJSMQ01vcnNlX1NoaWZ0ZWRfR2lyaWZhbGNvV2VpemVyXzE5NTlNZWRDdXRvZmZfRmVfX01PXzk4NDM1ODM0NDE5Nl8wMDSUjD1UZXJzb2ZmX0xBTU1QU19NdWVsbGVyRXJoYXJ0QWxiZV8yMDA3X0ZlX19NT18xMzc5NjQzMTA3MDJfMDAzlIxFU2ltX0xBTU1QU19FQU1DRF9TdHVrb3dza2lTYWRpZ2hFcmhhcnRfMjAwOV9GZUNyX19TTV83NzU1NjQ0OTk1MTNfMDAwlIxBU2ltX0xBTU1QU19FQU1fQm9ubnlDYXN0aW5CdWxsZW5zXzIwMTNfRmVDcldfX1NNXzY5OTI1NzM1MDcwNF8wMDCUjERTaW1fTEFNTVBTX0VBTV9Cb25ueVBhc2lhbm90VGVyZW50eWV2XzIwMTFfRmVDcl9fU01fMjM3MDg5Mjk4NDYzXzAwMJSMQFNpbV9MQU1NUFNfTUVBTV9Bc2FkaVphZWVtTm91cmFuaWFuXzIwMTVfRmVfX1NNXzA0MjYzMDY4MDk5M18wMDCUjDlTaW1fTEFNTVBTX01FQU1fRXRlc2FtaUFzYWRpXzIwMThfRmVfX1NNXzI2NzAxNjYwODc1NV8wMDCUjEtTaW1fTEFNTVBTX01FQU1fSmVsaW5la0dyb2hIb3JzdGVtZXllcl8yMDEyX0FsU2lNZ0N1RmVfX1NNXzY1NjUxNzM1MjQ4NV8wMDCUjDpTaW1fTEFNTVBTX01FQU1fS2ltSnVuZ0xlZV8yMDA5X0ZlVGlDX19TTV81MzEwMzgyNzQ0NzFfMDAwlIw+U2ltX0xBTU1QU19NRUFNX0xpeWFuYWdlS2ltSG91emVfMjAxNF9GZUNfX1NNXzY1MjQyNTc3NzgwOF8wMDCUjEhTaW1fTEFNTVBTX1JlYXhGRl9BcnlhbnBvdXJWYW5EdWluS3ViaWNraV8yMDEwX0ZlSE9fX1NNXzIyMjk2NDIxNjAwMV8wMDGUjEVTaW1fTEFNTVBTX1RlcnNvZmZaQkxfQnlnZ21hc3RhckdyYW5iZXJnXzIwMjBfRmVfX1NNXzk1ODg2Mzg5NTIzNF8wMDCUjE1TaW1fTEFNTVBTX1RlcnNvZmZaQkxfSGVucmlrc3NvbkJqb3JrYXNOb3JkbHVuZF8yMDEzX0ZlQ19fU01fNDczNDYzNDk4MjY5XzAwMJRldS4="
                             }
@@ -1512,14 +1512,14 @@
                             {
                                 "type": "data",
                                 "label": "engine",
-                                "GID": 190,
+                                "GID": 197,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVjgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjB9weWlyb25fYXRvbWlzdGljcy5sYW1tcHMubGFtbXBzlIwGTGFtbXBzlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIiMBHNpemWUjAFtlHUu",
                                 "otype_namespace": "atomistics",
                                 "otype_name": "lammps_output_job"
                             }
                         ],
-                        "GID": 186,
+                        "GID": 193,
                         "pos x": 937.6224577484961,
                         "pos y": 48.35164835164835
                     },
@@ -1532,14 +1532,14 @@
                             {
                                 "type": "data",
                                 "label": "x",
-                                "GID": 207,
+                                "GID": 199,
                                 "dtype": "DType.Untyped",
                                 "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
                             },
                             {
                                 "type": "data",
                                 "label": "y",
-                                "GID": 208,
+                                "GID": 200,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Untyped",
                                 "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
@@ -1547,7 +1547,7 @@
                             {
                                 "type": "data",
                                 "label": "type",
-                                "GID": 209,
+                                "GID": 201,
                                 "val": "gASVCAAAAAAAAACMBGhpc3SULg==",
                                 "dtype": "DType.Choice",
                                 "dtype state": "gASVfAAAAAAAAAB9lCiMB2RlZmF1bHSUjAdzY2F0dGVylIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlIwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlF2UKGgCjARoaXN0lIwFam9pbnSUZXUu"
@@ -1557,50 +1557,14 @@
                             {
                                 "type": "data",
                                 "label": "plot",
-                                "GID": 210,
+                                "GID": 202,
                                 "dtype": "DType.Untyped",
                                 "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
                             }
                         ],
-                        "GID": 206,
+                        "GID": 198,
                         "pos x": 1516.2073904325407,
                         "pos y": 542.8571428571429
-                    },
-                    {
-                        "identifier": "Slider_Node",
-                        "version": "v0.1",
-                        "state data": "gASVEwAAAAAAAAB9lIwDdmFslEc/7MzMzMzMzXMu",
-                        "additional data": {},
-                        "inputs": [
-                            {
-                                "type": "data",
-                                "label": "scl",
-                                "GID": 212,
-                                "val": "gARLAC4=",
-                                "dtype": "DType.Integer",
-                                "dtype state": "gASViwAAAAAAAAB9lCiMB2RlZmF1bHSUSwGMA3ZhbJRLAYwDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA2ludJSTlIwFbnVtcHmUjAdpbnRlZ2VylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
-                            },
-                            {
-                                "type": "data",
-                                "label": "round",
-                                "GID": 213,
-                                "val": "gASJLg==",
-                                "dtype": "DType.Boolean",
-                                "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
-                            }
-                        ],
-                        "outputs": [
-                            {
-                                "type": "data",
-                                "label": "",
-                                "GID": 214,
-                                "dtype": "DType.Untyped",
-                                "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
-                            }
-                        ],
-                        "GID": 211,
-                        "pos x": 943.0191922085362,
-                        "pos y": 255.8901098901099
                     },
                     {
                         "identifier": "AtomisticOutput_Node",
@@ -1611,22 +1575,22 @@
                             {
                                 "type": "data",
                                 "label": "job",
-                                "GID": 216,
+                                "GID": 208,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVpgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjCpweWlyb25fYXRvbWlzdGljcy5hdG9taXN0aWNzLmpvYi5hdG9taXN0aWOUjBNBdG9taXN0aWNHZW5lcmljSm9ilJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIiMBHNpemWUjAFtlHUu"
                             },
                             {
                                 "type": "data",
                                 "label": "field",
-                                "GID": 217,
+                                "GID": 209,
                                 "val": "gASVCgAAAAAAAACMBnZvbHVtZZQu",
                                 "dtype": "DType.Choice",
-                                "dtype state": "gASVUgEAAAAAAAB9lCiMB2RlZmF1bHSUjAVzdGVwc5SMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZSMCGJ1aWx0aW5zlIwDc3RylJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlI+UKIwKZW5lcmd5X3BvdJSMC3RlbXBlcmF0dXJllIwKZW5lcmd5X3RvdJRoAowQY29tcHV0YXRpb25fdGltZZSME3RvdGFsX2Rpc3BsYWNlbWVudHOUjAlwb3NpdGlvbnOUjAdpbmRpY2VzlIwFY2VsbHOUjA1kaXNwbGFjZW1lbnRzlIwGZm9yY2VzlIwJcHJlc3N1cmVzlIwGdm9sdW1llIwTdW53cmFwcGVkX3Bvc2l0aW9uc5SMCWZvcmNlX21heJSMEWdldF9kaXNwbGFjZW1lbnRzlJB1Lg=="
+                                "dtype state": "gASVUgEAAAAAAAB9lCiMB2RlZmF1bHSUjAVzdGVwc5SMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZSMCGJ1aWx0aW5zlIwDc3RylJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBWl0ZW1zlI+UKGgCjAdpbmRpY2VzlIwTdW53cmFwcGVkX3Bvc2l0aW9uc5SMBWNlbGxzlIwGdm9sdW1llIwNZGlzcGxhY2VtZW50c5SME3RvdGFsX2Rpc3BsYWNlbWVudHOUjAlmb3JjZV9tYXiUjAt0ZW1wZXJhdHVyZZSMCmVuZXJneV9wb3SUjAlwcmVzc3VyZXOUjAplbmVyZ3lfdG90lIwJcG9zaXRpb25zlIwQY29tcHV0YXRpb25fdGltZZSMBmZvcmNlc5SMEWdldF9kaXNwbGFjZW1lbnRzlJB1Lg=="
                             },
                             {
                                 "type": "data",
                                 "label": "transpose",
-                                "GID": 218,
+                                "GID": 210,
                                 "val": "gASILg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -1634,7 +1598,7 @@
                             {
                                 "type": "data",
                                 "label": "index",
-                                "GID": 219,
+                                "GID": 211,
                                 "val": "gASVBgAAAAAAAABK/////y4=",
                                 "dtype": "DType.Integer",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANpbnSUk5SMBW51bXB5lIwHaW50ZWdlcpSTlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
@@ -1644,12 +1608,12 @@
                             {
                                 "type": "data",
                                 "label": "output",
-                                "GID": 220,
+                                "GID": 212,
                                 "dtype": "DType.List",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjANpbnSUk5RoCIwFZmxvYXSUk5SMBW51bXB5lIwGbnVtYmVylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIh1Lg=="
                             }
                         ],
-                        "GID": 215,
+                        "GID": 207,
                         "pos x": 1533.806932111143,
                         "pos y": 81.31868131868131
                     },
@@ -1662,7 +1626,7 @@
                             {
                                 "type": "data",
                                 "label": "name",
-                                "GID": 283,
+                                "GID": 214,
                                 "val": "gASVCwAAAAAAAACMB2V4YW1wbGWULg==",
                                 "dtype": "DType.String",
                                 "dtype state": "gASVigAAAAAAAAB9lCiMB2RlZmF1bHSUjAEulIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwDc3RylJOUjAVudW1weZSMBHN0cl+Uk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
@@ -1670,7 +1634,7 @@
                             {
                                 "type": "exec",
                                 "label": "remove",
-                                "GID": 284,
+                                "GID": 215,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Untyped",
                                 "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
@@ -1678,7 +1642,7 @@
                             {
                                 "type": "data",
                                 "label": "enable_remove",
-                                "GID": 285,
+                                "GID": 216,
                                 "val": "gASJLg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -1686,7 +1650,7 @@
                             {
                                 "type": "data",
                                 "label": "remove_name",
-                                "GID": 286,
+                                "GID": 217,
                                 "val": "gASVBAAAAAAAAACMAJQu",
                                 "dtype": "DType.String",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUjACUjAN2YWyUaAKMA2RvY5RoAowGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA3N0cpSTlIwFbnVtcHmUjARzdHJflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -1694,7 +1658,7 @@
                             {
                                 "type": "data",
                                 "label": "remove_all",
-                                "GID": 287,
+                                "GID": 218,
                                 "val": "gASJLg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiYwDdmFslImMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -1702,7 +1666,7 @@
                             {
                                 "type": "data",
                                 "label": "recursive",
-                                "GID": 288,
+                                "GID": 219,
                                 "val": "gASILg==",
                                 "dtype": "DType.Boolean",
                                 "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUiIwDdmFslIiMA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjARib29slJOUjAVudW1weZSMBWJvb2xflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -1712,16 +1676,58 @@
                             {
                                 "type": "data",
                                 "label": "project",
-                                "GID": 289,
+                                "GID": 220,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASViQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjBlweWlyb25fYXRvbWlzdGljcy5wcm9qZWN0lIwHUHJvamVjdJSTlGGMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg==",
                                 "otype_namespace": "atomistics",
                                 "otype_name": "project_output_atomistics_project"
                             }
                         ],
-                        "GID": 282,
+                        "GID": 213,
                         "pos x": 51.04554568891435,
                         "pos y": 28.571428571428573
+                    },
+                    {
+                        "identifier": "Input_Node",
+                        "version": null,
+                        "state data": "gAR9lC4=",
+                        "additional data": {},
+                        "inputs": [
+                            {
+                                "type": "data",
+                                "label": "input",
+                                "GID": 246,
+                                "val": "gASVBQAAAAAAAACMATCULg==",
+                                "dtype": "DType.String",
+                                "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUjACUjAN2YWyUaAKMA2RvY5RoAowGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA3N0cpSTlIwFbnVtcHmUjARzdHJflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            }
+                        ],
+                        "outputs": [
+                            {
+                                "type": "data",
+                                "label": "as_str",
+                                "GID": 247,
+                                "dtype": "DType.String",
+                                "dtype state": "gASViAAAAAAAAAB9lCiMB2RlZmF1bHSUjACUjAN2YWyUaAKMA2RvY5RoAowGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA3N0cpSTlIwFbnVtcHmUjARzdHJflJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "as_int",
+                                "GID": 248,
+                                "dtype": "DType.Integer",
+                                "dtype state": "gASViwAAAAAAAAB9lCiMB2RlZmF1bHSUSwCMA3ZhbJRLAIwDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA2ludJSTlIwFbnVtcHmUjAdpbnRlZ2VylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
+                            },
+                            {
+                                "type": "data",
+                                "label": "as_float",
+                                "GID": 249,
+                                "dtype": "DType.Float",
+                                "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURwAAAAAAAAAAjAN2YWyURwAAAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
+                            }
+                        ],
+                        "GID": 245,
+                        "pos x": 918.8198224004584,
+                        "pos y": 279.25274725274727
                     },
                     {
                         "identifier": "CalcMinimize_Node",
@@ -1732,7 +1738,7 @@
                             {
                                 "type": "exec",
                                 "label": "run",
-                                "GID": 291,
+                                "GID": 251,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Untyped",
                                 "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
@@ -1740,7 +1746,7 @@
                             {
                                 "type": "exec",
                                 "label": "reset",
-                                "GID": 292,
+                                "GID": 252,
                                 "val": "gAROLg==",
                                 "dtype": "DType.Untyped",
                                 "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
@@ -1748,15 +1754,15 @@
                             {
                                 "type": "data",
                                 "label": "name",
-                                "GID": 293,
-                                "val": "gASVDAAAAAAAAACMCGNhbGNfbWlulC4=",
+                                "GID": 253,
+                                "val": "gASVCAAAAAAAAACMBGNhbGOULg==",
                                 "dtype": "DType.String",
                                 "dtype state": "gASVjQAAAAAAAAB9lCiMB2RlZmF1bHSUjARjYWxjlIwDdmFslGgCjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwDc3RylJOUjAVudW1weZSMBHN0cl+Uk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
                             },
                             {
                                 "type": "data",
                                 "label": "job",
-                                "GID": 294,
+                                "GID": 254,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVjgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjB9weWlyb25fYXRvbWlzdGljcy5sYW1tcHMubGFtbXBzlIwGTGFtbXBzlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIiMBHNpemWUjAFtlHUu",
                                 "otype_namespace": "atomistics",
@@ -1765,7 +1771,7 @@
                             {
                                 "type": "data",
                                 "label": "ionic_energy_tolerance",
-                                "GID": 295,
+                                "GID": 255,
                                 "val": "gASVCgAAAAAAAABHAAAAAAAAAAAu",
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURwAAAAAAAAAAjAN2YWyURwAAAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
@@ -1773,7 +1779,7 @@
                             {
                                 "type": "data",
                                 "label": "ionic_force_tolerance",
-                                "GID": 296,
+                                "GID": 256,
                                 "val": "gASVCgAAAAAAAABHPxo24uscQy0u",
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURz8aNuLrHEMtjAN2YWyURz8aNuLrHEMtjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu"
@@ -1781,7 +1787,7 @@
                             {
                                 "type": "data",
                                 "label": "max_iter",
-                                "GID": 297,
+                                "GID": 257,
                                 "val": "gASVBgAAAAAAAABKoIYBAC4=",
                                 "dtype": "DType.Integer",
                                 "dtype state": "gASVkQAAAAAAAAB9lCiMB2RlZmF1bHSUSqCGAQCMA3ZhbJRKoIYBAIwDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA2ludJSTlIwFbnVtcHmUjAdpbnRlZ2VylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -1789,14 +1795,14 @@
                             {
                                 "type": "data",
                                 "label": "pressure",
-                                "GID": 298,
+                                "GID": 258,
                                 "dtype": "DType.Data",
-                                "dtype state": "gASVlgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlGgIjARsaXN0lJOUjAVudW1weZSMB25kYXJyYXmUk5RljAphbGxvd19ub25llIiMB2JhdGNoZWSUiYwEc2l6ZZSMAW2UdS4="
+                                "dtype state": "gASVswAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlGgIjARsaXN0lJOUjAVudW1weZSMB25kYXJyYXmUk5RoDYwIZmxvYXRpbmeUk5RoDYwHaW50ZWdlcpSTlGWMCmFsbG93X25vbmWUiIwHYmF0Y2hlZJSJjARzaXpllIwBbZR1Lg=="
                             },
                             {
                                 "type": "data",
                                 "label": "n_print",
-                                "GID": 299,
+                                "GID": 259,
                                 "val": "gARLZC4=",
                                 "dtype": "DType.Integer",
                                 "dtype state": "gASViwAAAAAAAAB9lCiMB2RlZmF1bHSUS2SMA3ZhbJRLZIwDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZQojAhidWlsdGluc5SMA2ludJSTlIwFbnVtcHmUjAdpbnRlZ2VylJOUZYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklImMBHNpemWUjAFtlHUu"
@@ -1804,7 +1810,7 @@
                             {
                                 "type": "data",
                                 "label": "style",
-                                "GID": 300,
+                                "GID": 260,
                                 "val": "gASVBgAAAAAAAACMAmNnlC4=",
                                 "dtype": "DType.Choice",
                                 "dtype state": "gASVZwAAAAAAAAB9lCiMB2RlZmF1bHSUjAJjZ5SMA3ZhbJRoAowDZG9jlIwAlIwGYm91bmRzlE6MDXZhbGlkX2NsYXNzZXOUXZSMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSJjAVpdGVtc5RdlGgCYXUu"
@@ -1814,21 +1820,21 @@
                             {
                                 "type": "exec",
                                 "label": "ran",
-                                "GID": 301,
+                                "GID": 261,
                                 "dtype": "DType.Untyped",
                                 "dtype state": "gASVVQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjAphbGxvd19ub25llIiMB2JhdGNoZWSUiXUu"
                             },
                             {
                                 "type": "data",
                                 "label": "job",
-                                "GID": 302,
+                                "GID": 262,
                                 "dtype": "DType.Data",
                                 "dtype state": "gASVjgAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UjB9weWlyb25fYXRvbWlzdGljcy5sYW1tcHMubGFtbXBzlIwGTGFtbXBzlJOUYYwKYWxsb3dfbm9uZZSJjAdiYXRjaGVklIiMBHNpemWUjAFtlHUu"
                             },
                             {
                                 "type": "data",
                                 "label": "energy_pot",
-                                "GID": 303,
+                                "GID": 263,
                                 "dtype": "DType.Float",
                                 "dtype state": "gASVqQAAAAAAAAB9lCiMB2RlZmF1bHSURwAAAAAAAAAAjAN2YWyURwAAAAAAAAAAjANkb2OUjACUjAZib3VuZHOUTowNdmFsaWRfY2xhc3Nlc5RdlCiMCGJ1aWx0aW5zlIwFZmxvYXSUk5SMBW51bXB5lIwIZmxvYXRpbmeUk5RljAphbGxvd19ub25llImMB2JhdGNoZWSUiIwEc2l6ZZSMAW2UjAhkZWNpbWFsc5RLCnUu",
                                 "otype_namespace": "atomistics",
@@ -1837,86 +1843,86 @@
                             {
                                 "type": "data",
                                 "label": "forces",
-                                "GID": 304,
+                                "GID": 264,
                                 "dtype": "DType.List",
                                 "dtype state": "gASVgQAAAAAAAAB9lCiMB2RlZmF1bHSUTowDdmFslE6MA2RvY5SMAJSMBmJvdW5kc5ROjA12YWxpZF9jbGFzc2VzlF2UKIwIYnVpbHRpbnOUjAVmbG9hdJSTlIwFbnVtcHmUjAhmbG9hdGluZ5STlGWMCmFsbG93X25vbmWUiYwHYmF0Y2hlZJSIdS4=",
                                 "otype_namespace": "atomistics",
                                 "otype_name": "atomistic_taker_output_forces"
                             }
                         ],
-                        "GID": 290,
-                        "pos x": 1234.614723574907,
-                        "pos y": 81.31868131868131
+                        "GID": 250,
+                        "pos x": 1243.4144944142079,
+                        "pos y": 103.2967032967033
                     }
                 ],
                 "connections": [
                     {
-                        "GID": 222,
+                        "GID": 236,
                         "parent node index": 0,
                         "output port index": 0,
                         "connected node": 1,
                         "connected input port index": 0
                     },
                     {
-                        "GID": 223,
+                        "GID": 237,
                         "parent node index": 0,
                         "output port index": 0,
                         "connected node": 3,
                         "connected input port index": 1
                     },
                     {
-                        "GID": 224,
+                        "GID": 238,
                         "parent node index": 1,
                         "output port index": 0,
                         "connected node": 2,
                         "connected input port index": 0
                     },
                     {
-                        "GID": 225,
+                        "GID": 239,
                         "parent node index": 2,
                         "output port index": 0,
                         "connected node": 3,
                         "connected input port index": 2
                     },
                     {
-                        "GID": 306,
+                        "GID": 265,
                         "parent node index": 3,
                         "output port index": 0,
                         "connected node": 8,
                         "connected input port index": 3
                     },
                     {
-                        "GID": 305,
+                        "GID": 242,
                         "parent node index": 5,
-                        "output port index": 0,
-                        "connected node": 8,
-                        "connected input port index": 7
-                    },
-                    {
-                        "GID": 229,
-                        "parent node index": 6,
                         "output port index": 0,
                         "connected node": 4,
                         "connected input port index": 0
                     },
                     {
-                        "GID": 307,
-                        "parent node index": 7,
+                        "GID": 243,
+                        "parent node index": 6,
                         "output port index": 0,
                         "connected node": 3,
                         "connected input port index": 0
                     },
                     {
-                        "GID": 308,
+                        "GID": 267,
+                        "parent node index": 7,
+                        "output port index": 2,
+                        "connected node": 8,
+                        "connected input port index": 7
+                    },
+                    {
+                        "GID": 266,
                         "parent node index": 8,
                         "output port index": 1,
-                        "connected node": 6,
+                        "connected node": 5,
                         "connected input port index": 0
                     }
                 ],
-                "GID": 164
+                "GID": 174
             },
-            "GID": 158
+            "GID": 168
         }
     ]
 }


### PR DESCRIPTION
Added a node for wrapping the aimsgb builder. It takes planes (3-integer-arrays) as input, so I also added nodes for giving arbitrary string data and getting it back typed as string, int, or float (also CSV strings to commensurate arrays). This cleans up one of the demos a little bit, where pressure input was given with an awkward slider (pressure has weird type options, and in general if the type is not trivially supported by ipywidgets, you need to get it from another node and not the node controller. Now there's a prettier node to get it from than "slider".)